### PR TITLE
feat(optimus): [RND-103474] Update Date picker component

### DIFF
--- a/optimus/lib/src/date_time_field.dart
+++ b/optimus/lib/src/date_time_field.dart
@@ -32,8 +32,10 @@ class OptimusDateTimeField extends StatefulWidget {
   State<OptimusDateTimeField> createState() => _OptimusDateTimeFieldState();
 }
 
-class _OptimusDateTimeFieldState extends State<OptimusDateTimeField> {
+class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
+    with ThemeGetter {
   final TextEditingController _controller = TextEditingController();
+  late bool isClearEnabled;
 
   @override
   void initState() {
@@ -58,6 +60,7 @@ class _OptimusDateTimeFieldState extends State<OptimusDateTimeField> {
     _controller.value = _controller.value.copyWith(
       text: value == null ? '' : widget.formatDateTime(value),
     );
+    isClearEnabled = value != null;
   }
 
   void _showPickerDialog() {
@@ -83,10 +86,17 @@ class _OptimusDateTimeFieldState extends State<OptimusDateTimeField> {
   Widget build(BuildContext context) => OptimusInputField(
         controller: _controller,
         readOnly: true,
-        onTap: _showPickerDialog,
         error: widget.error,
         label: widget.label,
-        isClearEnabled: widget.isClearEnabled,
+        isClearEnabled: isClearEnabled,
+        suffix: GestureDetector(
+          onTap: _showPickerDialog,
+          child: Icon(
+            OptimusIcons.calendar,
+            size: 20,
+            color: theme.colors.neutral1000,
+          ),
+        ),
         placeholder: widget.placeholder,
         onChanged: _onInputChanged,
       );

--- a/optimus/lib/src/date_time_field.dart
+++ b/optimus/lib/src/date_time_field.dart
@@ -35,7 +35,7 @@ class OptimusDateTimeField extends StatefulWidget {
 class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
     with ThemeGetter {
   final TextEditingController _controller = TextEditingController();
-  late bool isClearEnabled;
+  late bool isClearVisible;
 
   @override
   void initState() {
@@ -60,7 +60,7 @@ class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
     _controller.value = _controller.value.copyWith(
       text: value == null ? '' : widget.formatDateTime(value),
     );
-    isClearEnabled = value != null;
+    isClearVisible = value != null && widget.isClearEnabled;
   }
 
   void _showPickerDialog() {
@@ -88,7 +88,7 @@ class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
         readOnly: true,
         error: widget.error,
         label: widget.label,
-        isClearEnabled: isClearEnabled,
+        isClearEnabled: isClearVisible,
         suffix: GestureDetector(
           onTap: _showPickerDialog,
           child: Icon(

--- a/optimus/lib/src/date_time_field.dart
+++ b/optimus/lib/src/date_time_field.dart
@@ -35,7 +35,7 @@ class OptimusDateTimeField extends StatefulWidget {
 class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
     with ThemeGetter {
   final TextEditingController _controller = TextEditingController();
-  late bool isClearVisible;
+  bool _isClearVisible = false;
 
   @override
   void initState() {
@@ -60,7 +60,7 @@ class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
     _controller.value = _controller.value.copyWith(
       text: value == null ? '' : widget.formatDateTime(value),
     );
-    isClearVisible = value != null && widget.isClearEnabled;
+    _isClearVisible = value != null && widget.isClearEnabled;
   }
 
   void _showPickerDialog() {
@@ -89,7 +89,7 @@ class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
         onTap: _showPickerDialog,
         error: widget.error,
         label: widget.label,
-        isClearEnabled: isClearVisible,
+        isClearEnabled: _isClearVisible,
         suffix: GestureDetector(
           onTap: _showPickerDialog,
           child: Icon(

--- a/optimus/lib/src/date_time_field.dart
+++ b/optimus/lib/src/date_time_field.dart
@@ -86,6 +86,7 @@ class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
   Widget build(BuildContext context) => OptimusInputField(
         controller: _controller,
         readOnly: true,
+        onTap: _showPickerDialog,
         error: widget.error,
         label: widget.label,
         isClearEnabled: isClearVisible,

--- a/storybook/lib/stories/date_time_field.dart
+++ b/storybook/lib/stories/date_time_field.dart
@@ -31,7 +31,7 @@ class _ContentState extends State<_Content> {
         child: OptimusDateTimeField(
           value: _dateTime,
           isClearEnabled: widget.k.boolean(label: 'Clear all', initial: false),
-          label: widget.k.text(label: 'Label', initial: 'Optimus input field'),
+          label: widget.k.text(label: 'Label', initial: 'Date'),
           error: widget.k.text(label: 'Error', initial: ''),
           placeholder: widget.k.text(label: 'Placeholder', initial: ''),
           formatDateTime: (d) {

--- a/storybook/lib/stories/date_time_field.dart
+++ b/storybook/lib/stories/date_time_field.dart
@@ -38,7 +38,7 @@ class _ContentState extends State<_Content> {
             final am = d.hour < 12 ? 'AM' : 'PM';
             final hours = d.hour % 12;
 
-            return '${d.day}/${d.month}/${d.year} ${hours.format()}:${d.minute.format()} $am';
+            return '${d.day}/${d.month}/${d.year} ${hours.padded()}:${d.minute.padded()} $am';
           },
           onChanged: (v) => setState(() {
             _dateTime = v;
@@ -48,5 +48,5 @@ class _ContentState extends State<_Content> {
 }
 
 extension on int {
-  String format() => this > 10 ? toString() : toString().padLeft(2, '0');
+  String padded() => toString().padLeft(2, '0');
 }

--- a/storybook/lib/stories/date_time_field.dart
+++ b/storybook/lib/stories/date_time_field.dart
@@ -36,8 +36,9 @@ class _ContentState extends State<_Content> {
           placeholder: widget.k.text(label: 'Placeholder', initial: ''),
           formatDateTime: (d) {
             final am = d.hour < 12 ? 'AM' : 'PM';
+            final hours = d.hour % 12;
 
-            return '${d.day}/${d.month}/${d.year} ${d.hour.format()}:${d.minute.format()} $am';
+            return '${d.day}/${d.month}/${d.year} ${hours.format()}:${d.minute.format()} $am';
           },
           onChanged: (v) => setState(() {
             _dateTime = v;

--- a/storybook/lib/stories/date_time_field.dart
+++ b/storybook/lib/stories/date_time_field.dart
@@ -34,10 +34,18 @@ class _ContentState extends State<_Content> {
           label: widget.k.text(label: 'Label', initial: 'Optimus input field'),
           error: widget.k.text(label: 'Error', initial: ''),
           placeholder: widget.k.text(label: 'Placeholder', initial: ''),
-          formatDateTime: (d) => '${d.day}.${d.month}.${d.year}',
+          formatDateTime: (d) {
+            final am = d.hour < 12 ? 'AM' : 'PM';
+
+            return '${d.day}/${d.month}/${d.year} ${d.hour.format()}:${d.minute.format()} $am';
+          },
           onChanged: (v) => setState(() {
             _dateTime = v;
           }),
         ),
       );
+}
+
+extension on int {
+  String format() => this > 10 ? toString() : toString().padLeft(2, '0');
 }


### PR DESCRIPTION
#### Summary

RND-103474

Updated date picker story to display picked time and AM/PM. The date picker is now called when tapping on the calendar icon, which is present by default. **Clear All** button is now visible if it is enabled and the selected date is not `null`.

<details>
<summary>Screenshot</summary>

![CleanShot 2022-06-14 at 14 38 03@2x](https://user-images.githubusercontent.com/9210422/173578846-ca77dcba-3329-46f4-851b-6b542bc753f3.png)
</details>


#### Testing steps

Open Storybook with DateTime picker story. Change the date and time. Clear all should be visible if it is enabled and the selected date is not `null`.

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
