### PR TITLE
refactor(optimus)!: [RND-108306] Allow multi-line title in OptimusNotification

### DIFF
--- a/optimus/lib/src/notification/notification.dart
+++ b/optimus/lib/src/notification/notification.dart
@@ -25,10 +25,7 @@ enum OptimusNotificationVariant {
 
 /// Notification is used for showing a brief and concise message that
 /// communicates immediate feedback with optional action included. Notifications
-/// are noticeable but not intrusive to the use and can be temporary. For
-/// constructing notification according to Optimus design we recommend you to
-/// use [OptimusNotificationTitle], [OptimusNotificationBody] and
-/// [OptimusNotificationLink] components.
+/// are noticeable but not intrusive to the use and can be temporary.
 class OptimusNotification extends StatelessWidget {
   const OptimusNotification({
     Key? key,
@@ -97,8 +94,8 @@ class OptimusNotification extends StatelessWidget {
 /// Optimus styled notification title.
 ///
 /// Title should be straight and easy-to-understand.
-class OptimusNotificationTitle extends StatelessWidget {
-  const OptimusNotificationTitle(
+class _OptimusNotificationTitle extends StatelessWidget {
+  const _OptimusNotificationTitle(
     this.title, {
     Key? key,
   }) : super(key: key);
@@ -123,8 +120,8 @@ class OptimusNotificationTitle extends StatelessWidget {
 /// The main content or description should be as brief and straight to the point
 /// as possible. Number or lines is limited to [_maxLinesBody] and is truncated
 /// with ellipsis.
-class OptimusNotificationBody extends StatelessWidget {
-  const OptimusNotificationBody(
+class _OptimusNotificationBody extends StatelessWidget {
+  const _OptimusNotificationBody(
     this.body, {
     Key? key,
   }) : super(key: key);
@@ -150,8 +147,8 @@ class OptimusNotificationBody extends StatelessWidget {
 ///
 /// Link should be short and precise. Number of lines is limited
 /// to [_maxLinesLink]
-class OptimusNotificationLink extends StatelessWidget {
-  const OptimusNotificationLink(
+class _OptimusNotificationLink extends StatelessWidget {
+  const _OptimusNotificationLink(
     this.link, {
     Key? key,
   }) : super(key: key);
@@ -243,18 +240,18 @@ class _NotificationContent extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    title,
+                    _OptimusNotificationTitle(title),
                     if (body != null)
                       Padding(
                         padding: const EdgeInsets.only(top: spacing50),
-                        child: body,
+                        child: _OptimusNotificationBody(body),
                       ),
                     if (link != null)
                       Padding(
                         padding: const EdgeInsets.only(top: spacing50),
                         child: GestureDetector(
                           onTap: onLinkPressed,
-                          child: link,
+                          child: _OptimusNotificationLink(link),
                         ),
                       )
                   ],

--- a/optimus/lib/src/notification/notification.dart
+++ b/optimus/lib/src/notification/notification.dart
@@ -25,7 +25,10 @@ enum OptimusNotificationVariant {
 
 /// Notification is used for showing a brief and concise message that
 /// communicates immediate feedback with optional action included. Notifications
-/// are noticeable but not intrusive to the use and can be temporary.
+/// are noticeable but not intrusive to the use and can be temporary. For
+/// constructing notification according to Optimus design we recommend you to
+/// use [OptimusNotificationTitle], [OptimusNotificationBody] and
+/// [OptimusNotificationLink] components.
 class OptimusNotification extends StatelessWidget {
   const OptimusNotification({
     Key? key,
@@ -37,25 +40,6 @@ class OptimusNotification extends StatelessWidget {
     this.onDismissed,
     this.variant = OptimusNotificationVariant.info,
   }) : super(key: key);
-
-  /// Notification built using predefined optimus design components.
-  OptimusNotification.styled({
-    Key? key,
-    required Widget title,
-    Widget? body,
-    Widget? link,
-    VoidCallback? onLinkPressed,
-    VoidCallback? onDismissed,
-    OptimusNotificationVariant variant = OptimusNotificationVariant.info,
-  }) : this(
-          key: key,
-          title: OptimusNotificationTitle(title),
-          body: body != null ? OptimusNotificationBody(body) : null,
-          link: link != null ? OptimusNotificationLink(link) : null,
-          onLinkPressed: onLinkPressed,
-          onDismissed: onDismissed,
-          variant: variant,
-        );
 
   final Widget title;
   final Widget? body;
@@ -269,7 +253,7 @@ class _NotificationContent extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.only(top: spacing50),
                         child: GestureDetector(
-                          onTap: () => onLinkPressed?.call(),
+                          onTap: onLinkPressed,
                           child: link,
                         ),
                       )
@@ -340,7 +324,7 @@ class _NotificationCloseButton extends StatelessWidget {
       top: spacing100,
       right: spacing100,
       child: GestureDetector(
-        onTap: onDismissed.call,
+        onTap: onDismissed,
         child: Padding(
           padding: const EdgeInsets.all(spacing100),
           child: Icon(

--- a/optimus/lib/src/notification/notification.dart
+++ b/optimus/lib/src/notification/notification.dart
@@ -41,9 +41,9 @@ class OptimusNotification extends StatelessWidget {
   /// Notification built using predefined optimus design components.
   OptimusNotification.styled({
     Key? key,
-    required String title,
-    String? body,
-    String? link,
+    required Widget title,
+    Widget? body,
+    Widget? link,
     VoidCallback? onLinkPressed,
     VoidCallback? onDismissed,
     OptimusNotificationVariant variant = OptimusNotificationVariant.info,
@@ -119,17 +119,17 @@ class OptimusNotificationTitle extends StatelessWidget {
     Key? key,
   }) : super(key: key);
 
-  final String title;
+  final Widget title;
 
   @override
   Widget build(BuildContext context) {
     final theme = OptimusTheme.of(context);
 
-    return Text(
-      title,
+    return DefaultTextStyle(
       style: preset300b.copyWith(
         color: theme.colors.neutral1000,
       ),
+      child: title,
     );
   }
 }
@@ -145,19 +145,19 @@ class OptimusNotificationBody extends StatelessWidget {
     Key? key,
   }) : super(key: key);
 
-  final String body;
+  final Widget body;
 
   @override
   Widget build(BuildContext context) {
     final theme = OptimusTheme.of(context);
 
-    return Text(
-      body,
+    return DefaultTextStyle(
       maxLines: _maxLinesBody,
       overflow: TextOverflow.ellipsis,
       style: preset200r.copyWith(
         color: theme.colors.neutral1000t64,
       ),
+      child: body,
     );
   }
 }
@@ -172,20 +172,20 @@ class OptimusNotificationLink extends StatelessWidget {
     Key? key,
   }) : super(key: key);
 
-  final String link;
+  final Widget link;
 
   @override
   Widget build(BuildContext context) {
     final theme = OptimusTheme.of(context);
 
-    return Text(
-      link,
+    return DefaultTextStyle(
       maxLines: _maxLinesLink,
       overflow: TextOverflow.ellipsis,
       style: preset200b.copyWith(
         color: theme.colors.neutral1000,
         decoration: TextDecoration.underline,
       ),
+      child: link,
     );
   }
 }

--- a/optimus/lib/src/notification/notification.dart
+++ b/optimus/lib/src/notification/notification.dart
@@ -38,10 +38,29 @@ class OptimusNotification extends StatelessWidget {
     this.variant = OptimusNotificationVariant.info,
   }) : super(key: key);
 
-  final String title;
-  final String? body;
+  /// Notification built using predefined optimus design components.
+  OptimusNotification.styled({
+    Key? key,
+    required String title,
+    String? body,
+    String? link,
+    VoidCallback? onLinkPressed,
+    VoidCallback? onDismissed,
+    OptimusNotificationVariant variant = OptimusNotificationVariant.info,
+  }) : this(
+          key: key,
+          title: OptimusNotificationTitle(title),
+          body: body != null ? OptimusNotificationBody(body) : null,
+          link: link != null ? OptimusNotificationLink(link) : null,
+          onLinkPressed: onLinkPressed,
+          onDismissed: onDismissed,
+          variant: variant,
+        );
+
+  final Widget title;
+  final Widget? body;
   final IconData? icon;
-  final String? link;
+  final Widget? link;
   final VoidCallback? onLinkPressed;
   final VoidCallback? onDismissed;
   final OptimusNotificationVariant variant;
@@ -91,6 +110,86 @@ class OptimusNotification extends StatelessWidget {
   }
 }
 
+/// Optimus styled notification title.
+///
+/// Title should be straight and easy-to-understand.
+class OptimusNotificationTitle extends StatelessWidget {
+  const OptimusNotificationTitle(
+    this.title, {
+    Key? key,
+  }) : super(key: key);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = OptimusTheme.of(context);
+
+    return Text(
+      title,
+      style: preset300b.copyWith(
+        color: theme.colors.neutral1000,
+      ),
+    );
+  }
+}
+
+/// Optimus styled notification body.
+///
+/// The main content or description should be as brief and straight to the point
+/// as possible. Number or lines is limited to [_maxLinesBody] and is truncated
+/// with ellipsis.
+class OptimusNotificationBody extends StatelessWidget {
+  const OptimusNotificationBody(
+    this.body, {
+    Key? key,
+  }) : super(key: key);
+
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = OptimusTheme.of(context);
+
+    return Text(
+      body,
+      maxLines: _maxLinesBody,
+      overflow: TextOverflow.ellipsis,
+      style: preset200r.copyWith(
+        color: theme.colors.neutral1000t64,
+      ),
+    );
+  }
+}
+
+/// Optimus styled notification link.
+///
+/// Link should be short and precise. Number of lines is limited
+/// to [_maxLinesLink]
+class OptimusNotificationLink extends StatelessWidget {
+  const OptimusNotificationLink(
+    this.link, {
+    Key? key,
+  }) : super(key: key);
+
+  final String link;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = OptimusTheme.of(context);
+
+    return Text(
+      link,
+      maxLines: _maxLinesLink,
+      overflow: TextOverflow.ellipsis,
+      style: preset200b.copyWith(
+        color: theme.colors.neutral1000,
+        decoration: TextDecoration.underline,
+      ),
+    );
+  }
+}
+
 class _NotificationContent extends StatelessWidget {
   const _NotificationContent({
     Key? key,
@@ -105,9 +204,9 @@ class _NotificationContent extends StatelessWidget {
 
   final IconData? icon;
   final OptimusNotificationVariant variant;
-  final String title;
-  final String? body;
-  final String? link;
+  final Widget title;
+  final Widget? body;
+  final Widget? link;
   final VoidCallback? onLinkPressed;
   final bool dismissible;
 
@@ -160,15 +259,19 @@ class _NotificationContent extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    _NotificationTitle(title: title),
+                    title,
                     if (body != null)
-                      _NotificationBody(
-                        body: body,
+                      Padding(
+                        padding: const EdgeInsets.only(top: spacing50),
+                        child: body,
                       ),
                     if (link != null)
-                      _NotificationLink(
-                        onLinkPressed: onLinkPressed,
-                        link: link,
+                      Padding(
+                        padding: const EdgeInsets.only(top: spacing50),
+                        child: GestureDetector(
+                          onTap: () => onLinkPressed?.call(),
+                          child: link,
+                        ),
                       )
                   ],
                 ),
@@ -216,87 +319,6 @@ class _LeadingIcon extends StatelessWidget {
         icon ?? _bannerIcon,
         color: variant.getBannerIconColor(theme),
         size: _iconSize,
-      ),
-    );
-  }
-}
-
-class _NotificationTitle extends StatelessWidget {
-  const _NotificationTitle({
-    Key? key,
-    required this.title,
-  }) : super(key: key);
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = OptimusTheme.of(context);
-
-    return Text(
-      title,
-      maxLines: _maxLinesTitle,
-      overflow: TextOverflow.ellipsis,
-      style: preset300b.copyWith(
-        color: theme.colors.neutral1000,
-      ),
-    );
-  }
-}
-
-class _NotificationBody extends StatelessWidget {
-  const _NotificationBody({
-    Key? key,
-    required this.body,
-  }) : super(key: key);
-
-  final String body;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = OptimusTheme.of(context);
-
-    return Padding(
-      padding: const EdgeInsets.only(top: spacing50),
-      child: Text(
-        body,
-        maxLines: _maxLinesBody,
-        overflow: TextOverflow.ellipsis,
-        style: preset200r.copyWith(
-          color: theme.colors.neutral1000t64,
-        ),
-      ),
-    );
-  }
-}
-
-class _NotificationLink extends StatelessWidget {
-  const _NotificationLink({
-    Key? key,
-    required this.onLinkPressed,
-    required this.link,
-  }) : super(key: key);
-
-  final VoidCallback? onLinkPressed;
-  final String link;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = OptimusTheme.of(context);
-
-    return GestureDetector(
-      onTap: () => onLinkPressed?.call(),
-      child: Padding(
-        padding: const EdgeInsets.only(top: spacing50),
-        child: Text(
-          link,
-          maxLines: _maxLinesLink,
-          overflow: TextOverflow.ellipsis,
-          style: preset200b.copyWith(
-            color: theme.colors.neutral1000,
-            decoration: TextDecoration.underline,
-          ),
-        ),
       ),
     );
   }
@@ -362,6 +384,5 @@ const double _maxWidth = 360;
 const double _closeIconSize = 16;
 const double _iconSize = 20;
 const double _iconHorizontalPadding = 10;
-const int _maxLinesTitle = 1;
 const int _maxLinesBody = 5;
 const int _maxLinesLink = 1;

--- a/optimus/lib/src/notification/notification.dart
+++ b/optimus/lib/src/notification/notification.dart
@@ -94,8 +94,8 @@ class OptimusNotification extends StatelessWidget {
 /// Optimus styled notification title.
 ///
 /// Title should be straight and easy-to-understand.
-class _OptimusNotificationTitle extends StatelessWidget {
-  const _OptimusNotificationTitle(
+class _NotificationTitle extends StatelessWidget {
+  const _NotificationTitle(
     this.title, {
     Key? key,
   }) : super(key: key);
@@ -120,8 +120,8 @@ class _OptimusNotificationTitle extends StatelessWidget {
 /// The main content or description should be as brief and straight to the point
 /// as possible. Number or lines is limited to [_maxLinesBody] and is truncated
 /// with ellipsis.
-class _OptimusNotificationBody extends StatelessWidget {
-  const _OptimusNotificationBody(
+class _NotificationBody extends StatelessWidget {
+  const _NotificationBody(
     this.body, {
     Key? key,
   }) : super(key: key);
@@ -147,8 +147,8 @@ class _OptimusNotificationBody extends StatelessWidget {
 ///
 /// Link should be short and precise. Number of lines is limited
 /// to [_maxLinesLink]
-class _OptimusNotificationLink extends StatelessWidget {
-  const _OptimusNotificationLink(
+class _NotificationLink extends StatelessWidget {
+  const _NotificationLink(
     this.link, {
     Key? key,
   }) : super(key: key);
@@ -240,18 +240,18 @@ class _NotificationContent extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    _OptimusNotificationTitle(title),
+                    _NotificationTitle(title),
                     if (body != null)
                       Padding(
                         padding: const EdgeInsets.only(top: spacing50),
-                        child: _OptimusNotificationBody(body),
+                        child: _NotificationBody(body),
                       ),
                     if (link != null)
                       Padding(
                         padding: const EdgeInsets.only(top: spacing50),
                         child: GestureDetector(
                           onTap: onLinkPressed,
-                          child: _OptimusNotificationLink(link),
+                          child: _NotificationLink(link),
                         ),
                       )
                   ],

--- a/storybook/lib/stories/notification.dart
+++ b/storybook/lib/stories/notification.dart
@@ -12,19 +12,21 @@ final Story notificationStory = Story(
     final dismissible = k.boolean(label: 'Is Dismissible');
 
     return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: OptimusNotificationVariant.values
-            .map(
-              (variant) => OptimusNotification(
-                title: title,
-                body: body.isNotEmpty ? body : null,
-                variant: variant,
-                link: link.isNotEmpty ? link : null,
-                onDismissed: dismissible ? () {} : null,
-              ),
-            )
-            .toList(),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: OptimusNotificationVariant.values
+              .map(
+                (variant) => OptimusNotification.styled(
+                  title: title,
+                  body: body.isNotEmpty ? body : null,
+                  variant: variant,
+                  link: link.isNotEmpty ? link : null,
+                  onDismissed: dismissible ? () {} : null,
+                ),
+              )
+              .toList(),
+        ),
       ),
     );
   },

--- a/storybook/lib/stories/notification.dart
+++ b/storybook/lib/stories/notification.dart
@@ -18,14 +18,10 @@ final Story notificationStory = Story(
           children: OptimusNotificationVariant.values
               .map(
                 (variant) => OptimusNotification(
-                  title: OptimusNotificationTitle(Text(title)),
-                  body: body.isNotEmpty
-                      ? OptimusNotificationBody(Text(body))
-                      : null,
+                  title: Text(title),
+                  body: body.isNotEmpty ? Text(body) : null,
                   variant: variant,
-                  link: link.isNotEmpty
-                      ? OptimusNotificationLink(Text(link))
-                      : null,
+                  link: link.isNotEmpty ? Text(link) : null,
                   onDismissed: dismissible ? () {} : null,
                 ),
               )

--- a/storybook/lib/stories/notification.dart
+++ b/storybook/lib/stories/notification.dart
@@ -17,11 +17,15 @@ final Story notificationStory = Story(
           mainAxisSize: MainAxisSize.min,
           children: OptimusNotificationVariant.values
               .map(
-                (variant) => OptimusNotification.styled(
-                  title: Text(title),
-                  body: body.isNotEmpty ? Text(body) : null,
+                (variant) => OptimusNotification(
+                  title: OptimusNotificationTitle(Text(title)),
+                  body: body.isNotEmpty
+                      ? OptimusNotificationBody(Text(body))
+                      : null,
                   variant: variant,
-                  link: link.isNotEmpty ? Text(link) : null,
+                  link: link.isNotEmpty
+                      ? OptimusNotificationLink(Text(link))
+                      : null,
                   onDismissed: dismissible ? () {} : null,
                 ),
               )

--- a/storybook/lib/stories/notification.dart
+++ b/storybook/lib/stories/notification.dart
@@ -18,10 +18,10 @@ final Story notificationStory = Story(
           children: OptimusNotificationVariant.values
               .map(
                 (variant) => OptimusNotification.styled(
-                  title: title,
-                  body: body.isNotEmpty ? body : null,
+                  title: Text(title),
+                  body: body.isNotEmpty ? Text(body) : null,
                   variant: variant,
-                  link: link.isNotEmpty ? link : null,
+                  link: link.isNotEmpty ? Text(link) : null,
                   onDismissed: dismissible ? () {} : null,
                 ),
               )


### PR DESCRIPTION
#### Summary
RND-108306

Updated OptimusNotification so it could be built using custom-styled widgets. Added named constructor `styled` for cases when design defined in Optimus Design System is sufficient.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
