### PR TITLE
feat(optimus): Update dialog

### DIFF
--- a/optimus/lib/src/dialogs/dialog.dart
+++ b/optimus/lib/src/dialogs/dialog.dart
@@ -73,6 +73,7 @@ Future<T?> showOptimusDialog<T>({
   OptimusDialogSize size = OptimusDialogSize.regular,
   OptimusDialogType type = OptimusDialogType.common,
   bool isDismissible = true,
+  bool hasCloseButton = false,
 }) =>
     showGeneralDialog(
       context: context,
@@ -84,6 +85,7 @@ Future<T?> showOptimusDialog<T>({
         actions: actions,
         size: size,
         type: type,
+        hasCloseButton: hasCloseButton,
       ),
       barrierDismissible: isDismissible,
       barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
@@ -108,7 +110,7 @@ class OptimusDialog extends StatelessWidget {
     this.size = OptimusDialogSize.regular,
     this.type = OptimusDialogType.common,
     this.close,
-    this.isDismissible,
+    this.hasCloseButton = false,
     this.position = OptimusDialogPosition.center,
   }) : super(key: key);
 
@@ -120,7 +122,7 @@ class OptimusDialog extends StatelessWidget {
     List<OptimusDialogAction> actions = const [],
     OptimusDialogSize size = OptimusDialogSize.regular,
     OptimusDialogType type = OptimusDialogType.common,
-    bool? isDismissible,
+    bool hasCloseButton = false,
   }) : this._(
           key: key,
           title: title,
@@ -129,7 +131,7 @@ class OptimusDialog extends StatelessWidget {
           actions: actions,
           size: size,
           type: type,
-          isDismissible: isDismissible,
+          hasCloseButton: hasCloseButton,
         );
 
   const OptimusDialog.nonModal({
@@ -139,8 +141,8 @@ class OptimusDialog extends StatelessWidget {
     ContentWrapperBuilder? contentWrapperBuilder,
     List<OptimusDialogAction> actions = const [],
     OptimusDialogSize size = OptimusDialogSize.regular,
-    bool? isDismissible,
     required VoidCallback close,
+    bool hasCloseButton = true,
   }) : this._(
           key: key,
           title: title,
@@ -150,13 +152,13 @@ class OptimusDialog extends StatelessWidget {
           size: size == OptimusDialogSize.large
               ? OptimusDialogSize.regular
               : size,
-          isDismissible: isDismissible,
+          hasCloseButton: hasCloseButton,
           close: close,
           position: OptimusDialogPosition.corner,
         );
 
   final VoidCallback? close;
-  final bool? isDismissible;
+  final bool hasCloseButton;
   final OptimusDialogPosition position;
 
   /// Serves as an identification of the action in the dialog. Can be
@@ -280,9 +282,7 @@ class OptimusDialog extends StatelessWidget {
                         context: context,
                         title: title,
                         close: close ?? () => Navigator.pop(context),
-                        isDismissible: isDismissible ??
-                            ModalRoute.of(context)?.barrierDismissible ??
-                            true,
+                        hasCloseButton: hasCloseButton,
                       ),
                       _divider(theme),
                       OptimusParagraph(
@@ -357,13 +357,13 @@ class _Title extends StatelessWidget {
     required this.context,
     required this.title,
     required this.close,
-    required this.isDismissible,
+    required this.hasCloseButton,
   }) : super(key: key);
 
   final BuildContext context;
   final Widget title;
   final VoidCallback close;
-  final bool isDismissible;
+  final bool hasCloseButton;
 
   @override
   Widget build(BuildContext context) => Row(
@@ -375,7 +375,7 @@ class _Title extends StatelessWidget {
               child: OptimusSubsectionTitle(child: title),
             ),
           ),
-          if (isDismissible)
+          if (hasCloseButton)
             Padding(
               padding: const EdgeInsets.only(top: spacing50),
               child: OptimusIconButton(

--- a/optimus/lib/src/dialogs/non_modal_wrapper.dart
+++ b/optimus/lib/src/dialogs/non_modal_wrapper.dart
@@ -6,7 +6,7 @@ abstract class NonModalController {
   void show({
     required Widget title,
     required Widget content,
-    bool isDismissible = true,
+    bool hasCloseButton = true,
     List<OptimusDialogAction> actions = const [],
     OptimusDialogSize size = OptimusDialogSize.regular,
   });
@@ -35,7 +35,7 @@ class _NonModalWrapperState extends State<NonModalWrapper>
   void show({
     required Widget title,
     required Widget content,
-    bool isDismissible = true,
+    bool hasCloseButton = true,
     List<OptimusDialogAction> actions = const [],
     OptimusDialogSize size = OptimusDialogSize.regular,
   }) {
@@ -45,7 +45,7 @@ class _NonModalWrapperState extends State<NonModalWrapper>
         title: title,
         content: content,
         close: hide,
-        isDismissible: isDismissible,
+        hasCloseButton: hasCloseButton,
         actions: actions,
         size: size,
       ),

--- a/storybook/lib/stories/dialog.dart
+++ b/storybook/lib/stories/dialog.dart
@@ -9,6 +9,7 @@ final Story dialogStory = Story(
   section: 'Dialogs',
   builder: (context, k) {
     final isDismissible = k.boolean(label: 'Dismissible', initial: true);
+    final hasCloseButton = k.boolean(label: 'Close button', initial: false);
     final content = k.boolean(label: 'Scrollable', initial: false)
         ? _scrollableContent
         : _content(context);
@@ -35,6 +36,7 @@ final Story dialogStory = Story(
                   onPressed: () => _showOneActionDialog(
                     context: context,
                     isDismissible: isDismissible,
+                    hasCloseButton: hasCloseButton,
                     size: OptimusDialogSize.small,
                     content: content,
                     type: type,
@@ -47,6 +49,7 @@ final Story dialogStory = Story(
                   onPressed: () => _showTwoActionDialog(
                     context: context,
                     isDismissible: isDismissible,
+                    hasCloseButton: hasCloseButton,
                     size: OptimusDialogSize.small,
                     content: content,
                     type: type,
@@ -59,6 +62,7 @@ final Story dialogStory = Story(
                   onPressed: () => _showThreeActionDialog(
                     context: context,
                     isDismissible: isDismissible,
+                    hasCloseButton: hasCloseButton,
                     size: OptimusDialogSize.small,
                     content: content,
                     type: type,
@@ -80,6 +84,7 @@ final Story dialogStory = Story(
                   onPressed: () => _showOneActionDialog(
                     context: context,
                     isDismissible: isDismissible,
+                    hasCloseButton: hasCloseButton,
                     size: OptimusDialogSize.regular,
                     content: content,
                     type: type,
@@ -92,6 +97,7 @@ final Story dialogStory = Story(
                   onPressed: () => _showTwoActionDialog(
                     context: context,
                     isDismissible: isDismissible,
+                    hasCloseButton: hasCloseButton,
                     size: OptimusDialogSize.regular,
                     content: content,
                     type: type,
@@ -104,6 +110,7 @@ final Story dialogStory = Story(
                   onPressed: () => _showThreeActionDialog(
                     context: context,
                     isDismissible: isDismissible,
+                    hasCloseButton: hasCloseButton,
                     size: OptimusDialogSize.regular,
                     content: content,
                     type: type,
@@ -125,6 +132,7 @@ final Story dialogStory = Story(
                   onPressed: () => _showOneActionDialog(
                     context: context,
                     isDismissible: isDismissible,
+                    hasCloseButton: hasCloseButton,
                     size: OptimusDialogSize.large,
                     content: content,
                     type: type,
@@ -137,6 +145,7 @@ final Story dialogStory = Story(
                   onPressed: () => _showTwoActionDialog(
                     context: context,
                     isDismissible: isDismissible,
+                    hasCloseButton: hasCloseButton,
                     size: OptimusDialogSize.large,
                     content: content,
                     type: type,
@@ -149,6 +158,7 @@ final Story dialogStory = Story(
                   onPressed: () => _showThreeActionDialog(
                     context: context,
                     isDismissible: isDismissible,
+                    hasCloseButton: hasCloseButton,
                     size: OptimusDialogSize.large,
                     content: content,
                     type: type,
@@ -188,6 +198,7 @@ final Story dialogStory = Story(
 Future<void> _showThreeActionDialog({
   required BuildContext context,
   required bool isDismissible,
+  required bool hasCloseButton,
   required OptimusDialogSize size,
   required Widget content,
   required OptimusDialogType type,
@@ -196,6 +207,7 @@ Future<void> _showThreeActionDialog({
     showOptimusDialog(
       context: context,
       isDismissible: isDismissible,
+      hasCloseButton: hasCloseButton,
       title: Text(title),
       content: content,
       size: size,
@@ -210,6 +222,7 @@ Future<void> _showThreeActionDialog({
 Future<void> _showTwoActionDialog({
   required BuildContext context,
   required bool isDismissible,
+  required bool hasCloseButton,
   required OptimusDialogSize size,
   required Widget content,
   required OptimusDialogType type,
@@ -218,6 +231,7 @@ Future<void> _showTwoActionDialog({
     showOptimusDialog(
       context: context,
       isDismissible: isDismissible,
+      hasCloseButton: hasCloseButton,
       title: Text(title),
       content: content,
       size: size,
@@ -231,6 +245,7 @@ Future<void> _showTwoActionDialog({
 Future<void> _showOneActionDialog({
   required BuildContext context,
   required bool isDismissible,
+  required bool hasCloseButton,
   required OptimusDialogSize size,
   required Widget content,
   required OptimusDialogType type,
@@ -239,6 +254,7 @@ Future<void> _showOneActionDialog({
     showOptimusDialog(
       context: context,
       isDismissible: isDismissible,
+      hasCloseButton: hasCloseButton,
       title: Text(title),
       content: content,
       size: size,

--- a/storybook/lib/stories/nonmodal_wrapper.dart
+++ b/storybook/lib/stories/nonmodal_wrapper.dart
@@ -18,7 +18,7 @@ class NonModalDialogStory extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDismissible = k.boolean(label: 'Dismissible', initial: true);
+    final hasCloseButton = k.boolean(label: 'Close button', initial: true);
     final hasActions = k.boolean(label: 'Has actions', initial: false);
     final title = k.text(label: 'Title', initial: 'Dialog title');
 
@@ -27,7 +27,7 @@ class NonModalDialogStory extends StatelessWidget {
         NonModalWrapper.of(context)?.show(
           title: Text(title),
           content: const Text('Content'),
-          isDismissible: isDismissible,
+          hasCloseButton: hasCloseButton,
           actions:
               hasActions ? [const OptimusDialogAction(title: Text('OK'))] : [],
           size: OptimusDialogSize.small,


### PR DESCRIPTION
#### Summary

Added `hasCloseButton`  property to modal and non-modal dialogs.

This property is now independent from `isDismissible`.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
