### PR TITLE
fix(optimus): [RND-52878] Center text on badge

### DIFF
--- a/optimus/lib/src/badge.dart
+++ b/optimus/lib/src/badge.dart
@@ -31,19 +31,23 @@ class OptimusBadge extends StatelessWidget {
         horizontal: spacing50,
         vertical: spacing25,
       ),
-      child: IntrinsicWidth(
-        child: Text(
-          text,
-          textAlign: TextAlign.center,
-          // TODO(KB): Sync with text presets
-          style: TextStyle(
-            fontSize: 12,
-            fontWeight: FontWeight.w600,
-            color:
-                theme.isDark ? theme.colors.neutral1000 : theme.colors.neutral0,
-            height: 1,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            text,
+            textAlign: TextAlign.center,
+            // TODO(KB): Sync with text presets
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: theme.isDark
+                  ? theme.colors.neutral1000
+                  : theme.colors.neutral0,
+              height: 1,
+            ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/optimus/lib/src/badge.dart
+++ b/optimus/lib/src/badge.dart
@@ -31,10 +31,9 @@ class OptimusBadge extends StatelessWidget {
         horizontal: spacing50,
         vertical: spacing25,
       ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(
+      child: IntrinsicWidth(
+        child: Center(
+          child: Text(
             text,
             textAlign: TextAlign.center,
             // TODO(KB): Sync with text presets
@@ -47,7 +46,7 @@ class OptimusBadge extends StatelessWidget {
               height: 1,
             ),
           ),
-        ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
#### Summary

[RND-52878](https://mews.myjetbrains.com/youtrack/issue/RND-52878)
Centered text on badges vertically.

Not easily reproducible, but the `Text` was aligned on the top of the badge before. Now its centered by force!
One way to try is just make the text smaller, it should be centered even then.

#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
