### PR TITLE
fix(optimus): [RND-92036] RenderBox null in SearchField

### DIFF
--- a/optimus/lib/src/search/search_field.dart
+++ b/optimus/lib/src/search/search_field.dart
@@ -65,6 +65,7 @@ class _OptimusSearchState<T> extends State<OptimusSearch<T>> {
   final _fieldBoxKey = GlobalKey();
 
   FocusNode? _focusNode;
+
   FocusNode get _effectiveFocusNode =>
       widget.focusNode ?? (_focusNode ??= FocusNode());
 
@@ -154,13 +155,16 @@ class _OptimusSearchState<T> extends State<OptimusSearch<T>> {
                   position: box.globalToLocal(details.globalPosition),
                 );
 
-            final RenderBox inputFieldBox =
-                _fieldBoxKey.currentContext?.findRenderObject() as RenderBox;
-            final dropdownBox = context.findRenderObject() as RenderBox;
+            final RenderObject? inputFieldRenderObject =
+                _fieldBoxKey.currentContext?.findRenderObject();
+            final RenderObject? dropdownRenderObject =
+                context.findRenderObject();
 
-            if (hitTest(dropdownBox)) {
+            if (dropdownRenderObject is RenderBox &&
+                hitTest(dropdownRenderObject)) {
               // Touch on dropdown shouldn't close overlay
-            } else if (hitTest(inputFieldBox)) {
+            } else if (inputFieldRenderObject is RenderBox &&
+                hitTest(inputFieldRenderObject)) {
               if (widget.shouldCloseOnInputTap) _removeOverlay();
             } else {
               _removeOverlay();


### PR DESCRIPTION
#### Summary

[RND-92036](https://mews.myjetbrains.com/youtrack/issue/RND-92036)
Added check if `RenderObject` is instance of `RenderBox` and is not null.

#### Testing steps

[Similar scenario like OptimusSlidable](https://github.com/MewsSystems/mews-flutter/pull/172) 🤷‍♂️

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
