### PR TITLE
feat: Update pedantic

### DIFF
--- a/kiosk_mode/example/pubspec.yaml
+++ b/kiosk_mode/example/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.0-dev.1
+  mews_pedantic: ^0.4.0-dev.2
 flutter:
   uses-material-design: true

--- a/kiosk_mode/pubspec.yaml
+++ b/kiosk_mode/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.0-dev.1
+  mews_pedantic: ^0.4.0-dev.2
 flutter:
   plugin:
     platforms:

--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0-dev.2
+
+ - **FEAT**: Temporarily disable prefer-extracting-callbacks.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.4.0-dev.1
 
  - **FEAT**: Update analysis options.

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -82,7 +82,7 @@ dart_code_metrics:
     - newline-before-return
     - no-equal-then-else
     - avoid-unnecessary-setstate
-    - prefer-extracting-callbacks
+    # - prefer-extracting-callbacks <- Enable after a new release of dart_code_metrics
   
   metrics-exclude:
     - lib/**

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mews_pedantic
 description: Dart and Flutter static analysis and lint rules incorporated in Mews.
-version: 0.4.0-dev.1
+version: 0.4.0-dev.2
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:

--- a/optimus/example/pubspec.yaml
+++ b/optimus/example/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.0-dev.1
+  mews_pedantic: ^0.4.0-dev.2

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^0.14.2
-  mews_pedantic: ^0.4.0-dev.1
+  mews_pedantic: ^0.4.0-dev.2
 flutter:
   fonts:
     - family: OpenSans

--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.2
-  mews_pedantic: ^0.4.0-dev.1
+  mews_pedantic: ^0.4.0-dev.2
   mockito: ^5.0.16
   test: ^1.16.0

--- a/storybook/pubspec.yaml
+++ b/storybook/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.0-dev.1
+  mews_pedantic: ^0.4.0-dev.2
 flutter:
   uses-material-design: true


### PR DESCRIPTION
#### Summary

Temporarily disabled `prefer-extracting-callbacks` rule, since it doesn't work properly in the current version of `dart_code_metrics`. It will be fixed in their next release, after that, we can turn it back on.

#### Testing steps

No.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
