### PR TITLE
feat: Add `imageOverlayColor`

### DIFF
--- a/optimus/lib/src/colors/colors.dart
+++ b/optimus/lib/src/colors/colors.dart
@@ -293,6 +293,8 @@ class OptimusColors {
   Color get invertedSecondaryTextColor =>
       _isLight ? neutral0t64 : neutral1000t64;
 
+  Color get imageOverlayColor => _isLight ? neutral0t64 : neutral1000t64;
+
   bool get _isLight => brightness == Brightness.light;
 
   Color get neutral0 =>


### PR DESCRIPTION
#### Summary

I've added `imageOverlayColor` to colors. Example usage in one of our porudcts you can find below (right-side image).

![overlay_fixed](https://user-images.githubusercontent.com/23047178/128341950-4a89dd08-172f-4e27-ba75-27502db1d2cb.png)

#### Testing steps

No.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
