### PR TITLE
feat!: Update chat avatars support

### DIFF
--- a/optimus/lib/src/chat/bubble.dart
+++ b/optimus/lib/src/chat/bubble.dart
@@ -187,12 +187,10 @@ class OptimusChatBubble extends StatelessWidget {
           ? OptimusStackAlignment.start
           : OptimusStackAlignment.end;
 
-  Widget get _avatar => isAvatarEnabled
-      ? SizedBox(
-          width: 40,
-          child: isAvatarVisible ? message.avatar : null,
-        )
-      : Container();
+  Widget get _avatar => SizedBox(
+        width: 40,
+        child: isAvatarVisible ? message.avatar : null,
+      );
 
   BoxDecoration _buildMessageBackground(OptimusThemeData theme) =>
       BoxDecoration(
@@ -237,9 +235,11 @@ class OptimusChatBubble extends StatelessWidget {
           mainAxisAlignment: _bubbleAlignment,
           crossAxisAlignment: OptimusStackAlignment.end,
           children: [
-            if (message.alignment == MessageAlignment.left) _avatar,
+            if (message.alignment == MessageAlignment.left && isAvatarEnabled)
+              _avatar,
             _buildMessageBubble(theme),
-            if (message.alignment == MessageAlignment.right) _avatar,
+            if (message.alignment == MessageAlignment.right && isAvatarEnabled)
+              _avatar,
           ],
         ),
         if (isStatusVisible) _buildStatus(theme),

--- a/optimus/lib/src/chat/bubble.dart
+++ b/optimus/lib/src/chat/bubble.dart
@@ -13,6 +13,7 @@ class OptimusChatBubble extends StatelessWidget {
     Key? key,
     required this.message,
     required this.isAvatarVisible,
+    required this.isAvatarEnabled,
     required this.isStatusVisible,
     required this.isUserNameVisible,
     required this.isDateVisible,
@@ -25,6 +26,7 @@ class OptimusChatBubble extends StatelessWidget {
 
   final OptimusMessage message;
   final bool isAvatarVisible;
+  final bool isAvatarEnabled;
   final bool isStatusVisible;
   final bool isUserNameVisible;
   final bool isDateVisible;
@@ -92,8 +94,16 @@ class OptimusChatBubble extends StatelessWidget {
       );
 
   EdgeInsets get _statusPadding => EdgeInsets.only(
-        left: message.alignment == MessageAlignment.left ? 48 : 0,
-        right: message.alignment != MessageAlignment.left ? 48 : 0,
+        left: message.alignment == MessageAlignment.left
+            ? isAvatarEnabled
+                ? 48
+                : spacing100
+            : 0,
+        right: message.alignment != MessageAlignment.left
+            ? isAvatarEnabled
+                ? 48
+                : spacing100
+            : 0,
       );
 
   Widget _buildStatusTextStyle(OptimusThemeData theme, Widget child) =>
@@ -177,10 +187,12 @@ class OptimusChatBubble extends StatelessWidget {
           ? OptimusStackAlignment.start
           : OptimusStackAlignment.end;
 
-  Widget get _avatar => SizedBox(
-        width: 40,
-        child: isAvatarVisible ? message.avatar : null,
-      );
+  Widget get _avatar => isAvatarEnabled
+      ? SizedBox(
+          width: 40,
+          child: isAvatarVisible ? message.avatar : null,
+        )
+      : Container();
 
   BoxDecoration _buildMessageBackground(OptimusThemeData theme) =>
       BoxDecoration(

--- a/optimus/lib/src/chat/bubble.dart
+++ b/optimus/lib/src/chat/bubble.dart
@@ -12,8 +12,6 @@ class OptimusChatBubble extends StatelessWidget {
   const OptimusChatBubble({
     Key? key,
     required this.message,
-    required this.isAvatarVisible,
-    required this.isAvatarEnabled,
     required this.isStatusVisible,
     required this.isUserNameVisible,
     required this.isDateVisible,
@@ -25,8 +23,6 @@ class OptimusChatBubble extends StatelessWidget {
   }) : super(key: key);
 
   final OptimusMessage message;
-  final bool isAvatarVisible;
-  final bool isAvatarEnabled;
   final bool isStatusVisible;
   final bool isUserNameVisible;
   final bool isDateVisible;
@@ -36,26 +32,23 @@ class OptimusChatBubble extends StatelessWidget {
   final Widget sent;
   final Widget error;
 
-  Widget _buildMessageBubble(OptimusThemeData theme) => Flexible(
-        child: Container(
-          margin: EdgeInsets.only(
-            top: isUserNameVisible ? spacing0 : spacing100,
-            left: message.alignment == MessageAlignment.left ? spacing100 : 64,
-            right:
-                message.alignment == MessageAlignment.right ? spacing100 : 64,
-          ),
-          constraints: const BoxConstraints(maxWidth: 480),
-          decoration: _buildMessageBackground(theme),
-          padding: const EdgeInsets.only(
-            left: spacing100,
-            right: spacing100,
-            top: spacing50,
-            bottom: spacing100,
-          ),
-          child: Text(
-            message.message,
-            style: preset200s.copyWith(color: _createMessageTextColor(theme)),
-          ),
+  Widget _buildMessageBubble(OptimusThemeData theme) => Container(
+        margin: EdgeInsets.only(
+          top: isUserNameVisible ? spacing0 : spacing100,
+          left: message.alignment == MessageAlignment.left ? spacing100 : 64,
+          right: message.alignment == MessageAlignment.right ? spacing100 : 64,
+        ),
+        constraints: const BoxConstraints(maxWidth: 480),
+        decoration: _buildMessageBackground(theme),
+        padding: const EdgeInsets.only(
+          left: spacing100,
+          right: spacing100,
+          top: spacing50,
+          bottom: spacing100,
+        ),
+        child: Text(
+          message.message,
+          style: preset200s.copyWith(color: _createMessageTextColor(theme)),
         ),
       );
 
@@ -94,16 +87,8 @@ class OptimusChatBubble extends StatelessWidget {
       );
 
   EdgeInsets get _statusPadding => EdgeInsets.only(
-        left: message.alignment == MessageAlignment.left
-            ? isAvatarEnabled
-                ? 48
-                : spacing100
-            : 0,
-        right: message.alignment != MessageAlignment.left
-            ? isAvatarEnabled
-                ? 48
-                : spacing100
-            : 0,
+        left: message.alignment == MessageAlignment.left ? spacing100 : 0,
+        right: message.alignment != MessageAlignment.left ? spacing100 : 0,
       );
 
   Widget _buildStatusTextStyle(OptimusThemeData theme, Widget child) =>
@@ -187,11 +172,6 @@ class OptimusChatBubble extends StatelessWidget {
           ? OptimusStackAlignment.start
           : OptimusStackAlignment.end;
 
-  Widget get _avatar => SizedBox(
-        width: 40,
-        child: isAvatarVisible ? message.avatar : null,
-      );
-
   BoxDecoration _buildMessageBackground(OptimusThemeData theme) =>
       BoxDecoration(
         borderRadius: const BorderRadius.all(borderRadius100),
@@ -230,18 +210,7 @@ class OptimusChatBubble extends StatelessWidget {
       children: [
         if (isDateVisible) _buildDate(theme),
         if (isUserNameVisible) _userName,
-        OptimusStack(
-          direction: Axis.horizontal,
-          mainAxisAlignment: _bubbleAlignment,
-          crossAxisAlignment: OptimusStackAlignment.end,
-          children: [
-            if (message.alignment == MessageAlignment.left && isAvatarEnabled)
-              _avatar,
-            _buildMessageBubble(theme),
-            if (message.alignment == MessageAlignment.right && isAvatarEnabled)
-              _avatar,
-          ],
-        ),
+        _buildMessageBubble(theme),
         if (isStatusVisible) _buildStatus(theme),
       ],
     );

--- a/optimus/lib/src/chat/chat.dart
+++ b/optimus/lib/src/chat/chat.dart
@@ -11,6 +11,7 @@ class OptimusChat extends StatelessWidget {
   OptimusChat({
     Key? key,
     required List<OptimusMessage> messages,
+    required this.isAvatarEnabled,
     required this.formatTime,
     required this.formatDate,
     required this.sending,
@@ -24,6 +25,7 @@ class OptimusChat extends StatelessWidget {
   }
 
   final List<OptimusMessage> _messages = [];
+  final bool isAvatarEnabled;
   final FormatTime formatTime;
   final FormatDate formatDate;
   final Widget sending;
@@ -41,6 +43,7 @@ class OptimusChat extends StatelessWidget {
               reverse: true,
               itemBuilder: (context, index) => OptimusChatBubble(
                 message: _messages[index],
+                isAvatarEnabled: isAvatarEnabled,
                 isAvatarVisible: _showAvatar(index),
                 isStatusVisible: _showStatus(index),
                 isUserNameVisible: _showUserName(index),

--- a/optimus/lib/src/chat/chat.dart
+++ b/optimus/lib/src/chat/chat.dart
@@ -11,7 +11,7 @@ class OptimusChat extends StatelessWidget {
   OptimusChat({
     Key? key,
     required List<OptimusMessage> messages,
-    required this.isAvatarEnabled,
+    required this.hasAvatars,
     required this.formatTime,
     required this.formatDate,
     required this.sending,
@@ -25,7 +25,7 @@ class OptimusChat extends StatelessWidget {
   }
 
   final List<OptimusMessage> _messages = [];
-  final bool isAvatarEnabled;
+  final bool hasAvatars;
   final FormatTime formatTime;
   final FormatDate formatDate;
   final Widget sending;
@@ -41,24 +41,50 @@ class OptimusChat extends StatelessWidget {
             child: ListView.builder(
               itemCount: _messages.length,
               reverse: true,
-              itemBuilder: (context, index) => OptimusChatBubble(
-                message: _messages[index],
-                isAvatarEnabled: isAvatarEnabled,
-                isAvatarVisible: _showAvatar(index),
-                isStatusVisible: _showStatus(index),
-                isUserNameVisible: _showUserName(index),
-                isDateVisible: _showDate(index),
-                formatTime: formatTime,
-                formatDate: formatDate,
-                sending: sending,
-                sent: sent,
-                error: error,
+              itemBuilder: (context, index) => OptimusStack(
+                direction: Axis.horizontal,
+                crossAxisAlignment: OptimusStackAlignment.end,
+                mainAxisAlignment: _bubbleAlignment(index),
+                children: [
+                  if (_messages[index].alignment == MessageAlignment.left &&
+                      hasAvatars)
+                    _avatar(index),
+                  Flexible(
+                    child: OptimusChatBubble(
+                      message: _messages[index],
+                      isStatusVisible: _showStatus(index),
+                      isUserNameVisible: _showUserName(index),
+                      isDateVisible: _showDate(index),
+                      formatTime: formatTime,
+                      formatDate: formatDate,
+                      sending: sending,
+                      sent: sent,
+                      error: error,
+                    ),
+                  ),
+                  if (_messages[index].alignment == MessageAlignment.right &&
+                      hasAvatars)
+                    _avatar(index),
+                ],
               ),
             ),
           ),
           OptimusChatInput(onSendPressed: onSendPressed),
         ],
       );
+
+  Widget _avatar(int index) => Padding(
+        padding: EdgeInsets.only(bottom: _showAvatar(index) ? 18 : 0),
+        child: SizedBox(
+          width: 40,
+          child: _showAvatar(index) ? _messages[index].avatar : null,
+        ),
+      );
+
+  OptimusStackAlignment _bubbleAlignment(int index) =>
+      _messages[index].alignment == MessageAlignment.left
+          ? OptimusStackAlignment.start
+          : OptimusStackAlignment.end;
 
   bool _previousMessageIsFromSameUser(int index) =>
       index - 1 >= 0 &&

--- a/optimus/lib/src/chat/chat.dart
+++ b/optimus/lib/src/chat/chat.dart
@@ -46,9 +46,9 @@ class OptimusChat extends StatelessWidget {
                 crossAxisAlignment: OptimusStackAlignment.end,
                 mainAxisAlignment: _bubbleAlignment(index),
                 children: [
-                  if (_messages[index].alignment == MessageAlignment.left &&
-                      hasAvatars)
-                    _avatar(index),
+                  if (hasAvatars &&
+                      _messages[index].alignment == MessageAlignment.left)
+                    _buildAvatar(index),
                   Flexible(
                     child: OptimusChatBubble(
                       message: _messages[index],
@@ -62,9 +62,9 @@ class OptimusChat extends StatelessWidget {
                       error: error,
                     ),
                   ),
-                  if (_messages[index].alignment == MessageAlignment.right &&
-                      hasAvatars)
-                    _avatar(index),
+                  if (hasAvatars &&
+                      _messages[index].alignment == MessageAlignment.right)
+                    _buildAvatar(index),
                 ],
               ),
             ),
@@ -73,7 +73,7 @@ class OptimusChat extends StatelessWidget {
         ],
       );
 
-  Widget _avatar(int index) => Padding(
+  Widget _buildAvatar(int index) => Padding(
         padding: EdgeInsets.only(bottom: _showAvatar(index) ? 18 : 0),
         child: SizedBox(
           width: 40,

--- a/optimus/lib/src/chat/message.dart
+++ b/optimus/lib/src/chat/message.dart
@@ -32,6 +32,6 @@ class OptimusMessage with _$OptimusMessage {
     required MessageColor color,
     required DateTime time,
     required MessageState state,
-    required Widget avatar,
+    required Widget? avatar,
   }) = _Message;
 }

--- a/optimus/lib/src/chat/message.freezed.dart
+++ b/optimus/lib/src/chat/message.freezed.dart
@@ -23,7 +23,7 @@ class _$OptimusMessageTearOff {
       required MessageColor color,
       required DateTime time,
       required MessageState state,
-      required Widget avatar}) {
+      required Widget? avatar}) {
     return _Message(
       userName: userName,
       message: message,
@@ -47,7 +47,7 @@ mixin _$OptimusMessage {
   MessageColor get color => throw _privateConstructorUsedError;
   DateTime get time => throw _privateConstructorUsedError;
   MessageState get state => throw _privateConstructorUsedError;
-  Widget get avatar => throw _privateConstructorUsedError;
+  Widget? get avatar => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $OptimusMessageCopyWith<OptimusMessage> get copyWith =>
@@ -66,7 +66,7 @@ abstract class $OptimusMessageCopyWith<$Res> {
       MessageColor color,
       DateTime time,
       MessageState state,
-      Widget avatar});
+      Widget? avatar});
 }
 
 /// @nodoc
@@ -116,7 +116,7 @@ class _$OptimusMessageCopyWithImpl<$Res>
       avatar: avatar == freezed
           ? _value.avatar
           : avatar // ignore: cast_nullable_to_non_nullable
-              as Widget,
+              as Widget?,
     ));
   }
 }
@@ -134,7 +134,7 @@ abstract class _$MessageCopyWith<$Res>
       MessageColor color,
       DateTime time,
       MessageState state,
-      Widget avatar});
+      Widget? avatar});
 }
 
 /// @nodoc
@@ -184,7 +184,7 @@ class __$MessageCopyWithImpl<$Res> extends _$OptimusMessageCopyWithImpl<$Res>
       avatar: avatar == freezed
           ? _value.avatar
           : avatar // ignore: cast_nullable_to_non_nullable
-              as Widget,
+              as Widget?,
     ));
   }
 }
@@ -214,7 +214,7 @@ class _$_Message implements _Message {
   @override
   final MessageState state;
   @override
-  final Widget avatar;
+  final Widget? avatar;
 
   @override
   String toString() {
@@ -269,7 +269,7 @@ abstract class _Message implements OptimusMessage {
       required MessageColor color,
       required DateTime time,
       required MessageState state,
-      required Widget avatar}) = _$_Message;
+      required Widget? avatar}) = _$_Message;
 
   @override
   String get userName => throw _privateConstructorUsedError;
@@ -284,7 +284,7 @@ abstract class _Message implements OptimusMessage {
   @override
   MessageState get state => throw _privateConstructorUsedError;
   @override
-  Widget get avatar => throw _privateConstructorUsedError;
+  Widget? get avatar => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$MessageCopyWith<_Message> get copyWith =>

--- a/storybook/lib/stories/chat/bubble.dart
+++ b/storybook/lib/stories/chat/bubble.dart
@@ -41,8 +41,6 @@ final chatBubbleStory = Story(
       return Center(
         child: OptimusChatBubble(
           message: message,
-          isAvatarVisible: k.boolean(label: 'Show avatar', initial: true),
-          isAvatarEnabled: k.boolean(label: 'Enable avatar', initial: true),
           isUserNameVisible: k.boolean(label: 'Show user name', initial: true),
           isStatusVisible: k.boolean(label: 'Show status', initial: true),
           isDateVisible: k.boolean(label: 'Show date', initial: true),

--- a/storybook/lib/stories/chat/bubble.dart
+++ b/storybook/lib/stories/chat/bubble.dart
@@ -42,6 +42,7 @@ final chatBubbleStory = Story(
         child: OptimusChatBubble(
           message: message,
           isAvatarVisible: k.boolean(label: 'Show avatar', initial: true),
+          isAvatarEnabled: k.boolean(label: 'Enable avatar', initial: true),
           isUserNameVisible: k.boolean(label: 'Show user name', initial: true),
           isStatusVisible: k.boolean(label: 'Show status', initial: true),
           isDateVisible: k.boolean(label: 'Show date', initial: true),

--- a/storybook/lib/stories/chat/chat.dart
+++ b/storybook/lib/stories/chat/chat.dart
@@ -7,7 +7,7 @@ final chatStory = Story(
   name: 'Chat',
   builder: (_, k) => OptimusChat(
     messages: messages,
-    isAvatarEnabled: k.boolean(label: 'Enable avatar', initial: true),
+    hasAvatars: k.boolean(label: 'Enable avatar', initial: true),
     formatTime: (DateTime input) =>
         '${input.hour}:${input.minute.toString().padLeft(2, '0')}',
     formatDate: (DateTime input) =>

--- a/storybook/lib/stories/chat/chat.dart
+++ b/storybook/lib/stories/chat/chat.dart
@@ -7,6 +7,7 @@ final chatStory = Story(
   name: 'Chat',
   builder: (_, k) => OptimusChat(
     messages: messages,
+    isAvatarEnabled: k.boolean(label: 'Enable avatar', initial: true),
     formatTime: (DateTime input) =>
         '${input.hour}:${input.minute.toString().padLeft(2, '0')}',
     formatDate: (DateTime input) =>


### PR DESCRIPTION
#### Summary

Added boolean to toggle the avatar widget. Its used not for hiding but for enabling the avatar support.

This PR is required for the [chat PR](https://github.com/MewsSystems/mews-mobile-commander/pull/765) to fit the design correctly. 

Currently we are supporting just hiding of the avatar widget, but there's always a blank space or the avatar. This adds support for disabling the avatar even with then blank space.

Correct design:
![image](https://user-images.githubusercontent.com/9150597/129683111-16b1ff05-b0dd-43ec-80f0-768fd8ec83c8.png)

Current implementation without the avatars:
![image](https://user-images.githubusercontent.com/9150597/129683332-5b054ff1-d089-4863-8ce4-7c43b349f05b.png)

#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
