### PR TITLE
fix(optimus): Fix layout issues with dispose

### DIFF
--- a/optimus/lib/src/common/dropdown.dart
+++ b/optimus/lib/src/common/dropdown.dart
@@ -34,6 +34,7 @@ class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
   late Rect _savedRect = _calculateRect();
 
   void _updateRect(dynamic _) {
+    if (!mounted) return;
     final newRect = _calculateRect();
     if (newRect != _savedRect) {
       setState(() {

--- a/optimus/lib/src/overlay_controller.dart
+++ b/optimus/lib/src/overlay_controller.dart
@@ -47,6 +47,7 @@ class _OverlayControllerState<T> extends State<OverlayController<T>> {
   void didUpdateWidget(OverlayController<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     WidgetsBinding.instance?.addPostFrameCallback((_) {
+      if (!mounted) return;
       _overlayEntry?.markNeedsBuild();
     });
   }

--- a/optimus/lib/src/search/search_field.dart
+++ b/optimus/lib/src/search/search_field.dart
@@ -75,6 +75,7 @@ class _OptimusSearchState<T> extends State<OptimusSearch<T>> {
   void didUpdateWidget(OptimusSearch<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     WidgetsBinding.instance?.addPostFrameCallback((_) {
+      if (!mounted) return;
       _overlayEntry?.markNeedsBuild();
     });
   }
@@ -130,9 +131,13 @@ class _OptimusSearchState<T> extends State<OptimusSearch<T>> {
     }
   }
 
-  void _afterLayoutBuild(Duration d) => _createOverlay();
+  void _afterLayoutBuild(Duration d) {
+    if (!mounted) return;
+    _createOverlay();
+  }
 
   void _afterLayoutWithShow(Duration d) {
+    if (!mounted) return;
     _createOverlay();
     _showOverlay();
   }

--- a/optimus/lib/src/slidable/slidable.dart
+++ b/optimus/lib/src/slidable/slidable.dart
@@ -24,6 +24,7 @@ class _OptimusSlidableState extends State<OptimusSlidable> {
   double _extentRatio = 1;
 
   void _afterLayout() {
+    if (!mounted) return;
     final size = context.size;
     if (size != null) {
       final ratio = size.height / size.width;

--- a/storybook/lib/main.dart
+++ b/storybook/lib/main.dart
@@ -20,6 +20,7 @@ import 'package:storybook/stories/radio.dart';
 import 'package:storybook/stories/search_field.dart';
 import 'package:storybook/stories/segmented_control.dart';
 import 'package:storybook/stories/select.dart';
+import 'package:storybook/stories/slidable.dart';
 import 'package:storybook/stories/spacing.dart';
 import 'package:storybook/stories/stack.dart';
 import 'package:storybook/stories/step_bar.dart';
@@ -67,6 +68,7 @@ class MyApp extends StatelessWidget {
           listTileStory,
           tabs,
           segmentedControlStory,
+          slidableStory,
         ],
       );
 }

--- a/storybook/lib/stories/slidable.dart
+++ b/storybook/lib/stories/slidable.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:optimus/optimus.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+final Story slidableStory = Story.simple(
+  padding: EdgeInsets.zero,
+  name: 'Slidable',
+  child: ListView.builder(
+    itemBuilder: (context, i) => OptimusSlidable(
+      actions: [
+        OptimusSlideAction(
+          color: Colors.red,
+          onTap: () {},
+          child: const Icon(Icons.delete, color: Colors.white),
+        ),
+      ],
+      child: ListTile(
+        title: Text('Slidable element #$i'),
+        subtitle: Text('Subtitle #$i'),
+      ),
+    ),
+    itemCount: 1000,
+  ),
+);


### PR DESCRIPTION
#### Summary

It happens if post frame callback happens after component is disposed. E.g. with long lists after scrolling back and forth.

#### Testing steps

Open `Slidable` story and scroll back and forth quickly. No errors should happen.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
