### PR TITLE
feat(optimus): [RND-103046] Fix color of Circle loader for contrast variant

### DIFF
--- a/optimus/lib/src/loader/loader.dart
+++ b/optimus/lib/src/loader/loader.dart
@@ -89,7 +89,7 @@ class OptimusCircleLoader extends StatelessWidget {
       case OptimusCircleLoaderAppearance.normal:
         return theme.colors.neutral50;
       case OptimusCircleLoaderAppearance.contrast:
-        return theme.colors.neutral1000t32;
+        return theme.colors.neutral0t32;
     }
   }
 


### PR DESCRIPTION

#### Summary

RND-103046

Fixed colors for contrast variant.

<details><summary>Screenshots</summary>

Before:
![CleanShot 2022-07-12 at 16 10 29](https://user-images.githubusercontent.com/9210422/178511330-8a87773c-09df-4277-835d-67cac5ff6add.png)

After:
![CleanShot 2022-07-12 at 16 11 24](https://user-images.githubusercontent.com/9210422/178511340-a4d980c9-c775-4c4e-a8b5-69215b87bd00.png)


</details> 

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
