### PR TITLE
fix: Bump dart_code_metrics [do not squash]

### DIFF
--- a/kiosk_mode/example/pubspec.yaml
+++ b/kiosk_mode/example/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.5.0
+  mews_pedantic: ^0.5.0+1
 flutter:
   uses-material-design: true

--- a/kiosk_mode/pubspec.yaml
+++ b/kiosk_mode/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.5.0
+  mews_pedantic: ^0.5.0+1
 flutter:
   plugin:
     platforms:

--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+1
+
+ - **FIX**: Bump dart_code_metrics.
+
 ## 0.5.0
 
 > Note: This release has breaking changes.

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mews_pedantic
 description: Dart and Flutter static analysis and lint rules incorporated in Mews.
-version: 0.5.0
+version: 0.5.0+1
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  dart_code_metrics: 4.15.0
+  dart_code_metrics: 4.15.1
   meta: ^1.7.0

--- a/optimus/example/pubspec.yaml
+++ b/optimus/example/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.5.0
+  mews_pedantic: ^0.5.0+1

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ">=1.0.0 <3.0.0"
-  mews_pedantic: ^0.5.0
+  mews_pedantic: ^0.5.0+1
 flutter:
   fonts:
     - family: OpenSans

--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.2
-  mews_pedantic: ^0.5.0
+  mews_pedantic: ^0.5.0+1
   mockito: ^5.0.16
   test: ^1.18.0

--- a/storybook/pubspec.yaml
+++ b/storybook/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.5.0
+  mews_pedantic: ^0.5.0+1
 flutter:
   uses-material-design: true


### PR DESCRIPTION
#### Summary

Bumped `dart_code_metrics` to 4.5.1 (there's a fix for analyzer constraint).

#### Testing steps

No.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
