### PR TITLE
fix: Fix OptimusSelect focus

### DIFF
--- a/optimus/lib/src/select.dart
+++ b/optimus/lib/src/select.dart
@@ -61,24 +61,27 @@ class _OptimusSelectState<T> extends State<OptimusSelect<T>> with ThemeGetter {
         onHidden: () => setState(() => _isOpened = false),
         child: GestureDetector(
           onTap: () => widget.isEnabled ? _node.requestFocus() : null,
-          child: FieldWrapper(
-            fieldBoxKey: _selectFieldKey,
+          child: Focus(
             focusNode: _node,
-            label: widget.label,
-            error: widget.error,
-            isEnabled: widget.isEnabled,
-            isRequired: widget.isRequired,
-            prefix: widget.prefix,
-            suffix: _icon,
-            caption: widget.caption,
-            secondaryCaption: widget.secondaryCaption,
-            children: [
-              _SelectedValue(
-                size: widget.size,
-                textStyle: _textStyle,
-                child: _fieldContent,
-              ),
-            ],
+            child: FieldWrapper(
+              fieldBoxKey: _selectFieldKey,
+              focusNode: _node,
+              label: widget.label,
+              error: widget.error,
+              isEnabled: widget.isEnabled,
+              isRequired: widget.isRequired,
+              prefix: widget.prefix,
+              suffix: _icon,
+              caption: widget.caption,
+              secondaryCaption: widget.secondaryCaption,
+              children: [
+                _SelectedValue(
+                  size: widget.size,
+                  textStyle: _textStyle,
+                  child: _fieldContent,
+                ),
+              ],
+            ),
           ),
         ),
       );


### PR DESCRIPTION
#### Summary

Added `Focus` wrapper in the `OptimusSelect`. 

The problem was that `FocusNode` itslef cannot receive focus, it should be passed to some focusable widget. `OptimusInputField` passes this `focusNode` to the underlying text field, so this is ok, but `OptimusSelect` doesn't have such focusable widget.

This focus node is also passed to field wrapper, bu this is ok, since it only listens to this node.

#### Testing steps

Selects should work.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
