### PR TITLE
feat(mews_pedantic): Always use package imports

### DIFF
--- a/kiosk_mode/example/pubspec.yaml
+++ b/kiosk_mode/example/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.0+1
+  mews_pedantic: ^0.4.1-dev.2
 flutter:
   uses-material-design: true

--- a/kiosk_mode/pubspec.yaml
+++ b/kiosk_mode/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.0+1
+  mews_pedantic: ^0.4.1-dev.2
 flutter:
   plugin:
     platforms:

--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.1-dev.2
+
+ - **FEAT**: Enable always_use_package_imports.
+ - **FEAT**: Update to dart_code_metrics 4.10 (#180).
+ - **FEAT**: Update rules.
+ - **FEAT**: Bump dart_code_metrics.
+
 ## 0.4.1-dev.1
 
  - **FEAT**: Update rules.

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -2,6 +2,7 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
+    - always_use_package_imports
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
     - avoid_dynamic_calls

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mews_pedantic
 description: Dart and Flutter static analysis and lint rules incorporated in Mews.
-version: 0.4.1-dev.1
+version: 0.4.1-dev.2
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:

--- a/optimus/CHANGELOG.md
+++ b/optimus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.0+2
+
+ - **REFACTOR**: Fix lint errors.
+
 ## 0.14.0+1
 
  - **REFACTOR**: Update imports (#173).

--- a/optimus/example/pubspec.yaml
+++ b/optimus/example/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.0+1
+  mews_pedantic: ^0.4.1-dev.2

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: optimus
 description: Optimus is a design system for mobile platforms (and web in future) used internally in Mews.
-version: 0.14.0+1
+version: 0.14.0+2
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^1.0.0
-  mews_pedantic: ^0.4.0+1
+  mews_pedantic: ^0.4.1-dev.2
 flutter:
   fonts:
     - family: OpenSans

--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.2
-  mews_pedantic: ^0.4.0+1
+  mews_pedantic: ^0.4.1-dev.2
   mockito: ^5.0.16
   test: ^1.18.0

--- a/storybook/pubspec.yaml
+++ b/storybook/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.0+1
+  mews_pedantic: ^0.4.1-dev.2
 flutter:
   uses-material-design: true


### PR DESCRIPTION
#### Summary

Enabled `always_use_package_imports` in `mews_pedantic`. We already use it like this, so just enforcing a lint rule.

#### Testing steps

No.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
