### PR TITLE
feat(optimus): Add params of OptimusSlidable inside OptimusExpansionTile

### DIFF
--- a/optimus/lib/src/expansion/expansion_tile.dart
+++ b/optimus/lib/src/expansion/expansion_tile.dart
@@ -25,7 +25,6 @@ class OptimusExpansionTile extends StatefulWidget {
     this.initiallyExpanded = false,
     this.hasBorders = true,
     this.actionsWidth = 0,
-    this.isSlidableEnabled = true,
     this.slidableActions = const <Widget>[],
   }) : super(key: key);
 
@@ -71,9 +70,6 @@ class OptimusExpansionTile extends StatefulWidget {
 
   /// Width of the inner slidable actions in [OptimusSlidable] widget
   final double actionsWidth;
-
-  /// Param of inner [OptimusSlidable.isEnabled] widget.
-  final bool isSlidableEnabled;
 
   /// List of actions on list tile left swipe.
   final List<Widget> slidableActions;
@@ -176,7 +172,7 @@ class _OptimusExpansionTileState extends State<OptimusExpansionTile>
         actions: actions,
         hasBorders: widget.hasBorders,
         actionsWidth: widget.actionsWidth,
-        isEnabled: widget.isSlidableEnabled,
+        isEnabled: widget.slidableActions.isNotEmpty,
         child: child,
       );
 


### PR DESCRIPTION
#### Summary

Added params of inner `OptimusSlidable`, `isEnabled` and `actionsWidth`
Needed for: [RND-79231](https://mews.myjetbrains.com/youtrack/issue/RND-79231)

#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
