### PR TITLE
fix(kiosk_mode): Fix startLockTask throwing

### DIFF
--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -2,6 +2,7 @@ package com.mews.kiosk_mode
 
 import androidx.annotation.NonNull
 import android.app.Activity
+import android.view.ViewGroup
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -23,7 +24,13 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
         if (call.method == "startKioskMode") {
-            activity?.startLockTask()
+            activity?.let { a ->
+                // ensures that startLockTask() will not throw
+                // see https://stackoverflow.com/questions/27826431/activity-startlocktask-occasionally-throws-illegalargumentexception
+                a.findViewById<ViewGroup>(android.R.id.content).getChildAt(0).post {
+                    a.startLockTask()
+                }
+            }
             result.success(null)
         } else if (call.method == "stopKioskMode") {
             activity?.stopLockTask()

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -28,10 +28,14 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 // ensures that startLockTask() will not throw
                 // see https://stackoverflow.com/questions/27826431/activity-startlocktask-occasionally-throws-illegalargumentexception
                 a.findViewById<ViewGroup>(android.R.id.content).getChildAt(0).post {
-                    a.startLockTask()
+                    try {
+                        a.startLockTask()
+                        result.success(true)
+                    } catch (e: IllegalArgumentException) {
+                        result.success(false)
+                    }
                 }
-            }
-            result.success(null)
+            } ?: result.success(false)
         } else if (call.method == "stopKioskMode") {
             activity?.stopLockTask()
             result.success(null)


### PR DESCRIPTION
#### Summary

`Activity::startLockTask` must be called when `Activity` is in the foreground. Otherwise, the call will fail. This PR ensures that one is able to call the method right on the app start-up - when `Activity` is not drawn (is in the foreground) yet - and get the expected behaviour of app being put into kiosk mode.

#### Testing steps

Test that the app is put into kiosk mode.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
