### PR TITLE
feat(kiosk_mode): Track Kiosk mode changes on Android

### DIFF
--- a/kiosk_mode/example/android/app/build.gradle
+++ b/kiosk_mode/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/kiosk_mode/example/android/build.gradle
+++ b/kiosk_mode/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.32'
     repositories {
         google()
         jcenter()

--- a/kiosk_mode/example/lib/main.dart
+++ b/kiosk_mode/example/lib/main.dart
@@ -55,13 +55,12 @@ class _HomeState extends State<_Home> {
             ),
             child: const Text('Check mode'),
           ),
-          if (Platform.isIOS)
-            StreamBuilder<KioskMode>(
-              stream: _currentMode,
-              builder: (context, snapshot) => Text(
-                'Current mode: ${snapshot.data}',
-              ),
+          StreamBuilder<KioskMode>(
+            stream: _currentMode,
+            builder: (context, snapshot) => Text(
+              'Current mode: ${snapshot.data}',
             ),
+          ),
         ],
       );
 }

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -1,9 +1,15 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 const _channel = MethodChannel('com.mews.kiosk_mode/kiosk_mode');
+
+/// Channel used to send "kiosk mode" updates from platform.
+///
+/// Implementing it on Android platform is useless, as this plugin already
+/// does it. See [watchKioskMode] for explanation.
 const _eventChannel = EventChannel('com.mews.kiosk_mode/kiosk_mode_stream');
 
 /// Corresponds to lock task / screen pinning mode on Android, and
@@ -45,13 +51,23 @@ Future<KioskMode> getKioskMode() => _channel
 
 /// Returns the stream with [KioskMode].
 ///
-/// It works on iOS only, as Android doesn't allow subscribing to lock task
-/// mode changes.
-Stream<KioskMode> watchKioskMode() =>
-    Stream.fromFuture(getKioskMode()).merge(_kioskModeStream);
+/// Since as Android doesn't allow subscribing to lock task mode changes,
+/// a mode is queried every time with a period of [androidQueryPeriod].
+Stream<KioskMode> watchKioskMode({
+  Duration androidQueryPeriod = const Duration(seconds: 5),
+}) =>
+    Stream.fromFuture(getKioskMode())
+        .merge(_getKioskModeStream(androidQueryPeriod));
 
-final Stream<KioskMode> _kioskModeStream =
-    _eventChannel.receiveBroadcastStream().map(
-          (dynamic value) =>
-              value == true ? KioskMode.enabled : KioskMode.disabled,
-        );
+Stream<KioskMode> _getKioskModeStream(Duration androidQueryPeriod) {
+  switch (defaultTargetPlatform) {
+    case TargetPlatform.android:
+      return Stream<void>.periodic(androidQueryPeriod)
+          .asyncMap((_) => getKioskMode());
+    default:
+      return _eventChannel.receiveBroadcastStream().map(
+            (dynamic value) =>
+                value == true ? KioskMode.enabled : KioskMode.disabled,
+          );
+  }
+}


### PR DESCRIPTION
#### Summary

`watchKioskMode` now works on Android too!

#### Testing steps

Test that you get a stream of values for kiosk mode on Android. You can run an example app to check this.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
