### PR TITLE
feat(optimus): Add hasBorders to OptimusExpansionTile

### DIFF
--- a/optimus/lib/src/expansion/expansion_tile.dart
+++ b/optimus/lib/src/expansion/expansion_tile.dart
@@ -166,8 +166,8 @@ class _OptimusExpansionTileState extends State<OptimusExpansionTile>
 
   Widget _buildSlidable(List<Widget> actions, Widget child) => OptimusSlidable(
         actions: actions,
-        child: child,
         hasBorders: widget.hasBorders,
+        child: child,
       );
 
   @override


### PR DESCRIPTION
#### Summary

Add `hasBorders` attribute to `OptimusExpansionTile`.
Needed for [RND-70062](https://mews.myjetbrains.com/youtrack/issue/RND-70062)

#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
