### PR TITLE
feat(storybook): [RND-104012] Categorize components the same way as Mews.design

### DIFF
--- a/storybook/lib/stories/avatar.dart
+++ b/storybook/lib/stories/avatar.dart
@@ -3,7 +3,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final avatarStory = Story(
-  name: 'Avatar',
+  name: 'Media And Icons/Avatar',
   builder: (_) => const OptimusStack(
     direction: Axis.horizontal,
     mainAxisSize: MainAxisSize.min,

--- a/storybook/lib/stories/badge.dart
+++ b/storybook/lib/stories/badge.dart
@@ -2,7 +2,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story badgeStory = Story(
-  name: 'Badge',
+  name: 'Feedback/Badge',
   builder: (context) => OptimusBadge(
     text: context.knobs.text(label: 'Content', initial: 'Info Text'),
   ),

--- a/storybook/lib/stories/banner.dart
+++ b/storybook/lib/stories/banner.dart
@@ -4,7 +4,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story bannerStory = Story(
-  name: 'Banner/Banner',
+  name: 'Feedback/Banner/Banner',
   builder: (context) {
     final k = context.knobs;
     final title = k.text(label: 'Title', initial: 'Title');

--- a/storybook/lib/stories/button/button.dart
+++ b/storybook/lib/stories/button/button.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story button = Story(
-  name: 'Button/Button',
+  name: 'General/Buttons/Button',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/button/dropdown.dart
+++ b/storybook/lib/stories/button/dropdown.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story dropdownButton = Story(
-  name: 'Button/Dropdown button',
+  name: 'General/Buttons/Dropdown button',
   builder: (context) {
     final k = context.knobs;
     final isEnabled = k.boolean(label: 'Enabled', initial: true);

--- a/storybook/lib/stories/button/icon.dart
+++ b/storybook/lib/stories/button/icon.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story iconButton = Story(
-  name: 'Button/Icon button',
+  name: 'General/Buttons/Icon button',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/button/split.dart
+++ b/storybook/lib/stories/button/split.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story splitButton = Story(
-  name: 'Button/Split button',
+  name: 'General/Buttons/Split button',
   builder: (context) {
     final k = context.knobs;
     final isEnabled = k.boolean(label: 'Enabled', initial: true);

--- a/storybook/lib/stories/card.dart
+++ b/storybook/lib/stories/card.dart
@@ -5,7 +5,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story cardStory = Story(
-  name: 'Cards/Card',
+  name: 'Structure/Cards/Card',
   builder: (context) {
     final k = context.knobs;
 
@@ -31,7 +31,7 @@ final Story cardStory = Story(
 );
 
 final Story nestedCardStory = Story(
-  name: 'Cards/Nested card',
+  name: 'Structure/Cards/Nested card',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/chat/bubble.dart
+++ b/storybook/lib/stories/chat/bubble.dart
@@ -5,7 +5,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final chatBubbleStory = Story(
-  name: 'Chat/Chat Bubble',
+  name: 'General/Chat/Chat Bubble',
   builder: (context) {
     final k = context.knobs;
     final message = OptimusMessage(

--- a/storybook/lib/stories/chat/chat.dart
+++ b/storybook/lib/stories/chat/chat.dart
@@ -4,7 +4,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final chatStory = Story(
-  name: 'Chat/Chat',
+  name: 'General/Chat/Chat',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/checkbox.dart
+++ b/storybook/lib/stories/checkbox.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story checkbox = Story(
-  name: 'Checkbox/Checkbox',
+  name: 'Forms/Checkbox/Checkbox',
   builder: (context) => _CheckboxStory(context.knobs),
 );
 

--- a/storybook/lib/stories/checkbox_group.dart
+++ b/storybook/lib/stories/checkbox_group.dart
@@ -3,7 +3,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story checkboxGroup = Story(
-  name: 'Checkbox/Checkbox Group',
+  name: 'Forms/Checkbox/Checkbox Group',
   builder: (context) => ConstrainedBox(
     constraints: const BoxConstraints(maxWidth: 400),
     child: _CheckboxGroupStory(context.knobs),

--- a/storybook/lib/stories/date_time_field.dart
+++ b/storybook/lib/stories/date_time_field.dart
@@ -3,7 +3,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story dateTimeFieldStory = Story(
-  name: 'Date time field',
+  name: 'Forms/Date time field',
   builder: (context) => _Content(k: context.knobs),
 );
 

--- a/storybook/lib/stories/dialog.dart
+++ b/storybook/lib/stories/dialog.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story dialogStory = Story(
-  name: 'Dialogs/Modal dialog',
+  name: 'General/Dialogs/Modal dialog',
   builder: (context) {
     final k = context.knobs;
     final isDismissible = k.boolean(label: 'Dismissible', initial: true);

--- a/storybook/lib/stories/form/form_story.dart
+++ b/storybook/lib/stories/form/form_story.dart
@@ -3,7 +3,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story formStory = Story(
-  name: 'Form',
+  name: 'Forms/Form',
   builder: (context) => _Content(context.knobs),
 );
 

--- a/storybook/lib/stories/icon.dart
+++ b/storybook/lib/stories/icon.dart
@@ -5,7 +5,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story iconStory = Story(
-  name: 'Icons/Icon',
+  name: 'Media And Icons/Icons/Icon',
   builder: (context) {
     final k = context.knobs;
     final icon = k.options(
@@ -39,7 +39,7 @@ final Story iconStory = Story(
 );
 
 final Story supplementaryIconStory = Story(
-  name: 'Icons/Supplementary icon',
+  name: 'Media And Icons/Icons/Supplementary icon',
   builder: (context) {
     final k = context.knobs;
     final icon = k.options(

--- a/storybook/lib/stories/icon_list.dart
+++ b/storybook/lib/stories/icon_list.dart
@@ -3,7 +3,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story iconListStory = Story(
-  name: 'Icons/Icon list',
+  name: 'Media And Icons/Icons/Icon list',
   builder: (context) => OptimusIconList(
     items: _items,
     listSize: context.knobs.options(

--- a/storybook/lib/stories/input.dart
+++ b/storybook/lib/stories/input.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story inputStory = Story(
-  name: 'Input',
+  name: 'Forms/Input',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/list/expanded_list.dart
+++ b/storybook/lib/stories/list/expanded_list.dart
@@ -5,7 +5,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story expandedListTileStory = Story(
-  name: 'List/Expanded list tile',
+  name: 'General/List/Expanded list tile',
   builder: (context) {
     final k = context.knobs;
     final title = k.text(label: 'Title', initial: 'Title');

--- a/storybook/lib/stories/list/list_tile.dart
+++ b/storybook/lib/stories/list/list_tile.dart
@@ -5,7 +5,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story listTileStory = Story(
-  name: 'List/List tile',
+  name: 'General/List/List tile',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/loader.dart
+++ b/storybook/lib/stories/loader.dart
@@ -5,7 +5,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story loaderStory = Story(
-  name: 'Circle loader',
+  name: 'Feedback/Circle loader',
   builder: (context) {
     final k = context.knobs;
     final size = k.options(

--- a/storybook/lib/stories/logo.dart
+++ b/storybook/lib/stories/logo.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story logoStory = Story(
-  name: 'Logo',
+  name: 'General/Logo',
   builder: (context) {
     final knobs = context.knobs;
     final variant = knobs.options(

--- a/storybook/lib/stories/nonmodal_wrapper.dart
+++ b/storybook/lib/stories/nonmodal_wrapper.dart
@@ -4,7 +4,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story nonModalDialogStory = Story(
-  name: 'Dialogs/Non-modal dialog',
+  name: 'General/Dialogs/Non-modal dialog',
   builder: (context) => NonModalWrapper(
     child: NonModalDialogStory(context.knobs),
   ),

--- a/storybook/lib/stories/notification.dart
+++ b/storybook/lib/stories/notification.dart
@@ -3,7 +3,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story notificationStory = Story(
-  name: 'Notification',
+  name: 'Feedback/Notification',
   builder: (context) {
     final k = context.knobs;
     final title = k.text(label: 'Title', initial: 'Title');

--- a/storybook/lib/stories/number_picker.dart
+++ b/storybook/lib/stories/number_picker.dart
@@ -3,7 +3,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story numberPickerStory = Story(
-  name: 'Number picker',
+  name: 'Forms/Number picker',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/radio.dart
+++ b/storybook/lib/stories/radio.dart
@@ -5,7 +5,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story radioStory = Story(
-  name: 'Radio/Radio',
+  name: 'Forms/Radio/Radio',
   builder: (context) {
     final k = context.knobs;
     final size = k.options(
@@ -65,7 +65,7 @@ class _RadioExampleState extends State<RadioExample> {
 }
 
 final Story radioGroupStory = Story(
-  name: 'Radio/Radio group',
+  name: 'Forms/Radio/Radio group',
   builder: (context) {
     final k = context.knobs;
     final size = k.options(

--- a/storybook/lib/stories/search_field.dart
+++ b/storybook/lib/stories/search_field.dart
@@ -5,7 +5,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story searchFieldStory = Story(
-  name: 'Search field',
+  name: 'Forms/Search field',
   builder: (context) => ConstrainedBox(
     constraints: const BoxConstraints(maxWidth: 400),
     child: SearchStory(context.knobs),

--- a/storybook/lib/stories/select_input.dart
+++ b/storybook/lib/stories/select_input.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story selectInputStory = Story(
-  name: 'Select Input',
+  name: 'Forms/Select Input',
   builder: (context) => ConstrainedBox(
     constraints: const BoxConstraints(maxWidth: 400),
     child: SelectInputStory(context.knobs),

--- a/storybook/lib/stories/spacing.dart
+++ b/storybook/lib/stories/spacing.dart
@@ -3,7 +3,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story spacingStory = Story(
-  name: 'Spacing',
+  name: 'Structure/Spacing',
   builder: (_) => SingleChildScrollView(
     child: Column(
       children: [

--- a/storybook/lib/stories/stack.dart
+++ b/storybook/lib/stories/stack.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story stackStory = Story(
-  name: 'Stack',
+  name: 'Structure/Stack',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/standalone_link.dart
+++ b/storybook/lib/stories/standalone_link.dart
@@ -4,7 +4,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story link = Story(
-  name: 'Link/Standalone link',
+  name: 'Navigation/Standalone link',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/step_bar.dart
+++ b/storybook/lib/stories/step_bar.dart
@@ -5,7 +5,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story stepBarStory = Story(
-  name: 'Step Bar',
+  name: 'Navigation/Step Bar',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/tabs.dart
+++ b/storybook/lib/stories/tabs.dart
@@ -4,7 +4,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story tabs = Story(
-  name: 'Tabs',
+  name: 'Navigation/Tabs',
   builder: (_) => Container(
     color: OptimusLightColors.success500t16,
     constraints: const BoxConstraints(maxWidth: 400, maxHeight: 200),

--- a/storybook/lib/stories/tags.dart
+++ b/storybook/lib/stories/tags.dart
@@ -4,7 +4,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story tagStory = Story(
-  name: 'Tags/Tag',
+  name: 'Feedback/Tags/Tag',
   builder: (context) {
     final k = context.knobs;
 
@@ -44,7 +44,7 @@ final Story tagStory = Story(
 );
 
 final Story interactiveTagStory = Story(
-  name: 'Tags/Interactive tag',
+  name: 'Feedback/Tags/Interactive tag',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/typography/caption.dart
+++ b/storybook/lib/stories/typography/caption.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story captionStory = Story(
-  name: 'Typography/Caption',
+  name: 'General/Typography/Caption',
   builder: (context) {
     final k = context.knobs;
     final variation = k.options(

--- a/storybook/lib/stories/typography/highlight.dart
+++ b/storybook/lib/stories/typography/highlight.dart
@@ -3,7 +3,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story highlightStory = Story(
-  name: 'Typography/Highlight',
+  name: 'General/Typography/Highlight',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/typography/label.dart
+++ b/storybook/lib/stories/typography/label.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story labelStory = Story(
-  name: 'Typography/Label',
+  name: 'General/Typography/Label',
   builder: (context) {
     final k = context.knobs;
     final variation = k.options(

--- a/storybook/lib/stories/typography/paragraph.dart
+++ b/storybook/lib/stories/typography/paragraph.dart
@@ -4,7 +4,7 @@ import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story paragraphStory = Story(
-  name: 'Typography/Paragraph',
+  name: 'General/Typography/Paragraph',
   builder: (context) {
     final k = context.knobs;
     final variation = k.options(

--- a/storybook/lib/stories/typography/title.dart
+++ b/storybook/lib/stories/typography/title.dart
@@ -3,7 +3,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story titleStory = Story(
-  name: 'Typography/Title',
+  name: 'General/Typography/Title',
   builder: (context) {
     final k = context.knobs;
 

--- a/storybook/lib/stories/wide_banner.dart
+++ b/storybook/lib/stories/wide_banner.dart
@@ -4,7 +4,7 @@ import 'package:optimus/optimus.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story wideBannerStory = Story(
-  name: 'Banner/System-Wide Banner',
+  name: 'Feedback/Banner/System-Wide Banner',
   builder: (context) {
     final k = context.knobs;
 


### PR DESCRIPTION
#### Summary 

RND-104012

Storybook categories match mews.design and components could be found faster.

It's a follow-up PR for https://github.com/MewsSystems/mews-flutter/pull/224
<details><summary>Screenshots</summary>

**Before:**
![CleanShot 2022-07-12 at 00 38 28@2x](https://user-images.githubusercontent.com/9210422/178370489-3de87d1a-6264-41c5-a185-3b0ed347c50e.png)

**After:**
![CleanShot 2022-07-12 at 00 37 32@2x](https://user-images.githubusercontent.com/9210422/178370457-671e61c2-5c32-40bb-b082-03a64a0fe12b.png)
</details>

#### Testing steps



None. Just an update in categories.



#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
