### PR TITLE
fix(optimus): RenderBox.size: Null check operator used on a null value

### DIFF
--- a/optimus/lib/src/common/dropdown.dart
+++ b/optimus/lib/src/common/dropdown.dart
@@ -94,11 +94,12 @@ class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
   }
 
   Rect _calculateRect() {
-    final RenderBox renderBox =
-        widget.anchorKey.currentContext?.findRenderObject() as RenderBox;
-    final size = renderBox.size;
+    final renderObject = widget.anchorKey.currentContext?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) return _savedRect;
 
-    return renderBox.localToGlobal(Offset.zero) & size;
+    final size = renderObject.size;
+
+    return renderObject.localToGlobal(Offset.zero) & size;
   }
 
   Widget _buildListView(bool isReversed) => Material(

--- a/optimus/lib/src/common/dropdown.dart
+++ b/optimus/lib/src/common/dropdown.dart
@@ -26,12 +26,13 @@ class OptimusDropdown<T> extends StatefulWidget {
 
 class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
     with ThemeGetter {
-  late Rect _savedRect = _calculateRect();
+  // shouldn't be null since its called right after widget creation
+  late Rect _savedRect = _calculateRect()!;
 
   void _updateRect(dynamic _) {
     if (!mounted) return;
     final newRect = _calculateRect();
-    if (newRect != _savedRect) {
+    if (newRect != null && newRect != _savedRect) {
       setState(() {
         _savedRect = newRect;
       });
@@ -93,9 +94,9 @@ class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
     );
   }
 
-  Rect _calculateRect() {
+  Rect? _calculateRect() {
     final renderObject = widget.anchorKey.currentContext?.findRenderObject();
-    if (renderObject is! RenderBox || !renderObject.hasSize) return _savedRect;
+    if (renderObject is! RenderBox || !renderObject.hasSize) return null;
 
     final size = renderObject.size;
 

--- a/optimus/lib/src/common/dropdown.dart
+++ b/optimus/lib/src/common/dropdown.dart
@@ -27,12 +27,12 @@ class OptimusDropdown<T> extends StatefulWidget {
 class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
     with ThemeGetter {
   // shouldn't be null since its called right after widget creation
-  late Rect _savedRect = _calculateRect()!;
+  late Rect _savedRect = _calculateRect();
 
   void _updateRect(dynamic _) {
     if (!mounted) return;
     final newRect = _calculateRect();
-    if (newRect != null && newRect != _savedRect) {
+    if (newRect != _savedRect) {
       setState(() {
         _savedRect = newRect;
       });
@@ -94,9 +94,9 @@ class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
     );
   }
 
-  Rect? _calculateRect() {
+  Rect _calculateRect() {
     final renderObject = widget.anchorKey.currentContext?.findRenderObject();
-    if (renderObject is! RenderBox || !renderObject.hasSize) return null;
+    if (renderObject is! RenderBox || !renderObject.hasSize) return Rect.zero;
 
     final size = renderObject.size;
 

--- a/optimus/lib/src/common/dropdown.dart
+++ b/optimus/lib/src/common/dropdown.dart
@@ -26,7 +26,6 @@ class OptimusDropdown<T> extends StatefulWidget {
 
 class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
     with ThemeGetter {
-  // shouldn't be null since its called right after widget creation
   late Rect _savedRect = _calculateRect();
 
   void _updateRect(dynamic _) {


### PR DESCRIPTION
#### Summary

Did the same check as in other places regarding `RenderBox`, but here if its `null` returns the previous `_savedRect` 🤷‍♂️

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
