### PR TITLE
feat(mews_pedantic): Update to dart_code_metrics 4.10

### DIFF
--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1-dev.1
+
+ - **FEAT**: Update rules.
+
 ## 0.4.1-dev.0
 
  - **FEAT**: Bump dart_code_metrics.

--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1-dev.0
+
+ - **FEAT**: Bump dart_code_metrics.
+
 ## 0.4.0+1
 
  - **DOCS**: Update readme.

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -54,8 +54,8 @@ analyzer:
   language:
     strict-raw-types: true
   
-  plugins:
-    - dart_code_metrics
+  # plugins:
+  #   - dart_code_metrics
   
   exclude:
     - "**/*.g.dart"

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -92,7 +92,6 @@ dart_code_metrics:
     - no-boolean-literal-compare
     - no-equal-then-else
     - prefer-const-border-radius
-    - prefer-extracting-callbacks
     - prefer-first
     - prefer-last
   

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -7,6 +7,6 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  dart_code_metrics: ^4.9.1
+  dart_code_metrics: ^4.10.0-dev.2
   flutter_lints: ^1.0.4
   meta: ^1.7.0

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mews_pedantic
 description: Dart and Flutter static analysis and lint rules incorporated in Mews.
-version: 0.4.1-dev.0
+version: 0.4.1-dev.1
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mews_pedantic
 description: Dart and Flutter static analysis and lint rules incorporated in Mews.
-version: 0.4.0+1
+version: 0.4.1-dev.0
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:


### PR DESCRIPTION
#### Summary

- Bumped `dart_code_metrics`.
- Temporarily switched off analyzer plugin integration due to https://github.com/Dart-Code/Dart-Code/issues/3745

   ⚠️ Keep in mid that it will disable hints in IDE, analyzer running on CI will continue to report errors.

#### Testing steps

No.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
