### PR TITLE
fix(optimus): Fix number picker

### DIFF
--- a/optimus/example/pubspec.lock
+++ b/optimus/example/pubspec.lock
@@ -112,7 +112,7 @@ packages:
       name: dart_code_metrics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.3.2"
   dart_style:
     dependency: transitive
     description:
@@ -220,14 +220,14 @@ packages:
       name: mews_pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0-dev.0"
+    version: "0.4.0-dev.1"
   optimus:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.11.2"
+    version: "0.11.5"
   package_config:
     dependency: transitive
     description:

--- a/optimus/lib/src/number_picker.dart
+++ b/optimus/lib/src/number_picker.dart
@@ -67,7 +67,13 @@ class _OptimusNumberPickerState extends State<OptimusNumberPicker> {
   }
 
   void _updateInputValue(int? value) {
-    _controller.value = _controller.value.copyWith(text: _format(value));
+    final formattedValue = _format(value);
+    _controller.value = _controller.value.copyWith(
+      text: formattedValue,
+      selection: TextSelection.fromPosition(
+        TextPosition(offset: formattedValue.length),
+      ),
+    );
   }
 
   void _onMinusTap() {

--- a/optimus/pubspec.lock
+++ b/optimus/pubspec.lock
@@ -353,7 +353,7 @@ packages:
       name: mews_pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0-dev.0"
+    version: "0.4.0-dev.1"
   mime:
     dependency: transitive
     description:

--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -112,7 +112,7 @@ packages:
       name: dart_code_metrics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.3.1"
   dart_style:
     dependency: transitive
     description:
@@ -234,7 +234,7 @@ packages:
       name: mews_pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0-dev.0"
+    version: "0.4.0-dev.1"
   nested:
     dependency: transitive
     description:
@@ -248,7 +248,7 @@ packages:
       path: "../optimus"
       relative: true
     source: path
-    version: "0.11.2"
+    version: "0.11.5"
   package_config:
     dependency: transitive
     description:


### PR DESCRIPTION
#### Summary

Fix number picker

#### Testing steps

- in storybook, go to `Number Picker` story
- number picker constraints are hardcoded to `[-5; 5]`
- tap on input and type negative value out of range (example: -9)
- errors will appear in console

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
