### PR TITLE
feat(optimus): [RND-103050] Add Logo component to mobile implementation

### DIFF
--- a/optimus/lib/optimus.dart
+++ b/optimus/lib/optimus.dart
@@ -43,6 +43,7 @@ export 'src/icon_list.dart';
 export 'src/input_field.dart';
 export 'src/lists/list_tile.dart';
 export 'src/loader/loader.dart';
+export 'src/logo.dart';
 export 'src/notification/notification.dart';
 export 'src/number_picker/number_picker.dart';
 export 'src/progress_spinner.dart';

--- a/optimus/lib/src/logo.dart
+++ b/optimus/lib/src/logo.dart
@@ -7,6 +7,8 @@ enum OptimusMewsLogoSizeVariant { large, medium, small }
 
 enum OptimusMewsLogoColorVariant { black, white }
 
+enum OptimusMewsLogoAlignVariant { topLeft, topCenter, center }
+
 class OptimusMewsLogo extends StatelessWidget {
   const OptimusMewsLogo({
     Key? key,
@@ -14,14 +16,18 @@ class OptimusMewsLogo extends StatelessWidget {
     OptimusMewsLogoSizeVariant sizeVariant = OptimusMewsLogoSizeVariant.medium,
     OptimusMewsLogoColorVariant colorVariant =
         OptimusMewsLogoColorVariant.black,
+    OptimusMewsLogoAlignVariant alignVariant =
+        OptimusMewsLogoAlignVariant.topCenter,
   })  : _logoVariant = logoVariant,
         _sizeVariant = sizeVariant,
         _colorVariant = colorVariant,
+        _alignVariant = alignVariant,
         super(key: key);
 
   final OptimusMewsLogoVariant _logoVariant;
   final OptimusMewsLogoSizeVariant _sizeVariant;
   final OptimusMewsLogoColorVariant _colorVariant;
+  final OptimusMewsLogoAlignVariant _alignVariant;
 
   Widget get _icon {
     switch (_logoVariant) {
@@ -60,9 +66,20 @@ class OptimusMewsLogo extends StatelessWidget {
     }
   }
 
+  EdgeInsets get _margin {
+    switch (_alignVariant) {
+      case OptimusMewsLogoAlignVariant.topLeft:
+        return EdgeInsets.only(bottom: _size, right: _size);
+      case OptimusMewsLogoAlignVariant.topCenter:
+        return EdgeInsets.fromLTRB(_size, 0, _size, _size);
+      case OptimusMewsLogoAlignVariant.center:
+        return EdgeInsets.all(_size);
+    }
+  }
+
   @override
   Widget build(BuildContext context) =>
-      Container(margin: EdgeInsets.all(_size), child: _icon);
+      Container(margin: _margin, child: _icon);
 }
 
 /// Copy of Flutter Icon, but it does not limit icon shape to square.

--- a/optimus/lib/src/logo.dart
+++ b/optimus/lib/src/logo.dart
@@ -1,14 +1,38 @@
 import 'package:flutter/material.dart';
 import 'package:optimus/optimus.dart';
 
+/// Design system has two versions of the logo:
+/// [OptimusMewsLogoVariant.wordmark] - The normal length version of the logo.
+/// It is recommended to use it as the default whenever possible.
+/// [OptimusMewsLogoVariant.logomark] - The compact, shortened version of the
+/// logo, used whenever available space is limited.
 enum OptimusMewsLogoVariant { wordmark, logomark }
 
+/// The logo is defined in 3 sizes:
+/// [OptimusMewsLogoSizeVariant.large] - Should be used with caution. For
+/// example, in cases when highlighting the brand is required.
+/// [OptimusMewsLogoSizeVariant.medium] - This is the system default variant,
+/// recommended for use whenever possible.
+/// [OptimusMewsLogoSizeVariant.small] - This size variant should be used when
+/// there is limited space available.
 enum OptimusMewsLogoSizeVariant { large, medium, small }
 
+/// For strong and consistent brand experience, the logo is available only in
+/// two color options. Always check contrast ratios to ensure the logo is
+/// legible and recognizable.
+/// [OptimusMewsLogoColorVariant.black] - Use on white or light gray surfaces.
+/// [OptimusMewsLogoColorVariant.white] - Use on dark or colored surfaces.
 enum OptimusMewsLogoColorVariant { black, white }
 
+/// The preferred placement of the logo in any product is either in the top left
+/// or top center. You should avoid aligning or placing the logo on the right
+/// side of the screen unless absolutely necessary.
 enum OptimusMewsLogoAlignVariant { topLeft, topCenter, center }
 
+/// OptimusMewsLogo is Mews Logo component with clearly defined margins, size
+/// and color options.
+/// It is provided for better consistency across all products. No text or visual
+/// elements may be placed within 1x(x = logo heigh) of the space around it.
 class OptimusMewsLogo extends StatelessWidget {
   const OptimusMewsLogo({
     Key? key,
@@ -29,20 +53,18 @@ class OptimusMewsLogo extends StatelessWidget {
   final OptimusMewsLogoColorVariant _colorVariant;
   final OptimusMewsLogoAlignVariant _alignVariant;
 
-  Widget get _icon {
+  Widget get _iconWidget => _NonSquaredIcon(
+        _logoIcon,
+        size: _size,
+        color: _color,
+      );
+
+  IconData get _logoIcon {
     switch (_logoVariant) {
       case OptimusMewsLogoVariant.wordmark:
-        return _NonSquaredIcon(
-          OptimusIcons.mews_logo,
-          size: _size,
-          color: _color,
-        );
+        return OptimusIcons.mews_logo;
       case OptimusMewsLogoVariant.logomark:
-        return _NonSquaredIcon(
-          OptimusIcons.mews_logo_small,
-          size: _size,
-          color: _color,
-        );
+        return OptimusIcons.mews_logo_small;
     }
   }
 
@@ -78,8 +100,10 @@ class OptimusMewsLogo extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) =>
-      Container(margin: _margin, child: _icon);
+  Widget build(BuildContext context) => Container(
+        margin: _margin,
+        child: _iconWidget,
+      );
 }
 
 /// Copy of Flutter Icon, but it does not limit icon shape to square.

--- a/optimus/lib/src/logo.dart
+++ b/optimus/lib/src/logo.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:optimus/optimus.dart';
+
+enum OptimusMewsLogoVariant { wordmark, logomark }
+
+enum OptimusMewsLogoSizeVariant { large, medium, small }
+
+enum OptimusMewsLogoColorVariant { black, white }
+
+class OptimusMewsLogo extends StatelessWidget {
+  const OptimusMewsLogo({
+    Key? key,
+    OptimusMewsLogoVariant logoVariant = OptimusMewsLogoVariant.logomark,
+    OptimusMewsLogoSizeVariant sizeVariant = OptimusMewsLogoSizeVariant.medium,
+    OptimusMewsLogoColorVariant colorVariant =
+        OptimusMewsLogoColorVariant.black,
+  })  : _logoVariant = logoVariant,
+        _sizeVariant = sizeVariant,
+        _colorVariant = colorVariant,
+        super(key: key);
+
+  final OptimusMewsLogoVariant _logoVariant;
+  final OptimusMewsLogoSizeVariant _sizeVariant;
+  final OptimusMewsLogoColorVariant _colorVariant;
+
+  Widget get _icon {
+    switch (_logoVariant) {
+      case OptimusMewsLogoVariant.wordmark:
+        return _NonSquaredIcon(
+          OptimusIcons.mews_logo,
+          size: _size,
+          color: _color,
+        );
+      case OptimusMewsLogoVariant.logomark:
+        return _NonSquaredIcon(
+          OptimusIcons.mews_logo_small,
+          size: _size,
+          color: _color,
+        );
+    }
+  }
+
+  double get _size {
+    switch (_sizeVariant) {
+      case OptimusMewsLogoSizeVariant.large:
+        return 24;
+      case OptimusMewsLogoSizeVariant.medium:
+        return 16;
+      case OptimusMewsLogoSizeVariant.small:
+        return 8;
+    }
+  }
+
+  Color get _color {
+    switch (_colorVariant) {
+      case OptimusMewsLogoColorVariant.black:
+        return Colors.black;
+      case OptimusMewsLogoColorVariant.white:
+        return Colors.white;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      Container(margin: EdgeInsets.all(_size), child: _icon);
+}
+
+/// Copy of Flutter Icon, but it does not limit icon shape to square.
+class _NonSquaredIcon extends StatelessWidget {
+  const _NonSquaredIcon(
+    this.icon, {
+    Key? key,
+    required this.size,
+    required this.color,
+  }) : super(key: key);
+
+  final IconData icon;
+
+  final double size;
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) => RichText(
+        overflow: TextOverflow.visible,
+        text: TextSpan(
+          text: String.fromCharCode(icon.codePoint),
+          style: TextStyle(
+            inherit: false,
+            color: color,
+            fontSize: size,
+            fontFamily: icon.fontFamily,
+            package: icon.fontPackage,
+          ),
+        ),
+      );
+}

--- a/optimus/lib/src/logo.dart
+++ b/optimus/lib/src/logo.dart
@@ -47,22 +47,16 @@ enum OptimusMewsLogoAlignVariant { topLeft, topCenter, center }
 class OptimusMewsLogo extends StatelessWidget {
   const OptimusMewsLogo({
     Key? key,
-    OptimusMewsLogoVariant logoVariant = OptimusMewsLogoVariant.logomark,
-    OptimusMewsLogoSizeVariant sizeVariant = OptimusMewsLogoSizeVariant.medium,
-    OptimusMewsLogoColorVariant colorVariant =
-        OptimusMewsLogoColorVariant.black,
-    OptimusMewsLogoAlignVariant alignVariant =
-        OptimusMewsLogoAlignVariant.topCenter,
-  })  : _logoVariant = logoVariant,
-        _sizeVariant = sizeVariant,
-        _colorVariant = colorVariant,
-        _alignVariant = alignVariant,
-        super(key: key);
+    this.logoVariant = OptimusMewsLogoVariant.logomark,
+    this.sizeVariant = OptimusMewsLogoSizeVariant.medium,
+    this.colorVariant = OptimusMewsLogoColorVariant.black,
+    this.alignVariant = OptimusMewsLogoAlignVariant.topCenter,
+  }) : super(key: key);
 
-  final OptimusMewsLogoVariant _logoVariant;
-  final OptimusMewsLogoSizeVariant _sizeVariant;
-  final OptimusMewsLogoColorVariant _colorVariant;
-  final OptimusMewsLogoAlignVariant _alignVariant;
+  final OptimusMewsLogoVariant logoVariant;
+  final OptimusMewsLogoSizeVariant sizeVariant;
+  final OptimusMewsLogoColorVariant colorVariant;
+  final OptimusMewsLogoAlignVariant alignVariant;
 
   Widget get _iconWidget => _NonSquaredIcon(
         _logoIcon,
@@ -71,7 +65,7 @@ class OptimusMewsLogo extends StatelessWidget {
       );
 
   IconData get _logoIcon {
-    switch (_logoVariant) {
+    switch (logoVariant) {
       case OptimusMewsLogoVariant.wordmark:
         return OptimusIcons.mews_logo;
       case OptimusMewsLogoVariant.logomark:
@@ -80,7 +74,7 @@ class OptimusMewsLogo extends StatelessWidget {
   }
 
   double get _size {
-    switch (_sizeVariant) {
+    switch (sizeVariant) {
       case OptimusMewsLogoSizeVariant.large:
         return 24;
       case OptimusMewsLogoSizeVariant.medium:
@@ -91,7 +85,7 @@ class OptimusMewsLogo extends StatelessWidget {
   }
 
   Color get _color {
-    switch (_colorVariant) {
+    switch (colorVariant) {
       case OptimusMewsLogoColorVariant.black:
         return Colors.black;
       case OptimusMewsLogoColorVariant.white:
@@ -100,7 +94,7 @@ class OptimusMewsLogo extends StatelessWidget {
   }
 
   EdgeInsets get _margin {
-    switch (_alignVariant) {
+    switch (alignVariant) {
       case OptimusMewsLogoAlignVariant.topLeft:
         return EdgeInsets.only(bottom: _size, right: _size);
       case OptimusMewsLogoAlignVariant.topCenter:

--- a/optimus/lib/src/logo.dart
+++ b/optimus/lib/src/logo.dart
@@ -1,36 +1,47 @@
 import 'package:flutter/material.dart';
 import 'package:optimus/optimus.dart';
 
+/// Mews logo variant.
+///
 /// Design system has two versions of the logo:
-/// [OptimusMewsLogoVariant.wordmark] - The normal length version of the logo.
-/// It is recommended to use it as the default whenever possible.
-/// [OptimusMewsLogoVariant.logomark] - The compact, shortened version of the
-/// logo, used whenever available space is limited.
+///
+/// - [OptimusMewsLogoVariant.wordmark] - The normal length version of the logo.
+///   It is recommended to use it as the default whenever possible.
+/// - [OptimusMewsLogoVariant.logomark] - The compact, shortened version of the
+///   logo, used whenever available space is limited.
 enum OptimusMewsLogoVariant { wordmark, logomark }
 
+/// Mews logo size.
+///
 /// The logo is defined in 3 sizes:
-/// [OptimusMewsLogoSizeVariant.large] - Should be used with caution. For
-/// example, in cases when highlighting the brand is required.
-/// [OptimusMewsLogoSizeVariant.medium] - This is the system default variant,
-/// recommended for use whenever possible.
-/// [OptimusMewsLogoSizeVariant.small] - This size variant should be used when
-/// there is limited space available.
+///
+/// - [OptimusMewsLogoSizeVariant.large] - Should be used with caution. For
+///   example, in cases when highlighting the brand is required.
+/// - [OptimusMewsLogoSizeVariant.medium] - This is the system default variant,
+///   recommended for use whenever possible.
+/// - [OptimusMewsLogoSizeVariant.small] - This size variant should be used when
+///   there is limited space available.
 enum OptimusMewsLogoSizeVariant { large, medium, small }
 
+/// Mews logo color.
+///
 /// For strong and consistent brand experience, the logo is available only in
 /// two color options. Always check contrast ratios to ensure the logo is
 /// legible and recognizable.
-/// [OptimusMewsLogoColorVariant.black] - Use on white or light gray surfaces.
-/// [OptimusMewsLogoColorVariant.white] - Use on dark or colored surfaces.
+///
+/// - [OptimusMewsLogoColorVariant.black] - Use on white or light gray surfaces.
+/// - [OptimusMewsLogoColorVariant.white] - Use on dark or colored surfaces.
 enum OptimusMewsLogoColorVariant { black, white }
 
+/// Mews logo alignment.
+///
 /// The preferred placement of the logo in any product is either in the top left
 /// or top center. You should avoid aligning or placing the logo on the right
 /// side of the screen unless absolutely necessary.
 enum OptimusMewsLogoAlignVariant { topLeft, topCenter, center }
 
-/// OptimusMewsLogo is Mews Logo component with clearly defined margins, size
-/// and color options.
+/// Mews Logo component with clearly defined margins, size and color options.
+///
 /// It is provided for better consistency across all products. No text or visual
 /// elements may be placed within 1x(x = logo heigh) of the space around it.
 class OptimusMewsLogo extends StatelessWidget {

--- a/storybook/lib/main.dart
+++ b/storybook/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:storybook/stories/icon_list.dart';
 import 'package:storybook/stories/input.dart';
 import 'package:storybook/stories/list_tile.dart';
 import 'package:storybook/stories/loader.dart';
+import 'package:storybook/stories/logo.dart';
 import 'package:storybook/stories/nested_overlays.dart';
 import 'package:storybook/stories/nonmodal_wrapper.dart';
 import 'package:storybook/stories/notification.dart';
@@ -72,6 +73,7 @@ class MyApp extends StatelessWidget {
           wideBannerStory,
           interactiveTagStory,
           iconStory,
+          logoStory,
           supplementaryIconStory,
           iconListStory,
           cardStory,

--- a/storybook/lib/stories/logo.dart
+++ b/storybook/lib/stories/logo.dart
@@ -22,14 +22,19 @@ final Story logoStory = Story(
       initial: OptimusMewsLogoColorVariant.black,
       options: OptimusMewsLogoColorVariant.values.toOptions(),
     );
+    final align = knobs.options(
+      label: 'Align',
+      initial: OptimusMewsLogoAlignVariant.topCenter,
+      options: OptimusMewsLogoAlignVariant.values.toOptions(),
+    );
 
     return Container(
-      alignment: Alignment.center,
       color: color == OptimusMewsLogoColorVariant.white ? Colors.black : null,
       child: OptimusMewsLogo(
         logoVariant: variant,
         sizeVariant: size,
         colorVariant: color,
+        alignVariant: align,
       ),
     );
   },

--- a/storybook/lib/stories/logo.dart
+++ b/storybook/lib/stories/logo.dart
@@ -29,6 +29,7 @@ final Story logoStory = Story(
     );
 
     return Container(
+      alignment: Alignment.center,
       color: color == OptimusMewsLogoColorVariant.white ? Colors.black : null,
       child: OptimusMewsLogo(
         logoVariant: variant,

--- a/storybook/lib/stories/logo.dart
+++ b/storybook/lib/stories/logo.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:optimus/optimus.dart';
+import 'package:storybook/utils.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+final Story logoStory = Story(
+  name: 'Logo',
+  builder: (context) {
+    final knobs = context.knobs;
+    final variant = knobs.options(
+      label: 'Variant',
+      initial: OptimusMewsLogoVariant.wordmark,
+      options: OptimusMewsLogoVariant.values.toOptions(),
+    );
+    final size = knobs.options(
+      label: 'Size',
+      initial: OptimusMewsLogoSizeVariant.medium,
+      options: OptimusMewsLogoSizeVariant.values.toOptions(),
+    );
+    final color = knobs.options(
+      label: 'Color',
+      initial: OptimusMewsLogoColorVariant.black,
+      options: OptimusMewsLogoColorVariant.values.toOptions(),
+    );
+
+    return Container(
+      alignment: Alignment.center,
+      color: color == OptimusMewsLogoColorVariant.white ? Colors.black : null,
+      child: OptimusMewsLogo(
+        logoVariant: variant,
+        sizeVariant: size,
+        colorVariant: color,
+      ),
+    );
+  },
+);


### PR DESCRIPTION
#### Summary
RND-103050
Added Mews Logo component. The logo component has specified margins and recommended placement options. Had to reuse the Flutter Icon class with some changes, because the default one does not support non-squared icons. Details:  https://github.com/flutter/flutter/issues/99830.
<details>
<summary>Screenshots</summary>

![Screenshot 2022-06-01 at 14 41 20](https://user-images.githubusercontent.com/9210422/171406832-d462f897-3c1e-4fe1-ac1e-488ea3bdacb5.png)
![Screenshot 2022-06-01 at 14 41 04](https://user-images.githubusercontent.com/9210422/171406957-574ef877-7ea3-4507-889c-502e7f298f47.png)
</details>

#### Testing steps

Check if the component is fulfilling design system specifications.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
