### PR TITLE
fix(optimus): Fix error on form fields

### DIFF
--- a/optimus/lib/src/form/date_time_form_field.dart
+++ b/optimus/lib/src/form/date_time_form_field.dart
@@ -24,7 +24,7 @@ class OptimusDateTimeFormField extends FormField<DateTime> {
             onChanged: (v) => field.didChange(v),
             minDate: minDate,
             maxDate: maxDate,
-            error: field.errorText,
+            error: field.hasError ? validator?.call(field.value) : null,
             formatDateTime: formatDateTime,
           ),
         );

--- a/optimus/lib/src/form/input_form_field.dart
+++ b/optimus/lib/src/form/input_form_field.dart
@@ -61,7 +61,7 @@ class OptimusInputFormField extends FormField<String> {
               maxLines: maxLines,
               minLines: minLines,
               controller: state._effectiveController,
-              error: field.errorText,
+              error: field.hasError ? validator?.call(field.value) : null,
               enableInteractiveSelection: enableInteractiveSelection,
               autofocus: autofocus,
               autocorrect: autocorrect,

--- a/optimus/lib/src/form/select_form_field.dart
+++ b/optimus/lib/src/form/select_form_field.dart
@@ -25,7 +25,7 @@ class OptimusSelectFormField<T> extends FormField<T> {
             label: label,
             placeholder: placeholder,
             value: field.value,
-            error: field.errorText,
+            error: field.hasError ? validator?.call(field.value) : null,
             builder: builder,
             items: items,
             isEnabled: enabled,


### PR DESCRIPTION
#### Summary

When rebuilding a form field widget, some clients need to update `error` text on the form field. The only way to update it, is to call `validator`.

Use-case in Mews: we rebuild form field widgets on a localization context change. With the change of localization context, we expect error text to be updated with a new translation.

Downside of the solution this PR suggests is that for those clients, that don't need to update `error` during form field widget rebuild, are going to have their `validator` called. We can introduce a constructor parameter for form field widgets to configure this behaviour. What do you think?

#### Testing steps

No.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
