### PR TITLE
feat(kiosk_mode): Add `isManagedKiosk` method

### DIFF
--- a/kiosk_mode/android/build.gradle
+++ b/kiosk_mode/android/build.gradle
@@ -31,7 +31,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
     }
 }
 

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -1,11 +1,10 @@
 package com.mews.kiosk_mode
 
-import androidx.annotation.NonNull
 import android.app.Activity
 import android.app.ActivityManager
 import android.content.Context
 import android.view.ViewGroup
-
+import androidx.annotation.NonNull
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -13,7 +12,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var channel: MethodChannel
@@ -48,7 +46,22 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 return
             }
 
-            result.success(service.isInLockTaskMode)
+            val isInKioskMode = when (service.lockTaskModeState) {
+                ActivityManager.LOCK_TASK_MODE_NONE -> false
+                ActivityManager.LOCK_TASK_MODE_PINNED,
+                ActivityManager.LOCK_TASK_MODE_LOCKED -> true
+                else -> false
+            }
+
+            result.success(isInKioskMode)
+        } else if (call.method == "isManagedKiosk") {
+            val service = activity?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+            if (service == null) {
+                result.success(null)
+                return
+            }
+
+            result.success(service.lockTaskModeState == ActivityManager.LOCK_TASK_MODE_LOCKED)
         } else {
             result.notImplemented()
         }

--- a/kiosk_mode/example/android/app/build.gradle
+++ b/kiosk_mode/example/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.mews.kiosk_mode_example"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/kiosk_mode/ios/Classes/SwiftKioskModePlugin.swift
+++ b/kiosk_mode/ios/Classes/SwiftKioskModePlugin.swift
@@ -14,6 +14,8 @@ public class SwiftKioskModePlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         if (call.method == "isInKioskMode") {
             result(UIAccessibility.isGuidedAccessEnabled)
+        } else if (call.method == "isManagedKiosk") {
+            result(false)
         } else {
             result(FlutterMethodNotImplemented)
         }

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -43,6 +43,19 @@ Future<KioskMode> getKioskMode() => _channel
     .invokeMethod<bool>('isInKioskMode')
     .then((value) => value == true ? KioskMode.enabled : KioskMode.disabled);
 
+/// Returns `true`, if app is in a proper managed kiosk mode.
+///
+/// On Android, it checks for `LOCK_TASK_MODE_LOCKED` and may return `false`,
+/// while [getKioskMode] returns [KioskMode.enabled]. In that case it would mean
+/// that the app is only pinned by user and doesn't represent a proper kiosk,
+/// i.e. it isn't managed by Device Policy Controller on Android.
+///
+/// On iOS, it always returns `false`, as this package doesn't support
+/// detection of Apple Business Manager yet.
+Future<bool> isManagedKiosk() => _channel
+    .invokeMethod<bool>('isManagedKiosk')
+    .then((value) => value == true);
+
 /// Returns the stream with [KioskMode].
 ///
 /// It works on iOS only, as Android doesn't allow subscribing to lock task

--- a/kiosk_mode/test/kiosk_mode_test.dart
+++ b/kiosk_mode/test/kiosk_mode_test.dart
@@ -33,7 +33,7 @@ void main() {
   });
 
   test('isManagedKiosk', () async {
-    await getKioskMode();
+    await isManagedKiosk();
     expect(calls, ['isManagedKiosk']);
   });
 }

--- a/kiosk_mode/test/kiosk_mode_test.dart
+++ b/kiosk_mode/test/kiosk_mode_test.dart
@@ -31,4 +31,9 @@ void main() {
     await getKioskMode();
     expect(calls, ['isInKioskMode']);
   });
+
+  test('isManagedKiosk', () async {
+    await getKioskMode();
+    expect(calls, ['isManagedKiosk']);
+  });
 }


### PR DESCRIPTION
#### Summary

BREAKING CHANGE: Bumps `minSdkVersion` from `21` to `23`.

Adds a functionality to distinguish between "kiosk modes": `isManagedKiosk` method:

* On Android it allows to check whether the app is just pinned, or properly locked into true kiosk mode, i.e. **managed** by DPC.

* On iOS, it currently always returns `false`, as it doesn't support detection of Apple Business **Manage**r yet.

#### Testing steps

Test that it behaves as in the description.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
