### PR TITLE
feat(optimus)!: [RND-103442] Added new variants for Tags

### DIFF
--- a/optimus/lib/src/colors/color_options.dart
+++ b/optimus/lib/src/colors/color_options.dart
@@ -1,1 +1,1 @@
-enum OptimusColorOption { primary, success, danger, warning, basic }
+enum OptimusColorOption { basic, plain, primary, success, info, warning, danger }

--- a/optimus/lib/src/colors/color_options.dart
+++ b/optimus/lib/src/colors/color_options.dart
@@ -1,1 +1,9 @@
-enum OptimusColorOption { basic, plain, primary, success, info, warning, danger }
+enum OptimusColorOption {
+  basic,
+  plain,
+  primary,
+  success,
+  info,
+  warning,
+  danger
+}

--- a/optimus/lib/src/colors/data_colors.dart
+++ b/optimus/lib/src/colors/data_colors.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+abstract class OptimusDataColors {
+  OptimusDataColors._();
+
+  static const denim50 = Color(0xFFE6EFF6);
+  static const denim100 = Color(0xFFC0D7E8);
+  static const denim200 = Color(0xFF97BDD9);
+  static const denim300 = Color(0xFF6DA3C9);
+  static const denim400 = Color(0xFF4D8FBE);
+  static const denim500 = Color(0xFF2E7BB2);
+  static const denim600 = Color(0xFF2973AB);
+  static const denim700 = Color(0xFF2368A2);
+  static const denim800 = Color(0xFF1D5E99);
+  static const denim900 = Color(0xFF124B8A);
+
+  static const denim500t8 = Color(0x142E7BB2);
+  static const denim500t16 = Color(0x282E7BB2);
+  static const denim500t24 = Color(0x3D2E7BB2);
+  static const denim500t32 = Color(0x512E7BB2);
+  static const denim500t40 = Color(0x662E7BB2);
+  static const denim500t48 = Color(0x7A2E7BB2);
+
+  static const lavender50 = Color(0xFFF0EDF7);
+  static const lavender100 = Color(0xFFD8D2EA);
+  static const lavender200 = Color(0xFFBFB5DD);
+  static const lavender300 = Color(0xFFA597CF);
+  static const lavender400 = Color(0xFF9180C4);
+  static const lavender500 = Color(0xFF7E6ABA);
+  static const lavender600 = Color(0xFF7662B3);
+  static const lavender700 = Color(0xFF6B57AB);
+  static const lavender800 = Color(0xFF614DA3);
+  static const lavender900 = Color(0xFF4E3C94);
+
+  static const lavender500t8 = Color(0x147E6ABA);
+  static const lavender500t16 = Color(0x287E6ABA);
+  static const lavender500t24 = Color(0x3D7E6ABA);
+  static const lavender500t32 = Color(0x517E6ABA);
+  static const lavender500t40 = Color(0x667E6ABA);
+  static const lavender500t48 = Color(0x7A7E6ABA);
+
+  static const lime50 = Color(0xFFE5F1E6);
+  static const lime100 = Color(0xFFBFDBC2);
+  static const lime200 = Color(0xFF95C399);
+  static const lime300 = Color(0xFF6AAB70);
+  static const lime400 = Color(0xFF4A9951);
+  static const lime500 = Color(0xFF2A8732);
+  static const lime600 = Color(0xFF257F2D);
+  static const lime700 = Color(0xFF1F7426);
+  static const lime800 = Color(0xFF196A1F);
+  static const lime900 = Color(0xFF0F5713);
+
+  static const lime500t8 = Color(0x142A8732);
+  static const lime500t16 = Color(0x282A8732);
+  static const lime500t24 = Color(0x3D2A8732);
+  static const lime500t32 = Color(0x512A8732);
+  static const lime500t40 = Color(0x662A8732);
+  static const lime500t48 = Color(0x7A2A8732);
+
+  static const mustard50 = Color(0xFFFCF6E4);
+  static const mustard100 = Color(0xFFF9E9BC);
+  static const mustard200 = Color(0xFFF5DB8F);
+  static const mustard300 = Color(0xFFF0CD62);
+  static const mustard400 = Color(0xFFEDC241);
+  static const mustard500 = Color(0xFFEAB71F);
+  static const mustard600 = Color(0xFFE7B01B);
+  static const mustard700 = Color(0xFFE4A717);
+  static const mustard800 = Color(0xFFE19F12);
+  static const mustard900 = Color(0xFFDB900A);
+
+  static const mustard500t8 = Color(0x14EAB71F);
+  static const mustard500t16 = Color(0x28EAB71F);
+  static const mustard500t24 = Color(0x3DEAB71F);
+  static const mustard500t32 = Color(0x51EAB71F);
+  static const mustard500t40 = Color(0x66EAB71F);
+  static const mustard500t48 = Color(0x7AEAB71F);
+
+  static const tangerine50 = Color(0xFFFCF0EA);
+  static const tangerine100 = Color(0xFFF9D9CA);
+  static const tangerine200 = Color(0xFFF5C0A6);
+  static const tangerine300 = Color(0xFFF0A782);
+  static const tangerine400 = Color(0xFFED9468);
+  static const tangerine500 = Color(0xFFEA814D);
+  static const tangerine600 = Color(0xFFE77946);
+  static const tangerine700 = Color(0xFFE46E3D);
+  static const tangerine800 = Color(0xFFE16434);
+  static const tangerine900 = Color(0xFFDB5125);
+
+  static const tangerine500t8 = Color(0x14EA814D);
+  static const tangerine500t16 = Color(0x28EA814D);
+  static const tangerine500t24 = Color(0x3DEA814D);
+  static const tangerine500t32 = Color(0x51EA814D);
+  static const tangerine500t40 = Color(0x66EA814D);
+  static const tangerine500t48 = Color(0x7AEA814D);
+
+  static const ruby50 = Color(0xFFFAE8EB);
+  static const ruby100 = Color(0xFFF3C5CC);
+  static const ruby200 = Color(0xFFEB9EAB);
+  static const ruby300 = Color(0xFFE27789);
+  static const ruby400 = Color(0xFFDC596F);
+  static const ruby500 = Color(0xFFD63C56);
+  static const ruby600 = Color(0xFFD1364F);
+  static const ruby700 = Color(0xFFCC2E45);
+  static const ruby800 = Color(0xFFC6273C);
+  static const ruby900 = Color(0xFFBC1A2B);
+
+  static const ruby500t8 = Color(0x14D63C56);
+  static const ruby500t16 = Color(0x28D63C56);
+  static const ruby500t24 = Color(0x3DD63C56);
+  static const ruby500t32 = Color(0x51D63C56);
+  static const ruby500t40 = Color(0x66D63C56);
+  static const ruby500t48 = Color(0x7AD63C56);
+
+  static const denim = denim500;
+  static const lavender = lavender500;
+  static const lime = lime500;
+  static const mustard = mustard500;
+  static const tangerine = tangerine500;
+  static const ruby = ruby500;
+}

