### PR TITLE
fix(optimus): Fix keyboard in dialog

### DIFF
--- a/optimus/lib/src/dialogs/dialog.dart
+++ b/optimus/lib/src/dialogs/dialog.dart
@@ -76,15 +76,14 @@ Future<T?> showOptimusDialog<T>({
 }) =>
     showGeneralDialog(
       context: context,
-      pageBuilder: (buildContext, animation, secondaryAnimation) => SafeArea(
-        child: OptimusDialog.modal(
-          title: title,
-          content: content,
-          contentWrapperBuilder: contentWrapperBuilder,
-          actions: actions,
-          size: size,
-          type: type,
-        ),
+      pageBuilder: (buildContext, animation, secondaryAnimation) =>
+          OptimusDialog.modal(
+        title: title,
+        content: content,
+        contentWrapperBuilder: contentWrapperBuilder,
+        actions: actions,
+        size: size,
+        type: type,
       ),
       barrierDismissible: isDismissible,
       barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
@@ -252,50 +251,53 @@ class OptimusDialog extends StatelessWidget {
     final theme = OptimusTheme.of(context);
 
     return SafeArea(
-      child: Align(
-        alignment: _alignment(context),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: spacing300,
-            vertical: spacing300,
-          ),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(maxWidth: _maxWidth(autoSize)),
-            child: OptimusCard(
-              variant: OptimusBasicCardVariant.overlay,
-              padding: OptimusCardSpacing.spacing0,
-              child: Material(
-                color: theme.isDark
-                    ? theme.colors.neutral500
-                    : theme.colors.neutral0,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    _Title(
-                      context: context,
-                      title: title,
-                      close: close ?? () => Navigator.pop(context),
-                      isDismissible: isDismissible ??
-                          ModalRoute.of(context)?.barrierDismissible ??
-                          true,
-                    ),
-                    _divider(theme),
-                    OptimusParagraph(
-                      child: _Content(
-                        content: content,
-                        contentWrapperBuilder: contentWrapperBuilder,
-                      ),
-                    ),
-                    if (actions.isNotEmpty) _divider(theme),
-                    if (actions.isNotEmpty)
-                      _Actions(
-                        actions: actions,
-                        type: type,
-                        dialogSize: autoSize,
+      child: Container(
+        margin: MediaQuery.of(context).viewInsets,
+        child: Align(
+          alignment: _alignment(context),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: spacing300,
+              vertical: spacing300,
+            ),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: _maxWidth(autoSize)),
+              child: OptimusCard(
+                variant: OptimusBasicCardVariant.overlay,
+                padding: OptimusCardSpacing.spacing0,
+                child: Material(
+                  color: theme.isDark
+                      ? theme.colors.neutral500
+                      : theme.colors.neutral0,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      _Title(
+                        context: context,
+                        title: title,
                         close: close ?? () => Navigator.pop(context),
-                      )
-                  ],
+                        isDismissible: isDismissible ??
+                            ModalRoute.of(context)?.barrierDismissible ??
+                            true,
+                      ),
+                      _divider(theme),
+                      OptimusParagraph(
+                        child: _Content(
+                          content: content,
+                          contentWrapperBuilder: contentWrapperBuilder,
+                        ),
+                      ),
+                      if (actions.isNotEmpty) _divider(theme),
+                      if (actions.isNotEmpty)
+                        _Actions(
+                          actions: actions,
+                          type: type,
+                          dialogSize: autoSize,
+                          close: close ?? () => Navigator.pop(context),
+                        )
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/storybook/lib/stories/dialog.dart
+++ b/storybook/lib/stories/dialog.dart
@@ -260,7 +260,15 @@ Future<void> _showCustomContentDialog({
     title: Text(title),
     content: Container(
       color: theme.isDark ? theme.colors.neutral400 : theme.colors.neutral100,
-      child: const Center(child: Text('Custom content without paddings')),
+      padding: const EdgeInsets.all(8),
+      child: Column(
+        children: const [
+          Center(child: Text('Custom content without paddings')),
+          OptimusInputField(
+            placeholder: 'Input field to test offsets on keyboard',
+          ),
+        ],
+      ),
     ),
     contentWrapperBuilder: (_, child) => child,
     size: size,


### PR DESCRIPTION
#### Summary

Added margin to the dialog, so that it has correct offsets when the soft keyboard is shown.

| Before | After |
|---|---|
| <img width="1065" alt="Screenshot 2021-09-02 at 12 41 53" src="https://user-images.githubusercontent.com/853356/131830145-08df1c22-72be-406e-8f7f-0dac964f5499.png"> | <img width="1065" alt="Screenshot 2021-09-02 at 12 42 01" src="https://user-images.githubusercontent.com/853356/131830187-81970014-15f6-44a0-ad9c-85f498dda2b2.png"> |

#### Testing steps

1. Select Dialog story and open dialog with custom content.
2. Focus on the text field.
3. Observe that the dialog is not overflown by the keyboard.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
