### PR TITLE
feat: Upgrade to Dart 2.17 [do not squash]

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
+        with:
+          flutter-version: "3.0.0"
+          cache: true
       - run: echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
       - run: dart pub global activate melos
       - run: melos run check_master

--- a/kiosk_mode/example/pubspec.yaml
+++ b/kiosk_mode/example/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.2
+  mews_pedantic: ^0.5.0
 flutter:
   uses-material-design: true

--- a/kiosk_mode/pubspec.yaml
+++ b/kiosk_mode/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.2
+  mews_pedantic: ^0.5.0
 flutter:
   plugin:
     platforms:

--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **FEAT**: Upgrade to dart 2.17.
+
 ## 0.4.2
 
  - **FEAT**: Bump dart_code_metrics to 4.14.0.

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -1,40 +1,107 @@
-include: package:flutter_lints/flutter.yaml
-
 linter:
   rules:
     - always_use_package_imports
+    - annotate_overrides
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
     - avoid_dynamic_calls
+    - avoid_empty_else
     - avoid_final_parameters
+    - avoid_function_literals_in_foreach_calls
     - avoid_implementing_value_types
+    - avoid_init_to_null
+    - avoid_null_checks_in_equality_operators
+    - avoid_print
+    - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
+    - avoid_return_types_on_setters
+    - avoid_returning_null_for_void
+    - avoid_shadowing_type_parameters
+    - avoid_single_cascade_in_expression_statements
+    - avoid_types_as_parameter_names
+    - avoid_unnecessary_containers
     - avoid_unused_constructor_parameters
     - avoid_void_async
+    - avoid_web_libraries_in_flutter
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
     - cancel_subscriptions
     - cascade_invocations
     - close_sinks
     - comment_references
+    - constant_identifier_names
+    - control_flow_in_finally
+    - curly_braces_in_flow_control_structures
+    - depend_on_referenced_packages
     - directives_ordering
+    - empty_catches
+    - empty_constructor_bodies
+    - empty_statements
+    - exhaustive_cases
+    - file_names
     - flutter_style_todos
+    - hash_and_equals
+    - implementation_imports
     - invariant_booleans
+    - iterable_contains_unrelated_type
     - join_return_with_assignment
+    - library_names
+    - library_prefixes
+    - library_private_types_in_public_api
+    - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - no_adjacent_strings_in_list
+    - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
+    - no_logic_in_create_state
+    - non_constant_identifier_names
+    - null_check_on_nullable_type_parameter
     - only_throw_errors
+    - overridden_fields
     - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
     - prefer_asserts_with_message
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+    - prefer_contains
+    - prefer_equal_for_default_values
     - prefer_expression_function_bodies
+    - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
+    - prefer_for_elements_to_map_fromIterable
+    - prefer_function_declarations_over_variables
+    - prefer_generic_function_type_aliases
     - prefer_if_elements_to_conditional_expressions
+    - prefer_if_null_operators
+    - prefer_initializing_formals
+    - prefer_inlined_adds
     - prefer_interpolation_to_compose_strings
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_is_not_operator
+    - prefer_iterable_whereType
     - prefer_mixin
+    - prefer_null_aware_operators
     - prefer_single_quotes
+    - prefer_spread_collections
+    - prefer_typing_uninitialized_variables
+    - prefer_void_to_null
+    - provide_deprecation_message
+    - recursive_getters
     - require_trailing_commas
+    - sized_box_for_whitespace
     - sized_box_shrink_expand
+    - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
     - sort_pub_dependencies
@@ -45,17 +112,36 @@ linter:
     - type_init_formals
     - unawaited_futures
     - unnecessary_await_in_return
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    - unnecessary_constructor_name
+    - unnecessary_getters_setters
     - unnecessary_lambdas
     - unnecessary_late
+    - unnecessary_new
     - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
+    - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_statements
+    - unnecessary_string_escapes
+    - unnecessary_string_interpolations
+    - unnecessary_this
+    - unrelated_type_equality_checks
+    - use_build_context_synchronously
     - use_decorated_box
+    - use_full_hex_values_for_flutter_colors
+    - use_function_type_syntax_for_parameters
+    - use_key_in_widget_constructors
     - use_named_constants
     - use_raw_strings
+    - use_rethrow_when_possible
     - use_setters_to_change_properties
     - use_string_buffers
     - use_to_and_as_if_applicable