--- a/optimus/lib/src/tag.dart
+++ b/optimus/lib/src/tag.dart
@@ -202,16 +202,16 @@ class _TagState extends State<_Tag> with ThemeGetter {
   }
 }
 
-enum CategoricalColorOption { denim, lavender, lime, mustard, ruby, tangerine }
+enum OptimusCategoricalColorOption { denim, lavender, lime, mustard, ruby, tangerine }
 
 /// Color options are designed so they won't carry any semantic meaning. Could be used in any cause when
 /// displaying categorical data.
-/// [CategoricalColorOption.denim] - Denim Blue
-/// [CategoricalColorOption.lavender] - Lavender Purple
-/// [CategoricalColorOption.lime] - Lime Green
-/// [CategoricalColorOption.mustard] - Mustard Yellow
-/// [CategoricalColorOption.ruby] - Ruby Red
-/// [CategoricalColorOption.tangerine] - Tangerine Orange
+/// [OptimusCategoricalColorOption.denim] - Denim Blue
+/// [OptimusCategoricalColorOption.lavender] - Lavender Purple
+/// [OptimusCategoricalColorOption.lime] - Lime Green
+/// [OptimusCategoricalColorOption.mustard] - Mustard Yellow
+/// [OptimusCategoricalColorOption.ruby] - Ruby Red
+/// [OptimusCategoricalColorOption.tangerine] - Tangerine Orange
 ///
 class OptimusCategoricalTag extends StatelessWidget {
   const OptimusCategoricalTag({
@@ -221,7 +221,7 @@ class OptimusCategoricalTag extends StatelessWidget {
   }) : super(key: key);
 
   final String text;
-  final CategoricalColorOption colorOption;
+  final OptimusCategoricalColorOption colorOption;
 
   @override
   Widget build(BuildContext context) {
@@ -248,51 +248,51 @@ class OptimusCategoricalTag extends StatelessWidget {
 
   Color get _borderColor {
     switch (colorOption) {
-      case CategoricalColorOption.denim:
+      case OptimusCategoricalColorOption.denim:
         return OptimusDataColors.denim200;
-      case CategoricalColorOption.lavender:
+      case OptimusCategoricalColorOption.lavender:
         return OptimusDataColors.lavender200;
-      case CategoricalColorOption.lime:
+      case OptimusCategoricalColorOption.lime:
         return OptimusDataColors.lime200;
-      case CategoricalColorOption.mustard:
+      case OptimusCategoricalColorOption.mustard:
         return OptimusDataColors.mustard200;
-      case CategoricalColorOption.ruby:
+      case OptimusCategoricalColorOption.ruby:
         return OptimusDataColors.ruby200;
-      case CategoricalColorOption.tangerine:
+      case OptimusCategoricalColorOption.tangerine:
         return OptimusDataColors.tangerine200;
     }
   }
 
   Color get _tagColor {
     switch (colorOption) {
-      case CategoricalColorOption.denim:
+      case OptimusCategoricalColorOption.denim:
         return OptimusDataColors.denim50;
-      case CategoricalColorOption.lavender:
+      case OptimusCategoricalColorOption.lavender:
         return OptimusDataColors.lavender50;
-      case CategoricalColorOption.lime:
+      case OptimusCategoricalColorOption.lime:
         return OptimusDataColors.lime50;
-      case CategoricalColorOption.mustard:
+      case OptimusCategoricalColorOption.mustard:
         return OptimusDataColors.mustard50;
-      case CategoricalColorOption.ruby:
+      case OptimusCategoricalColorOption.ruby:
         return OptimusDataColors.ruby50;
-      case CategoricalColorOption.tangerine:
+      case OptimusCategoricalColorOption.tangerine:
         return OptimusDataColors.tangerine50;
     }
   }
 
   Color _textColor(OptimusThemeData theme) {
     switch (colorOption) {
-      case CategoricalColorOption.denim:
+      case OptimusCategoricalColorOption.denim:
         return OptimusDataColors.denim900;
-      case CategoricalColorOption.lavender:
+      case OptimusCategoricalColorOption.lavender:
         return OptimusDataColors.lavender900;
-      case CategoricalColorOption.lime:
+      case OptimusCategoricalColorOption.lime:
         return OptimusDataColors.lime900;
-      case CategoricalColorOption.mustard:
+      case OptimusCategoricalColorOption.mustard:
         return theme.colors.neutral1000;
-      case CategoricalColorOption.ruby:
+      case OptimusCategoricalColorOption.ruby:
         return OptimusDataColors.ruby900;
-      case CategoricalColorOption.tangerine:
+      case OptimusCategoricalColorOption.tangerine:
         return theme.colors.neutral1000;
     }
   }

--- a/optimus/lib/src/tag.dart
+++ b/optimus/lib/src/tag.dart
@@ -149,44 +149,52 @@ class _TagState extends State<_Tag> with ThemeGetter {
     switch (widget.colorOption) {
       case OptimusColorOption.basic:
         // TODO(VG): can be changed when final dark theme design is ready.
-        return theme.colors.neutral50;
+        return theme.isDark ? theme.colors.neutral300 : theme.colors.neutral50;
       case OptimusColorOption.plain:
-        return theme.colors.neutral25;
+        return theme.isDark ? theme.colors.neutral200 : theme.colors.neutral25;
       case OptimusColorOption.primary:
-        return theme.colors.primary50;
+        return theme.isDark
+            ? theme.colors.primary500t32
+            : theme.colors.primary50;
       case OptimusColorOption.success:
-        return theme.colors.success50;
+        return theme.isDark
+            ? theme.colors.success500t32
+            : theme.colors.success50;
       case OptimusColorOption.info:
-        return theme.colors.info50;
+        return theme.isDark ? theme.colors.info500t32 : theme.colors.info50;
       case OptimusColorOption.warning:
-        return theme.colors.warning50;
+        return theme.isDark
+            ? theme.colors.warning500t32
+            : theme.colors.warning50;
       case OptimusColorOption.danger:
-        return theme.colors.danger50;
+        return theme.isDark ? theme.colors.danger500t32 : theme.colors.danger50;
     }
   }
 
   Color get _borderColor {
     switch (widget.colorOption) {
       case OptimusColorOption.basic:
+        return theme.isDark ? theme.colors.neutral100 : theme.colors.neutral200;
+
       // TODO(VG): can be changed when final dark theme design is ready.
       case OptimusColorOption.plain:
-        return theme.colors.neutral200;
+        return theme.isDark ? theme.colors.neutral50 : theme.colors.neutral200;
       case OptimusColorOption.primary:
-        return theme.colors.primary200;
+        return theme.isDark ? theme.colors.primary500 : theme.colors.primary200;
       case OptimusColorOption.success:
-        return theme.colors.success200;
+        return theme.isDark ? theme.colors.success500 : theme.colors.success200;
       case OptimusColorOption.info:
-        return theme.colors.info200;
+        return theme.isDark ? theme.colors.info500 : theme.colors.info200;
       case OptimusColorOption.warning:
-        return theme.colors.warning200;
+        return theme.isDark ? theme.colors.warning500 : theme.colors.warning200;
       case OptimusColorOption.danger:
-        return theme.colors.danger200;
+        return theme.isDark ? theme.colors.danger500 : theme.colors.danger200;
     }
   }
 
   Color get _textColor {
     // TODO(VG): can be changed when final dark theme design is ready.
-    if (theme.isDark) return theme.colors.neutral1000;
+    if (theme.isDark) return theme.colors.neutral50;
 
     switch (widget.colorOption) {
       case OptimusColorOption.basic:
@@ -215,41 +223,67 @@ enum OptimusCategoricalColorOption {
 }
 
 extension on OptimusCategoricalColorOption {
-  Color borderColor() {
+  Color borderColor(OptimusThemeData theme) {
     switch (this) {
       case OptimusCategoricalColorOption.denim:
-        return OptimusDataColors.denim200;
+        return theme.isDark
+            ? OptimusDataColors.denim500
+            : OptimusDataColors.denim200;
       case OptimusCategoricalColorOption.lavender:
-        return OptimusDataColors.lavender200;
+        return theme.isDark
+            ? OptimusDataColors.lavender500
+            : OptimusDataColors.lavender200;
       case OptimusCategoricalColorOption.lime:
-        return OptimusDataColors.lime200;
+        return theme.isDark
+            ? OptimusDataColors.lime500
+            : OptimusDataColors.lime200;
       case OptimusCategoricalColorOption.mustard:
-        return OptimusDataColors.mustard200;
+        return theme.isDark
+            ? OptimusDataColors.mustard500
+            : OptimusDataColors.mustard200;
       case OptimusCategoricalColorOption.ruby:
-        return OptimusDataColors.ruby200;
+        return theme.isDark
+            ? OptimusDataColors.ruby500
+            : OptimusDataColors.ruby200;
       case OptimusCategoricalColorOption.tangerine:
-        return OptimusDataColors.tangerine200;
+        return theme.isDark
+            ? OptimusDataColors.tangerine500
+            : OptimusDataColors.tangerine200;
     }
   }
 
-  Color tagColor() {
+  Color tagColor(OptimusThemeData theme) {
     switch (this) {
       case OptimusCategoricalColorOption.denim:
-        return OptimusDataColors.denim50;
+        return theme.isDark
+            ? OptimusDataColors.denim500t32
+            : OptimusDataColors.denim50;
       case OptimusCategoricalColorOption.lavender:
-        return OptimusDataColors.lavender50;
+        return theme.isDark
+            ? OptimusDataColors.lavender500t32
+            : OptimusDataColors.lavender50;
       case OptimusCategoricalColorOption.lime:
-        return OptimusDataColors.lime50;
+        return theme.isDark
+            ? OptimusDataColors.lime500t32
+            : OptimusDataColors.lime50;
       case OptimusCategoricalColorOption.mustard:
-        return OptimusDataColors.mustard50;
+        return theme.isDark
+            ? OptimusDataColors.mustard500t32
+            : OptimusDataColors.mustard50;
       case OptimusCategoricalColorOption.ruby:
-        return OptimusDataColors.ruby50;
+        return theme.isDark
+            ? OptimusDataColors.ruby500t32
+            : OptimusDataColors.ruby50;
       case OptimusCategoricalColorOption.tangerine:
-        return OptimusDataColors.tangerine50;
+        return theme.isDark
+            ? OptimusDataColors.tangerine500t32
+            : OptimusDataColors.tangerine50;
     }
   }
 
   Color textColor(OptimusThemeData theme) {
+    if (theme.isDark) return theme.colors.neutral50;
+
     switch (this) {
       case OptimusCategoricalColorOption.denim:
         return OptimusDataColors.denim900;
@@ -292,8 +326,8 @@ class OptimusCategoricalTag extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: colorOption.tagColor(),
-        border: Border.all(color: colorOption.borderColor()),
+        color: colorOption.tagColor(theme),
+        border: Border.all(color: colorOption.borderColor(theme)),
         borderRadius: const BorderRadius.all(borderRadius25),
       ),
       padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),

--- a/optimus/lib/src/tag.dart
+++ b/optimus/lib/src/tag.dart
@@ -9,8 +9,8 @@ import 'package:optimus/src/typography/presets.dart';
 /// Tags are used to highlight an item’s status or make it easier to recognize
 /// certain items in data-dense content.
 /// For system-specific feedback with semantic significance use OptimusTag.
-/// For data-dense content, where representation isn't carrying semantic significance
-/// use OptimusCategoricalTag.
+/// For data-dense content, where representation isn't carrying semantic
+/// significance use OptimusCategoricalTag.
 ///
 /// Be wary of using multiple tags on one item, as it could cause visual noise.
 /// Non-interactive tags are used to highlight an item’s status or make it
@@ -214,15 +214,68 @@ enum OptimusCategoricalColorOption {
   tangerine
 }
 
-/// Color options are designed so they won't carry any semantic meaning. Could be used in any cause when
-/// displaying categorical data.
+extension on OptimusCategoricalColorOption {
+  Color borderColor() {
+    switch (this) {
+      case OptimusCategoricalColorOption.denim:
+        return OptimusDataColors.denim200;
+      case OptimusCategoricalColorOption.lavender:
+        return OptimusDataColors.lavender200;
+      case OptimusCategoricalColorOption.lime:
+        return OptimusDataColors.lime200;
+      case OptimusCategoricalColorOption.mustard:
+        return OptimusDataColors.mustard200;
+      case OptimusCategoricalColorOption.ruby:
+        return OptimusDataColors.ruby200;
+      case OptimusCategoricalColorOption.tangerine:
+        return OptimusDataColors.tangerine200;
+    }
+  }
+
+  Color tagColor() {
+    switch (this) {
+      case OptimusCategoricalColorOption.denim:
+        return OptimusDataColors.denim50;
+      case OptimusCategoricalColorOption.lavender:
+        return OptimusDataColors.lavender50;
+      case OptimusCategoricalColorOption.lime:
+        return OptimusDataColors.lime50;
+      case OptimusCategoricalColorOption.mustard:
+        return OptimusDataColors.mustard50;
+      case OptimusCategoricalColorOption.ruby:
+        return OptimusDataColors.ruby50;
+      case OptimusCategoricalColorOption.tangerine:
+        return OptimusDataColors.tangerine50;
+    }
+  }
+
+  Color textColor(OptimusThemeData theme) {
+    switch (this) {
+      case OptimusCategoricalColorOption.denim:
+        return OptimusDataColors.denim900;
+      case OptimusCategoricalColorOption.lavender:
+        return OptimusDataColors.lavender900;
+      case OptimusCategoricalColorOption.lime:
+        return OptimusDataColors.lime900;
+      case OptimusCategoricalColorOption.mustard:
+        return theme.colors.neutral1000;
+      case OptimusCategoricalColorOption.ruby:
+        return OptimusDataColors.ruby900;
+      case OptimusCategoricalColorOption.tangerine:
+        return theme.colors.neutral1000;
+    }
+  }
+}
+
+/// Color options are designed so they won't carry any semantic meaning. Could
+/// be used in any case when displaying categorical data.
+///
 /// [OptimusCategoricalColorOption.denim] - Denim Blue
 /// [OptimusCategoricalColorOption.lavender] - Lavender Purple
 /// [OptimusCategoricalColorOption.lime] - Lime Green
 /// [OptimusCategoricalColorOption.mustard] - Mustard Yellow
 /// [OptimusCategoricalColorOption.ruby] - Ruby Red
 /// [OptimusCategoricalColorOption.tangerine] - Tangerine Orange
-///
 class OptimusCategoricalTag extends StatelessWidget {
   const OptimusCategoricalTag({
     Key? key,
@@ -239,71 +292,20 @@ class OptimusCategoricalTag extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: _tagColor,
-        border: Border.all(color: _borderColor),
+        color: colorOption.tagColor(),
+        border: Border.all(color: colorOption.borderColor()),
         borderRadius: const BorderRadius.all(borderRadius25),
       ),
       padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
       child: Text(
         text.toUpperCase(),
         style: baseTextStyle.copyWith(
-          color: _textColor(theme),
+          color: colorOption.textColor(theme),
           fontWeight: FontWeight.w600,
           fontSize: 12,
         ),
         overflow: TextOverflow.ellipsis,
       ),
     );
-  }
-
-  Color get _borderColor {
-    switch (colorOption) {
-      case OptimusCategoricalColorOption.denim:
-        return OptimusDataColors.denim200;
-      case OptimusCategoricalColorOption.lavender:
-        return OptimusDataColors.lavender200;
-      case OptimusCategoricalColorOption.lime:
-        return OptimusDataColors.lime200;
-      case OptimusCategoricalColorOption.mustard:
-        return OptimusDataColors.mustard200;
-      case OptimusCategoricalColorOption.ruby:
-        return OptimusDataColors.ruby200;
-      case OptimusCategoricalColorOption.tangerine:
-        return OptimusDataColors.tangerine200;
-    }
-  }
-
-  Color get _tagColor {
-    switch (colorOption) {
-      case OptimusCategoricalColorOption.denim:
-        return OptimusDataColors.denim50;
-      case OptimusCategoricalColorOption.lavender:
-        return OptimusDataColors.lavender50;
-      case OptimusCategoricalColorOption.lime:
-        return OptimusDataColors.lime50;
-      case OptimusCategoricalColorOption.mustard:
-        return OptimusDataColors.mustard50;
-      case OptimusCategoricalColorOption.ruby:
-        return OptimusDataColors.ruby50;
-      case OptimusCategoricalColorOption.tangerine:
-        return OptimusDataColors.tangerine50;
-    }
-  }
-
-  Color _textColor(OptimusThemeData theme) {
-    switch (colorOption) {
-      case OptimusCategoricalColorOption.denim:
-        return OptimusDataColors.denim900;
-      case OptimusCategoricalColorOption.lavender:
-        return OptimusDataColors.lavender900;
-      case OptimusCategoricalColorOption.lime:
-        return OptimusDataColors.lime900;
-      case OptimusCategoricalColorOption.mustard:
-        return theme.colors.neutral1000;
-      case OptimusCategoricalColorOption.ruby:
-        return OptimusDataColors.ruby900;
-      case OptimusCategoricalColorOption.tangerine:
-        return theme.colors.neutral1000;
-    }
   }
 }

--- a/optimus/lib/src/tag.dart
+++ b/optimus/lib/src/tag.dart
@@ -38,7 +38,8 @@ class OptimusTag extends StatelessWidget {
   final OptimusColorOption colorOption;
 
   @override
-  Widget build(BuildContext context) => _Tag(text: text, colorOption: colorOption);
+  Widget build(BuildContext context) =>
+      _Tag(text: text, colorOption: colorOption);
 }
 
 /// Tags are used to highlight an item’s status or make it easier to recognize
@@ -116,7 +117,9 @@ class _TagState extends State<_Tag> with ThemeGetter {
           children: [
             Flexible(
               child: Text(
-                widget.onRemoved != null ? widget.text : widget.text.toUpperCase(),
+                widget.onRemoved != null
+                    ? widget.text
+                    : widget.text.toUpperCase(),
                 style: widget.onRemoved != null
                     ? preset200s.copyWith(
                         height: 1.1,
@@ -202,7 +205,14 @@ class _TagState extends State<_Tag> with ThemeGetter {
   }
 }
 
-enum OptimusCategoricalColorOption { denim, lavender, lime, mustard, ruby, tangerine }
+enum OptimusCategoricalColorOption {
+  denim,
+  lavender,
+  lime,
+  mustard,
+  ruby,
+  tangerine
+}
 
 /// Color options are designed so they won't carry any semantic meaning. Could be used in any cause when
 /// displaying categorical data.

--- a/optimus/lib/src/tag.dart
+++ b/optimus/lib/src/tag.dart
@@ -2,20 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/border_radius.dart';
+import 'package:optimus/src/colors/data_colors.dart';
 import 'package:optimus/src/constants.dart';
 import 'package:optimus/src/typography/presets.dart';
 
-enum TagVersion {
-  /// Use the bold version to highlight important items onscreen.
-  bold,
-
-  /// Use the subtle version, if you want express an item’s status in heavy,
-  /// data-dense scenarios (like in long tables with lot of tags)
-  subtle,
-}
-
 /// Tags are used to highlight an item’s status or make it easier to recognize
 /// certain items in data-dense content.
+/// For system-specific feedback with semantic significance use OptimusTag.
+/// For data-dense content, where representation isn't carrying semantic significance
+/// use OptimusCategoricalTag.
 ///
 /// Be wary of using multiple tags on one item, as it could cause visual noise.
 /// Non-interactive tags are used to highlight an item’s status or make it
@@ -26,7 +21,6 @@ class OptimusTag extends StatelessWidget {
     Key? key,
     required this.text,
     this.colorOption = OptimusColorOption.basic,
-    this.version = TagVersion.bold,
   }) : super(key: key);
 
   /// The text to display in the tag.
@@ -34,19 +28,17 @@ class OptimusTag extends StatelessWidget {
 
   /// Controls color of the tag. Use-cases:
   /// - [OptimusColorOption.basic] – highlight general status or state of item;
+  /// - [OptimusColorOption.plain] - highlight general status or state of item;
   /// - [OptimusColorOption.primary] – highlight primary item, in progress, or
   ///   current item;
   /// - [OptimusColorOption.success] – highlight success state of item;
-  /// - [OptimusColorOption.danger] – highlight problematic or error item;
+  /// - [OptimusColorOption.info] - highlighting informational/helpful item;
   /// - [OptimusColorOption.warning] – highlight item that requires attention.
+  /// - [OptimusColorOption.danger] – highlight problematic or error item;
   final OptimusColorOption colorOption;
 
-  /// The version of the tag.
-  final TagVersion version;
-
   @override
-  Widget build(BuildContext context) =>
-      _Tag(text: text, colorOption: colorOption, version: version);
+  Widget build(BuildContext context) => _Tag(text: text, colorOption: colorOption);
 }
 
 /// Tags are used to highlight an item’s status or make it easier to recognize
@@ -87,13 +79,11 @@ class _Tag extends StatefulWidget {
     Key? key,
     required this.text,
     this.colorOption = OptimusColorOption.basic,
-    this.version = TagVersion.bold,
     this.onRemoved,
   }) : super(key: key);
 
   final String text;
   final OptimusColorOption colorOption;
-  final TagVersion version;
   final VoidCallback? onRemoved;
 
   @override
@@ -117,6 +107,7 @@ class _TagState extends State<_Tag> with ThemeGetter {
   Widget build(BuildContext context) => Container(
         decoration: BoxDecoration(
           color: widget.onRemoved != null ? theme.colors.neutral50 : _tagColor,
+          border: Border.all(color: _borderColor),
           borderRadius: const BorderRadius.all(borderRadius25),
         ),
         padding: _tagPadding,
@@ -125,9 +116,7 @@ class _TagState extends State<_Tag> with ThemeGetter {
           children: [
             Flexible(
               child: Text(
-                widget.onRemoved != null
-                    ? widget.text
-                    : widget.text.toUpperCase(),
+                widget.onRemoved != null ? widget.text : widget.text.toUpperCase(),
                 style: widget.onRemoved != null
                     ? preset200s.copyWith(
                         height: 1.1,
@@ -151,89 +140,159 @@ class _TagState extends State<_Tag> with ThemeGetter {
 
   EdgeInsets get _tagPadding => widget.onRemoved != null
       ? const EdgeInsets.only(top: 1.5, bottom: 1.5, left: 8)
-      : const EdgeInsets.symmetric(vertical: 1, horizontal: 8);
+      : const EdgeInsets.symmetric(vertical: 2, horizontal: 8);
 
   Color get _tagColor {
-    switch (widget.version) {
-      case TagVersion.bold:
-        return _tagBoldColor;
-      case TagVersion.subtle:
-        return _tagSubtleColor;
-    }
-  }
-
-  Color get _tagBoldColor {
     switch (widget.colorOption) {
       case OptimusColorOption.basic:
         // TODO(VG): can be changed when final dark theme design is ready.
-        return theme.isDark ? theme.colors.neutral0 : theme.colors.neutral500;
+        return theme.colors.neutral50;
+      case OptimusColorOption.plain:
+        return theme.colors.neutral25;
       case OptimusColorOption.primary:
-        return theme.colors.primary500;
+        return theme.colors.primary50;
       case OptimusColorOption.success:
-        return theme.colors.success500;
+        return theme.colors.success50;
+      case OptimusColorOption.info:
+        return theme.colors.info50;
       case OptimusColorOption.warning:
-        return theme.colors.warning500;
+        return theme.colors.warning50;
       case OptimusColorOption.danger:
-        return theme.colors.danger500;
+        return theme.colors.danger50;
     }
   }
 
-  // TODO(VG): can be changed when final dark theme design is ready.
-  Color get _tagSubtleColor {
+  Color get _borderColor {
     switch (widget.colorOption) {
       case OptimusColorOption.basic:
-        return theme.isDark ? theme.colors.neutral400 : theme.colors.neutral50;
+      // TODO(VG): can be changed when final dark theme design is ready.
+      case OptimusColorOption.plain:
+        return theme.colors.neutral200;
       case OptimusColorOption.primary:
-        return theme.isDark
-            ? theme.colors.primary500t32
-            : theme.colors.primary50;
+        return theme.colors.primary200;
       case OptimusColorOption.success:
-        return theme.isDark
-            ? theme.colors.success500t32
-            : theme.colors.success50;
+        return theme.colors.success200;
+      case OptimusColorOption.info:
+        return theme.colors.info200;
       case OptimusColorOption.warning:
-        return theme.isDark
-            ? theme.colors.warning500t32
-            : theme.colors.warning50;
+        return theme.colors.warning200;
       case OptimusColorOption.danger:
-        return theme.isDark ? theme.colors.danger500t32 : theme.colors.danger50;
+        return theme.colors.danger200;
     }
   }
 
   Color get _textColor {
-    switch (widget.version) {
-      case TagVersion.bold:
-        return _textBoldColor;
-      case TagVersion.subtle:
-        return _textSubtleColor;
-    }
-  }
-
-  Color get _textBoldColor {
     // TODO(VG): can be changed when final dark theme design is ready.
     if (theme.isDark) return theme.colors.neutral1000;
 
     switch (widget.colorOption) {
+      case OptimusColorOption.basic:
+      case OptimusColorOption.plain:
       case OptimusColorOption.warning:
         return theme.colors.neutral1000;
-      default:
-        return theme.colors.neutral0;
-    }
-  }
-
-  Color get _textSubtleColor {
-    // TODO(VG): can be changed when final dark theme design is ready.
-    if (theme.isDark) return theme.colors.neutral0;
-
-    switch (widget.colorOption) {
       case OptimusColorOption.primary:
         return theme.colors.primary900;
       case OptimusColorOption.success:
         return theme.colors.success900;
+      case OptimusColorOption.info:
+        return theme.colors.info900;
       case OptimusColorOption.danger:
         return theme.colors.danger900;
-      case OptimusColorOption.basic:
-      case OptimusColorOption.warning:
+    }
+  }
+}
+
+enum CategoricalColorOption { denim, lavender, lime, mustard, ruby, tangerine }
+
+/// Color options are designed so they won't carry any semantic meaning. Could be used in any cause when
+/// displaying categorical data.
+/// [CategoricalColorOption.denim] - Denim Blue
+/// [CategoricalColorOption.lavender] - Lavender Purple
+/// [CategoricalColorOption.lime] - Lime Green
+/// [CategoricalColorOption.mustard] - Mustard Yellow
+/// [CategoricalColorOption.ruby] - Ruby Red
+/// [CategoricalColorOption.tangerine] - Tangerine Orange
+///
+class OptimusCategoricalTag extends StatelessWidget {
+  const OptimusCategoricalTag({
+    Key? key,
+    required this.text,
+    required this.colorOption,
+  }) : super(key: key);
+
+  final String text;
+  final CategoricalColorOption colorOption;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = OptimusTheme.of(context);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: _tagColor,
+        border: Border.all(color: _borderColor),
+        borderRadius: const BorderRadius.all(borderRadius25),
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
+      child: Text(
+        text.toUpperCase(),
+        style: baseTextStyle.copyWith(
+          color: _textColor(theme),
+          fontWeight: FontWeight.w600,
+          fontSize: 12,
+        ),
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  Color get _borderColor {
+    switch (colorOption) {
+      case CategoricalColorOption.denim:
+        return OptimusDataColors.denim200;
+      case CategoricalColorOption.lavender:
+        return OptimusDataColors.lavender200;
+      case CategoricalColorOption.lime:
+        return OptimusDataColors.lime200;
+      case CategoricalColorOption.mustard:
+        return OptimusDataColors.mustard200;
+      case CategoricalColorOption.ruby:
+        return OptimusDataColors.ruby200;
+      case CategoricalColorOption.tangerine:
+        return OptimusDataColors.tangerine200;
+    }
+  }
+
+  Color get _tagColor {
+    switch (colorOption) {
+      case CategoricalColorOption.denim:
+        return OptimusDataColors.denim50;
+      case CategoricalColorOption.lavender:
+        return OptimusDataColors.lavender50;
+      case CategoricalColorOption.lime:
+        return OptimusDataColors.lime50;
+      case CategoricalColorOption.mustard:
+        return OptimusDataColors.mustard50;
+      case CategoricalColorOption.ruby:
+        return OptimusDataColors.ruby50;
+      case CategoricalColorOption.tangerine:
+        return OptimusDataColors.tangerine50;
+    }
+  }
+
+  Color _textColor(OptimusThemeData theme) {
+    switch (colorOption) {
+      case CategoricalColorOption.denim:
+        return OptimusDataColors.denim900;
+      case CategoricalColorOption.lavender:
+        return OptimusDataColors.lavender900;
+      case CategoricalColorOption.lime:
+        return OptimusDataColors.lime900;
+      case CategoricalColorOption.mustard:
+        return theme.colors.neutral1000;
+      case CategoricalColorOption.ruby:
+        return OptimusDataColors.ruby900;
+      case CategoricalColorOption.tangerine:
         return theme.colors.neutral1000;
     }
   }

--- a/storybook/lib/stories/tags.dart
+++ b/storybook/lib/stories/tags.dart
@@ -8,11 +8,21 @@ final Story tagStory = Story(
   builder: (context) {
     final k = context.knobs;
 
-    Widget buildTags(TagVersion version) => Wrap(
+    Widget buildSystemTags() => Wrap(
           children: OptimusColorOption.values
               .map(
-                (c) => _PaddedTag(
-                  version: version,
+                (c) => _PaddedSystemTag(
+                  colorOption: c,
+                  text: k.text(label: 'Text', initial: ''),
+                ),
+              )
+              .toList(),
+        );
+
+    Widget buildCategoricalTags() => Wrap(
+          children: OptimusCategoricalColorOption.values
+              .map(
+                (c) => _PaddedCategoricalTag(
                   colorOption: c,
                   text: k.text(label: 'Text', initial: ''),
                 ),
@@ -23,11 +33,11 @@ final Story tagStory = Story(
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        const OptimusSectionTitle(child: Text('Bold')),
-        buildTags(TagVersion.bold),
+        const OptimusSectionTitle(child: Text('System')),
+        buildSystemTags(),
         const SizedBox(height: 20),
-        const OptimusSectionTitle(child: Text('Subtle')),
-        buildTags(TagVersion.subtle),
+        const OptimusSectionTitle(child: Text('Categorical')),
+        buildCategoricalTags(),
       ],
     );
   },
@@ -45,15 +55,13 @@ final Story interactiveTagStory = Story(
   },
 );
 
-class _PaddedTag extends StatelessWidget {
-  const _PaddedTag({
+class _PaddedSystemTag extends StatelessWidget {
+  const _PaddedSystemTag({
     Key? key,
-    required this.version,
     required this.colorOption,
     required this.text,
   }) : super(key: key);
 
-  final TagVersion version;
   final OptimusColorOption colorOption;
   final String text;
 
@@ -63,7 +71,26 @@ class _PaddedTag extends StatelessWidget {
         child: OptimusTag(
           text: text.isEmpty ? describeEnum(colorOption) : text,
           colorOption: colorOption,
-          version: version,
+        ),
+      );
+}
+
+class _PaddedCategoricalTag extends StatelessWidget {
+  const _PaddedCategoricalTag({
+    Key? key,
+    required this.colorOption,
+    required this.text,
+  }) : super(key: key);
+
+  final OptimusCategoricalColorOption colorOption;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.all(8),
+        child: OptimusCategoricalTag(
+          text: text.isEmpty ? describeEnum(colorOption) : text,
+          colorOption: colorOption,
         ),
       );
 }


### PR DESCRIPTION
#### Summary

RND-103442

Added missing variants for the Tag component.

**BREAKING CHANGE:** Bold/Subtle variants are replaced with OptimusTag (system, prev. bold) and OptimusCategoricalTag (data, prev. subtle). The signature of OptumusTag was changed.

Screenshots are below, hidden under spoilers. 

<details>
<summary>Light Mode</summary>

- Was
<img width="598" alt="Screenshot 2022-05-11 at 12 05 20" src="https://user-images.githubusercontent.com/9210422/167825511-afb59969-ef80-4174-a62f-62d1ebd31297.png">

- Is
<img width="684" alt="Screenshot 2022-05-11 at 12 00 58" src="https://user-images.githubusercontent.com/9210422/167825444-c8c6c5a1-fe20-474f-a670-548965a649e0.png">
</details>

<details>
<summary>Dark Mode</summary>

- Was
<img width="496" alt="Screenshot 2022-05-11 at 12 15 11" src="https://user-images.githubusercontent.com/9210422/167828421-ea8cec9f-930a-4a76-871a-c8e16c12e256.png">

- Is
<img width="601" alt="Screenshot 2022-05-12 at 13 33 59" src="https://user-images.githubusercontent.com/9210422/168066090-81dbdb25-1e9a-4cbe-804a-83b3ba95bb05.png">
</details>

#### Testing steps

No.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
