### PR TITLE
feat(kiosk_mode): [RND-106334] move watchKioskMode implementation on platform side (android)

### DIFF
--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -77,14 +77,12 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         val service = activity?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
             ?: return null
 
-        val isInKioskMode = when (service.lockTaskModeState) {
+        return when (service.lockTaskModeState) {
             ActivityManager.LOCK_TASK_MODE_NONE -> false
             ActivityManager.LOCK_TASK_MODE_PINNED,
             ActivityManager.LOCK_TASK_MODE_LOCKED -> true
             else -> false
         }
-
-        return isInKioskMode
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -25,7 +25,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         channel.setMethodCallHandler(this)
 
         eventChannel = EventChannel(flutterPluginBinding.binaryMessenger, eventChannelName)
-        eventChannel.setStreamHandler(KioskModeStreamHandler { isInKioskMode() ?: false})
+        eventChannel.setStreamHandler(KioskModeStreamHandler(this::isInKioskMode))
     }
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -78,7 +78,6 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             ?: return null
 
         return when (service.lockTaskModeState) {
-            ActivityManager.LOCK_TASK_MODE_NONE -> false
             ActivityManager.LOCK_TASK_MODE_PINNED,
             ActivityManager.LOCK_TASK_MODE_LOCKED -> true
             else -> false

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -21,7 +21,6 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var channel: MethodChannel
     private var activity: Activity? = null
 
-
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, methodChannelName)
         channel.setMethodCallHandler(this)
@@ -88,7 +87,6 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
         return isInKioskMode
     }
-
 
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -15,7 +15,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
 private const val methodChannelName = "com.mews.kiosk_mode/kiosk_mode"
-private const val kioskModeEventChannel = "com.mews.kiosk_mode/kiosk_mode_stream"
+private const val kioskModeEventChannelName = "com.mews.kiosk_mode/kiosk_mode_stream"
 
 class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var channel: MethodChannel
@@ -25,7 +25,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, methodChannelName)
         channel.setMethodCallHandler(this)
 
-        EventChannel(flutterPluginBinding.binaryMessenger, kioskModeEventChannel)
+        EventChannel(flutterPluginBinding.binaryMessenger, kioskModeEventChannelName)
             .setStreamHandler(KioskModeStreamHandler { isInKioskMode() })
     }
 

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -3,7 +3,7 @@ package com.mews.kiosk_mode
 import android.os.Handler
 import android.os.Looper
 import io.flutter.plugin.common.EventChannel
-import java.util.*
+import java.util.Timer
 import kotlin.concurrent.fixedRateTimer
 
 

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -14,10 +14,10 @@ class KioskModeStreamHandler(val isKioskMode: KioskModeHandler) : EventChannel.S
     private var previousIsKioskModeState: Boolean? = null
     private val uiThreadHandler: Handler = Handler(Looper.getMainLooper())
 
-
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-        eventSink = events
         val period: Int = (arguments as Map<*, *>)["androidQueryPeriod"] as Int