+    - valid_regexps
+    - void_checks
 
 analyzer:
   language:

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mews_pedantic
 description: Dart and Flutter static analysis and lint rules incorporated in Mews.
-version: 0.4.2
+version: 0.5.0
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -4,9 +4,8 @@ version: 0.4.2
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  dart_code_metrics: 4.14.0
-  flutter_lints: ^1.0.4
+  dart_code_metrics: 4.15.0
   meta: ^1.7.0

--- a/optimus/example/pubspec.yaml
+++ b/optimus/example/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.2
+  mews_pedantic: ^0.5.0

--- a/optimus/lib/src/borders.dart
+++ b/optimus/lib/src/borders.dart
@@ -16,7 +16,7 @@ class TileBorders extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         Stack(
-          overflow: Overflow.visible,
+          clipBehavior: Clip.none,
           children: <Widget>[
             Positioned(
               bottom: -1,

--- a/optimus/lib/src/button/base_dropdown_button.dart
+++ b/optimus/lib/src/button/base_dropdown_button.dart
@@ -26,7 +26,7 @@ class BaseDropDownButton<T> extends StatefulWidget {
   final BorderRadius borderRadius;
 
   @override
-  _BaseDropDownButtonState<T> createState() => _BaseDropDownButtonState<T>();
+  State<BaseDropDownButton<T>> createState() => _BaseDropDownButtonState<T>();
 }
 
 class _BaseDropDownButtonState<T> extends State<BaseDropDownButton<T>>

--- a/optimus/lib/src/button/icon.dart
+++ b/optimus/lib/src/button/icon.dart
@@ -57,7 +57,7 @@ class OptimusIconButton extends StatefulWidget {
   final OptimusIconButtonVariant variant;
 
   @override
-  _OptimusIconButtonState createState() => _OptimusIconButtonState();
+  State<OptimusIconButton> createState() => _OptimusIconButtonState();
 }
 
 class _OptimusIconButtonState extends State<OptimusIconButton>

--- a/optimus/lib/src/chat/optimus_chat_input.dart
+++ b/optimus/lib/src/chat/optimus_chat_input.dart
@@ -9,7 +9,7 @@ class OptimusChatInput extends StatefulWidget {
   final SendCallback onSendPressed;
 
   @override
-  _OptimusChatInputState createState() => _OptimusChatInputState();
+  State<OptimusChatInput> createState() => _OptimusChatInputState();
 }
 
 class _OptimusChatInputState extends State<OptimusChatInput> {

--- a/optimus/lib/src/checkbox/checkbox.dart
+++ b/optimus/lib/src/checkbox/checkbox.dart
@@ -70,7 +70,7 @@ class OptimusCheckbox extends StatefulWidget {
   final ValueChanged<bool> onChanged;
 
   @override
-  _OptimusCheckboxState createState() => _OptimusCheckboxState();
+  State<OptimusCheckbox> createState() => _OptimusCheckboxState();
 }
 
 class _OptimusCheckboxState extends State<OptimusCheckbox> with ThemeGetter {

--- a/optimus/lib/src/common/dropdown.dart
+++ b/optimus/lib/src/common/dropdown.dart
@@ -21,7 +21,7 @@ class OptimusDropdown<T> extends StatefulWidget {
   final double? width;
 
   @override
-  _OptimusDropdownState<T> createState() => _OptimusDropdownState<T>();
+  State<OptimusDropdown<T>> createState() => _OptimusDropdownState<T>();
 }
 
 class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
@@ -49,7 +49,7 @@ class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
   Widget build(BuildContext context) {
     if (widget.items.isEmpty) return Container();
 
-    WidgetsBinding.instance?.addPostFrameCallback(_updateRect);
+    WidgetsBinding.instance.addPostFrameCallback(_updateRect);
 
     final isOnTop = _topSpace > _bottomSpace;
     final maxHeight = max(_topSpace, _bottomSpace);

--- a/optimus/lib/src/common/field_wrapper.dart
+++ b/optimus/lib/src/common/field_wrapper.dart
@@ -44,7 +44,7 @@ class FieldWrapper extends StatefulWidget {
   }
 
   @override
-  _FieldWrapper createState() => _FieldWrapper();
+  State<FieldWrapper> createState() => _FieldWrapper();
 }
 
 class _FieldWrapper extends State<FieldWrapper> with ThemeGetter {

--- a/optimus/lib/src/date_time_field.dart
+++ b/optimus/lib/src/date_time_field.dart
@@ -29,7 +29,7 @@ class OptimusDateTimeField extends StatefulWidget {
   final String? placeholder;
 
   @override
-  _OptimusDateTimeFieldState createState() => _OptimusDateTimeFieldState();
+  State<OptimusDateTimeField> createState() => _OptimusDateTimeFieldState();
 }
 
 class _OptimusDateTimeFieldState extends State<OptimusDateTimeField> {

--- a/optimus/lib/src/dialogs/non_modal_wrapper.dart
+++ b/optimus/lib/src/dialogs/non_modal_wrapper.dart
@@ -23,7 +23,7 @@ class NonModalWrapper extends StatefulWidget {
       ?.controller;
 
   @override
-  _NonModalWrapperState createState() => _NonModalWrapperState();
+  State<NonModalWrapper> createState() => _NonModalWrapperState();
 }
 
 class _NonModalWrapperState extends State<NonModalWrapper>

--- a/optimus/lib/src/expansion/expansion_tile.dart
+++ b/optimus/lib/src/expansion/expansion_tile.dart
@@ -73,7 +73,7 @@ class OptimusExpansionTile extends StatefulWidget {
   final List<Widget> slidableActions;
 
   @override
-  _OptimusExpansionTileState createState() => _OptimusExpansionTileState();
+  State<OptimusExpansionTile> createState() => _OptimusExpansionTileState();
 }
 
 class _OptimusExpansionTileState extends State<OptimusExpansionTile>

--- a/optimus/lib/src/form/input_form_field.dart
+++ b/optimus/lib/src/form/input_form_field.dart
@@ -84,7 +84,7 @@ class OptimusInputFormField extends FormField<String> {
   final TextEditingController? controller;
 
   @override
-  _InputFormFieldState createState() => _InputFormFieldState();
+  FormFieldState<String> createState() => _InputFormFieldState();
 }
 
 class _InputFormFieldState extends FormFieldState<String> {

--- a/optimus/lib/src/input_field.dart
+++ b/optimus/lib/src/input_field.dart
@@ -112,7 +112,7 @@ class OptimusInputField extends StatefulWidget {
   }
 
   @override
-  _OptimusInputFieldState createState() => _OptimusInputFieldState();
+  State<OptimusInputField> createState() => _OptimusInputFieldState();
 }
 
 class _OptimusInputFieldState extends State<OptimusInputField>

--- a/optimus/lib/src/lists/list_tile.dart
+++ b/optimus/lib/src/lists/list_tile.dart
@@ -27,7 +27,7 @@ class OptimusListTile extends StatefulWidget {
   final FontVariant fontVariant;
 
   @override
-  _OptimusListTileState createState() => _OptimusListTileState();
+  State<OptimusListTile> createState() => _OptimusListTileState();
 }
 
 class _OptimusListTileState extends State<OptimusListTile> with ThemeGetter {

--- a/optimus/lib/src/loader/spinning_container.dart
+++ b/optimus/lib/src/loader/spinning_container.dart
@@ -9,7 +9,7 @@ class SpinningContainer extends StatefulWidget {
   final Widget child;
 
   @override
-  _SpinningContainerState createState() => _SpinningContainerState();
+  State<SpinningContainer> createState() => _SpinningContainerState();
 }
 
 class _SpinningContainerState extends State<SpinningContainer>

--- a/optimus/lib/src/overlay_controller.dart
+++ b/optimus/lib/src/overlay_controller.dart
@@ -28,7 +28,7 @@ class OverlayController<T> extends StatefulWidget {
   final VoidCallback? onHidden;
 
   @override
-  _OverlayControllerState<T> createState() => _OverlayControllerState<T>();
+  State<OverlayController<T>> createState() => _OverlayControllerState<T>();
 }
 
 class _OverlayControllerState<T> extends State<OverlayController<T>> {
@@ -47,7 +47,7 @@ class _OverlayControllerState<T> extends State<OverlayController<T>> {
   @override
   void didUpdateWidget(OverlayController<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _overlayEntry?.markNeedsBuild();
     });

--- a/optimus/lib/src/radio/radio.dart
+++ b/optimus/lib/src/radio/radio.dart
@@ -77,7 +77,7 @@ class OptimusRadio<T> extends StatefulWidget {
   final bool isEnabled;
 
   @override
-  _OptimusRadioState<T> createState() => _OptimusRadioState<T>();
+  State<OptimusRadio<T>> createState() => _OptimusRadioState<T>();
 }
 
 class _OptimusRadioState<T> extends State<OptimusRadio<T>> with ThemeGetter {

--- a/optimus/lib/src/search/base_dropdown_tile.dart
+++ b/optimus/lib/src/search/base_dropdown_tile.dart
@@ -14,7 +14,7 @@ class BaseDropdownTile extends StatefulWidget {
   final Widget? subtitle;
 
   @override
-  _BaseDropdownTileState createState() => _BaseDropdownTileState();
+  State<BaseDropdownTile> createState() => _BaseDropdownTileState();
 }
 
 class _BaseDropdownTileState extends State<BaseDropdownTile> {

--- a/optimus/lib/src/search/search_field.dart
+++ b/optimus/lib/src/search/search_field.dart
@@ -58,7 +58,7 @@ class OptimusSearch<T> extends StatefulWidget {
   final bool readOnly;
 
   @override
-  _OptimusSearchState<T> createState() => _OptimusSearchState<T>();
+  State<OptimusSearch<T>> createState() => _OptimusSearchState<T>();
 }
 
 class _OptimusSearchState<T> extends State<OptimusSearch<T>> {
@@ -76,12 +76,12 @@ class _OptimusSearchState<T> extends State<OptimusSearch<T>> {
     super.initState();
     _effectiveFocusNode.addListener(_onFocusChanged);
 
-    WidgetsBinding.instance?.addPostFrameCallback(_afterLayoutBuild);
+    WidgetsBinding.instance.addPostFrameCallback(_afterLayoutBuild);
   }
 
   void _onFocusChanged() {
     if (_effectiveFocusNode.hasFocus) {
-      WidgetsBinding.instance?.addPostFrameCallback(_afterLayoutWithShow);
+      WidgetsBinding.instance.addPostFrameCallback(_afterLayoutWithShow);
     } else {
       setState(_removeOverlay);
     }
@@ -104,7 +104,7 @@ class _OptimusSearchState<T> extends State<OptimusSearch<T>> {
         ..addListener(_onFocusChanged);
     }
 
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _overlayEntry?.markNeedsBuild();
     });

--- a/optimus/lib/src/segmented_control/wrapper.dart
+++ b/optimus/lib/src/segmented_control/wrapper.dart
@@ -20,7 +20,7 @@ class BorderWrapper extends StatefulWidget {
   final int listSize;
 
   @override
-  _BorderWrapperState createState() => _BorderWrapperState();
+  State<BorderWrapper> createState() => _BorderWrapperState();
 }
 
 class _BorderWrapperState extends State<BorderWrapper> with ThemeGetter {

--- a/optimus/lib/src/select.dart
+++ b/optimus/lib/src/select.dart
@@ -40,7 +40,7 @@ class OptimusSelect<T> extends StatefulWidget {
   final ValueSetter<T> onItemSelected;
 
   @override
-  _OptimusSelectState<T> createState() => _OptimusSelectState<T>();
+  State<OptimusSelect<T>> createState() => _OptimusSelectState<T>();
 }
 
 class _OptimusSelectState<T> extends State<OptimusSelect<T>> with ThemeGetter {

--- a/optimus/lib/src/select_input.dart
+++ b/optimus/lib/src/select_input.dart
@@ -57,7 +57,7 @@ class OptimusSelectInput<T> extends StatefulWidget {
   final bool? readOnly;
 
   @override
-  _OptimusSelectInput<T> createState() => _OptimusSelectInput<T>();
+  State<OptimusSelectInput<T>> createState() => _OptimusSelectInput<T>();
 }
 
 class _OptimusSelectInput<T> extends State<OptimusSelectInput<T>>

--- a/optimus/lib/src/slidable/slidable.dart
+++ b/optimus/lib/src/slidable/slidable.dart
@@ -19,7 +19,7 @@ class OptimusSlidable extends StatefulWidget {
   final double actionsWidth;
 
   @override
-  _OptimusSlidableState createState() => _OptimusSlidableState();
+  State<OptimusSlidable> createState() => _OptimusSlidableState();
 }
 
 class _OptimusSlidableState extends State<OptimusSlidable> {
@@ -46,7 +46,7 @@ class _OptimusSlidableState extends State<OptimusSlidable> {
 
   @override
   Widget build(BuildContext context) {
-    WidgetsBinding.instance?.addPostFrameCallback((_) => _afterLayout());
+    WidgetsBinding.instance.addPostFrameCallback((_) => _afterLayout());
 
     return Slidable(
       endActionPane: ActionPane(

--- a/optimus/lib/src/standalone_link.dart
+++ b/optimus/lib/src/standalone_link.dart
@@ -48,7 +48,7 @@ class OptimusStandaloneLink extends StatefulWidget {
   final TextOverflow? overflow;
 
   @override
-  _OptimusStandaloneLinkState createState() => _OptimusStandaloneLinkState();
+  State<OptimusStandaloneLink> createState() => _OptimusStandaloneLinkState();
 }
 
 class _OptimusStandaloneLinkState extends State<OptimusStandaloneLink>

--- a/optimus/lib/src/step_bar.dart
+++ b/optimus/lib/src/step_bar.dart
@@ -43,7 +43,7 @@ class OptimusStepBar extends StatefulWidget {
   final int? maxItem;
 
   @override
-  _OptimusStepBarState createState() => _OptimusStepBarState();
+  State<OptimusStepBar> createState() => _OptimusStepBarState();
 }
 
 class _OptimusStepBarState extends State<OptimusStepBar> with ThemeGetter {

--- a/optimus/lib/src/typography/typography.dart
+++ b/optimus/lib/src/typography/typography.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 
 typedef ResolveStyle = TextStyle Function(Breakpoint);
+
 enum OptimusTypographyColor { primary, secondary }
 
 class OptimusTypography extends StatelessWidget {

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ">=1.0.0 <3.0.0"
-  mews_pedantic: ^0.4.2
+  mews_pedantic: ^0.5.0
 flutter:
   fonts:
     - family: OpenSans

--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.2
-  mews_pedantic: ^0.4.2
+  mews_pedantic: ^0.5.0
   mockito: ^5.0.16
   test: ^1.18.0

--- a/storybook/ios/Runner.xcodeproj/project.pbxproj
+++ b/storybook/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -135,7 +135,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/storybook/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/storybook/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/storybook/lib/stories/radio.dart
+++ b/storybook/lib/stories/radio.dart
@@ -33,7 +33,7 @@ class RadioExample extends StatefulWidget {
   final bool isEnabled;
 
   @override
-  _RadioExampleState createState() => _RadioExampleState();
+  State<RadioExample> createState() => _RadioExampleState();
 }
 
 class _RadioExampleState extends State<RadioExample> {

--- a/storybook/lib/stories/search_field.dart
+++ b/storybook/lib/stories/search_field.dart
@@ -18,7 +18,7 @@ class SearchStory extends StatefulWidget {
   final KnobsBuilder knobs;
 
   @override
-  _SearchStoryState createState() => _SearchStoryState();
+  State<SearchStory> createState() => _SearchStoryState();
 }
 
 class _SearchStoryState extends State<SearchStory> {

--- a/storybook/lib/stories/select_input.dart
+++ b/storybook/lib/stories/select_input.dart
@@ -17,7 +17,7 @@ class SelectInputStory extends StatefulWidget {
   final KnobsBuilder knobs;
 
   @override
-  _SelectInputStoryState createState() => _SelectInputStoryState();
+  State<SelectInputStory> createState() => _SelectInputStoryState();
 }
 
 class _SelectInputStoryState extends State<SelectInputStory> {

--- a/storybook/pubspec.yaml
+++ b/storybook/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.4.2
+  mews_pedantic: ^0.5.0
 flutter:
   uses-material-design: true


### PR DESCRIPTION
#### Summary

- Upgraded `mews_pedantic` to Dart 2.17 and `dart_code_metrics` 4.15.0.
- Removed dependency on `flutter_lints` and included all the necessary rules explicitly.
- Fixed new lint issues in other packages.

⚠️ `dart_code_metric` doesn't work as an analyzer plugin so far due to https://github.com/dart-lang/sdk/issues/48682 – but it should still run on a CI machine.

#### Testing steps

No, lint issues fixed.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
