### PR TITLE
fix(optimus): [RND-73262] Misalignment of the text with radio button in Switch property option in both Andriod and iOS

### DIFF
--- a/optimus/lib/src/radio/radio.dart
+++ b/optimus/lib/src/radio/radio.dart
@@ -119,23 +119,28 @@ class _OptimusRadioState<T> extends State<OptimusRadio<T>> with ThemeGetter {
               onTapDown: (_) => setState(() => _isTappedDown = true),
               onTapUp: (_) => setState(() => _isTappedDown = false),
               onTapCancel: () => setState(() => _isTappedDown = false),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _RadioCircle(
-                    isSelected: _isSelected,
-                    isActive: _isHovering || _isTappedDown,
-                  ),
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 2),
-                      child: DefaultTextStyle.merge(
-                        style: _labelStyle,
-                        child: widget.label,
+              child: IntrinsicHeight(
+                child: Row(
+                  children: [
+                    Align(
+                      alignment: Alignment.topCenter,
+                      child: _RadioCircle(
+                        isSelected: _isSelected,
+                        isActive: _isHovering || _isTappedDown,
                       ),
                     ),
-                  ),
-                ],
+                    Expanded(
+                      child: Padding(
+                        padding:
+                            const EdgeInsets.symmetric(vertical: spacing25),
+                        child: DefaultTextStyle.merge(
+                          style: _labelStyle,
+                          child: widget.label,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
#### Summary

RND-73262

The whole row was aligned to the top, so the text widget wasn't aligned properly when the text could fit into one line.

<details>
<summary>Before</summary>

<img width="369" alt="CleanShot 2022-06-28 at 18 58 06@2x" src="https://user-images.githubusercontent.com/9210422/176244524-122625d0-d115-446b-a1aa-9f12bf5a4279.png">


</details>

<details>

<summary>After</summary>

<img width="414" alt="CleanShot 2022-06-28 at 18 57 32@2x" src="https://user-images.githubusercontent.com/9210422/176244562-cbc6cf77-d862-42ff-bd9e-0391aec789f1.png">

</details>

#### Testing steps

1. Open Storybook
2. Check Radio Story if the OptimusRadio displayed correctly.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