+        
+        eventSink = events
         timer = fixedRateTimer(period = period.toLong(), daemon = true) {
             val newIsKioskModeState = isKioskMode()
             if (newIsKioskModeState != previousIsKioskModeState) {

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -3,7 +3,7 @@ package com.mews.kiosk_mode
 import android.os.Handler
 import android.os.Looper
 import io.flutter.plugin.common.EventChannel
-import java.util.Timer
+import java.util.*
 import kotlin.concurrent.fixedRateTimer
 
 
@@ -15,14 +15,13 @@ class KioskModeStreamHandler(val getKioskModeState: () -> Boolean) : EventChanne
 
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
         val period: Int = (arguments as Map<*, *>)["androidQueryPeriod"] as Int
-
         eventSink = events
         timer = fixedRateTimer(period = period.toLong(), daemon = true) {
             val currentState = getKioskModeState()
             if (currentState != previousState) {
                 previousState = currentState
-                mainHandler.post() {
-                    eventSink?.success(currentState)
+                eventSink?.let {
+                    mainHandler.post() {it.success(currentState)}
                 }
             }
         }

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -7,7 +7,7 @@ import java.util.Timer
 import kotlin.concurrent.fixedRateTimer
 
 
-class KioskModeStreamHandler(val isKioskMode: () -> Boolean) : EventChannel.StreamHandler {
+class KioskModeStreamHandler(val getKioskModeState: () -> Boolean) : EventChannel.StreamHandler {
     private var eventSink: EventChannel.EventSink? = null
     private var timer: Timer? = null
     private var previousState: Boolean = false
@@ -18,7 +18,7 @@ class KioskModeStreamHandler(val isKioskMode: () -> Boolean) : EventChannel.Stre
 
         eventSink = events
         timer = fixedRateTimer(period = period.toLong(), daemon = true) {
-            val currentState = isKioskMode()
+            val currentState = getKioskModeState()
             if (currentState != previousState) {
                 previousState = currentState
                 uiThreadHandler.post() {

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -7,10 +7,10 @@ import java.util.*
 import kotlin.concurrent.fixedRateTimer
 
 
-class KioskModeStreamHandler(val getKioskModeState: () -> Boolean) : EventChannel.StreamHandler {
+class KioskModeStreamHandler(val getKioskModeState: () -> Boolean?) : EventChannel.StreamHandler {
     private var eventSink: EventChannel.EventSink? = null
     private var timer: Timer? = null
-    private var previousState: Boolean = getKioskModeState()
+    private var previousState: Boolean? = getKioskModeState()
     private val mainHandler: Handler = Handler(Looper.getMainLooper())
 
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
@@ -21,7 +21,7 @@ class KioskModeStreamHandler(val getKioskModeState: () -> Boolean) : EventChanne
             if (currentState != previousState) {
                 previousState = currentState
                 eventSink?.let {
-                    mainHandler.post() {it.success(currentState)}
+                    mainHandler.post { it.success(currentState) }
                 }
             }
         }

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -1,0 +1,37 @@
+package com.mews.kiosk_mode
+
+import android.os.Handler
+import android.os.Looper
+import io.flutter.plugin.common.EventChannel
+import java.util.*
+import kotlin.concurrent.fixedRateTimer
+
+typealias KioskModeHandler = () -> Boolean?
+
+class KioskModeStreamHandler(val isKioskMode: KioskModeHandler) : EventChannel.StreamHandler {
+    private var eventSink: EventChannel.EventSink? = null
+    private var timer: Timer? = null
+    private var previousIsKioskModeState: Boolean? = null
+    private val uiThreadHandler: Handler = Handler(Looper.getMainLooper())
+
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        eventSink = events
+        val period: Int = (arguments as Map<*, *>)["androidQueryPeriod"] as Int
+        timer = fixedRateTimer(period = period.toLong(), daemon = true) {
+            val newIsKioskModeState = isKioskMode()
+            if (newIsKioskModeState != previousIsKioskModeState) {
+                previousIsKioskModeState = newIsKioskModeState
+                uiThreadHandler.post() {
+                    eventSink?.success(newIsKioskModeState)
+                }
+            }
+        }
+    }
+
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+        timer?.cancel()
+        timer = null
+    }
+}

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -10,8 +10,8 @@ import kotlin.concurrent.fixedRateTimer
 class KioskModeStreamHandler(val getKioskModeState: () -> Boolean) : EventChannel.StreamHandler {
     private var eventSink: EventChannel.EventSink? = null
     private var timer: Timer? = null
-    private var previousState: Boolean = false
-    private val uiThreadHandler: Handler = Handler(Looper.getMainLooper())
+    private var previousState: Boolean = getKioskModeState()
+    private val mainHandler: Handler = Handler(Looper.getMainLooper())
 
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
         val period: Int = (arguments as Map<*, *>)["androidQueryPeriod"] as Int
@@ -21,7 +21,7 @@ class KioskModeStreamHandler(val getKioskModeState: () -> Boolean) : EventChanne
             val currentState = getKioskModeState()
             if (currentState != previousState) {
                 previousState = currentState
-                uiThreadHandler.post() {
+                mainHandler.post() {
                     eventSink?.success(currentState)
                 }
             }

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -16,7 +16,7 @@ class KioskModeStreamHandler(val isKioskMode: KioskModeHandler) : EventChannel.S
 
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
         val period: Int = (arguments as Map<*, *>)["androidQueryPeriod"] as Int
-        
+
         eventSink = events
         timer = fixedRateTimer(period = period.toLong(), daemon = true) {
             val newIsKioskModeState = isKioskMode()

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -26,7 +26,9 @@ enum KioskMode {
 ///
 /// It's only supported on Android currently, where it calls `startLockTask`.
 /// It will throw `FlutterMethodNotImplemented` on iOS.
-Future<bool> startKioskMode() => _channel.invokeMethod<bool>('startKioskMode').then((value) => value ?? false);
+Future<bool> startKioskMode() => _channel
+    .invokeMethod<bool>('startKioskMode')
+    .then((value) => value ?? false);
 
 /// Stop the current task from being locked.
 ///
@@ -52,7 +54,9 @@ Future<KioskMode> getKioskMode() => _channel
 ///
 /// On iOS, it always returns `false`, as this package doesn't support
 /// detection of Apple Business Manager yet.
-Future<bool> isManagedKiosk() => _channel.invokeMethod<bool>('isManagedKiosk').then((value) => value == true);
+Future<bool> isManagedKiosk() => _channel
+    .invokeMethod<bool>('isManagedKiosk')
+    .then((value) => value == true);
 
 /// Returns the stream with [KioskMode].
 ///
@@ -63,9 +67,12 @@ Future<bool> isManagedKiosk() => _channel.invokeMethod<bool>('isManagedKiosk').t
 Stream<KioskMode> watchKioskMode({
   Duration androidQueryPeriod = const Duration(seconds: 5),
 }) =>
-    Stream.fromFuture(getKioskMode()).merge(_getKioskModeStream(androidQueryPeriod));
+    Stream.fromFuture(getKioskMode())
+        .merge(_getKioskModeStream(androidQueryPeriod));
 
 Stream<KioskMode> _getKioskModeStream(Duration androidQueryPeriod) =>
-    _eventChannel.receiveBroadcastStream({'androidQueryPeriod': androidQueryPeriod.inMilliseconds}).map(
+    _eventChannel.receiveBroadcastStream(
+      {'androidQueryPeriod': androidQueryPeriod.inMilliseconds},
+    ).map(
       (dynamic value) => value == true ? KioskMode.enabled : KioskMode.disabled,
     );

--- a/kiosk_mode/pubspec.yaml
+++ b/kiosk_mode/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kiosk_mode
 description: Plugin for working with Lock Task / Guided Access modes.
-version: 0.2.1
+version: 0.2.0
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:

--- a/kiosk_mode/pubspec.yaml
+++ b/kiosk_mode/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kiosk_mode
 description: Plugin for working with Lock Task / Guided Access modes.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:


### PR DESCRIPTION
#### Summary

RND-106334

Based on [this discussion ](https://github.com/MewsSystems/mews-flutter/pull/205#discussion_r878016846), this PR moves the implementation of watchKioskMode periodic checks for android to the platform side.

The advantages are:
- no inconsistencies between android and iOS plugin, both use the EventChannel
- the stream will not emit the same value again if the mode hasn't changed
- Platform channel won't be used until the value actually changes

For better visibility, the android implementation has been extracted in functions. 

#### Testing steps

1. Listen to `watchKioskMode` stream on Android
2. Confirm that an event is not being sent every `androidQueryPeriod` like before, and only when kiosk mode actually changes
3. Confirm that `androidQueryPeriod` changes the checking period on the platform level

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
