### PR TITLE
feat(optimus)!: [RND-103470] Update Select component

### DIFF
--- a/optimus/lib/src/common/dropdown.dart
+++ b/optimus/lib/src/common/dropdown.dart
@@ -86,7 +86,11 @@ class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
           child: Container(
             decoration: _dropdownDecoration,
             constraints: BoxConstraints(maxHeight: maxHeight),
-            child: _buildListView(isOnTop),
+            child: _DropdownListView(
+              items: widget.items,
+              onChanged: widget.onChanged,
+              isReversed: isOnTop,
+            ),
           ),
         ),
       ],
@@ -101,22 +105,6 @@ class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
 
     return renderObject.localToGlobal(Offset.zero) & size;
   }
-
-  Widget _buildListView(bool isReversed) => Material(
-        type: MaterialType.transparency,
-        child: OptimusScrollConfiguration(
-          child: ListView.builder(
-            reverse: isReversed,
-            padding: const EdgeInsets.symmetric(vertical: spacing100),
-            shrinkWrap: true,
-            itemCount: widget.items.length,
-            itemBuilder: (context, index) => _DropdownItem(
-              onChanged: widget.onChanged,
-              child: widget.items[index],
-            ),
-          ),
-        ),
-      );
 
   double get _offsetBottom => _screenHeight - _savedRect.top + _widgetPadding;
 
@@ -138,6 +126,36 @@ class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
   double get _rightSpace => _screenWidth - _savedRect.left;
 
   double get _leftSpace => _savedRect.right;
+}
+
+class _DropdownListView<T> extends StatelessWidget {
+  const _DropdownListView({
+    Key? key,
+    required this.onChanged,
+    required this.items,
+    required this.isReversed,
+  }) : super(key: key);
+
+  final ValueSetter<T> onChanged;
+  final List<OptimusDropdownTile<T>> items;
+  final bool isReversed;
+
+  @override
+  Widget build(BuildContext context) => Material(
+        type: MaterialType.transparency,
+        child: OptimusScrollConfiguration(
+          child: ListView.builder(
+            reverse: isReversed,
+            padding: const EdgeInsets.symmetric(vertical: spacing100),
+            shrinkWrap: true,
+            itemCount: items.length,
+            itemBuilder: (context, index) => _DropdownItem(
+              onChanged: onChanged,
+              child: items[index],
+            ),
+          ),
+        ),
+      );
 }
 
 class _DropdownItem<T> extends StatefulWidget {

--- a/optimus/lib/src/input_field.dart
+++ b/optimus/lib/src/input_field.dart
@@ -94,7 +94,7 @@ class OptimusInputField extends StatefulWidget {
   /// An optional text to display after the text.
   final Widget? suffix;
 
-  /// An optional tailing interactive icon/image. If [isPasswordField] is true,
+  /// An optional trailing interactive icon/image. If [isPasswordField] is true,
   /// [trailing] will be replaced with a [_PasswordButton].
   final Widget? trailing;
 

--- a/optimus/lib/src/search/search_field.dart
+++ b/optimus/lib/src/search/search_field.dart
@@ -32,6 +32,7 @@ class OptimusSearch<T> extends StatefulWidget {
     this.suffix,
     this.focusNode,
     this.shouldCloseOnInputTap = false,
+    this.showLoader = false,
   }) : super(key: key);
 
   final String? label;
@@ -52,6 +53,7 @@ class OptimusSearch<T> extends StatefulWidget {
   final Widget? prefix;
   final Widget? suffix;
   final Widget? trailing;
+  final bool showLoader;
   final FocusNode? focusNode;
   final bool shouldCloseOnInputTap;
 
@@ -217,6 +219,7 @@ class _OptimusSearchState<T> extends State<OptimusSearch<T>> {
           size: widget.size,
           readOnly: widget.readOnly,
           showCursor: widget.showCursor,
+          showLoader: widget.showLoader,
         ),
       );
 }

--- a/optimus/lib/src/select_input.dart
+++ b/optimus/lib/src/select_input.dart
@@ -203,7 +203,10 @@ class _TrailingSelect extends StatelessWidget {
       direction: Axis.horizontal,
       spacing: OptimusStackSpacing.spacing100,
       mainAxisSize: MainAxisSize.min,
-      children: [if (trailingWidget != null) trailingWidget, _icon],
+      children: [
+        if (trailingWidget != null) trailingWidget,
+        _icon,
+      ],
     );
   }
 }

--- a/optimus/lib/src/select_input.dart
+++ b/optimus/lib/src/select_input.dart
@@ -173,7 +173,7 @@ class _OptimusSelectInput<T> extends State<OptimusSelectInput<T>>
         prefix: widget.prefix,
         leading: widget.leading,
         suffix: widget.suffix,
-        trailing: _icon,
+        trailing: _TrailingSelect(trailing: widget.trailing, icon: _icon),
         focusNode: _effectiveFocusNode,
         placeholderStyle: _textStyle,
         controller: _effectiveController,
@@ -182,4 +182,28 @@ class _OptimusSelectInput<T> extends State<OptimusSelectInput<T>>
         showLoader: widget.showLoader,
         shouldCloseOnInputTap: !_isSearchable,
       );
+}
+
+class _TrailingSelect extends StatelessWidget {
+  const _TrailingSelect({
+    Key? key,
+    required this.trailing,
+    required Widget icon,
+  })  : _icon = icon,
+        super(key: key);
+
+  final Widget? trailing;
+  final Widget _icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final trailingWidget = trailing;
+
+    return OptimusStack(
+      direction: Axis.horizontal,
+      spacing: OptimusStackSpacing.spacing100,
+      mainAxisSize: MainAxisSize.min,
+      children: [if (trailingWidget != null) trailingWidget, _icon],
+    );
+  }
 }

--- a/optimus/lib/src/select_input.dart
+++ b/optimus/lib/src/select_input.dart
@@ -21,7 +21,10 @@ class OptimusSelectInput<T> extends StatefulWidget {
     required this.builder,
     this.isEnabled = true,
     this.isRequired = false,
+    this.leading,
     this.prefix,
+    this.trailing,
+    this.suffix,
     this.caption,
     this.secondaryCaption,
     this.error,
@@ -31,6 +34,7 @@ class OptimusSelectInput<T> extends StatefulWidget {
     this.onTextChanged,
     this.focusNode,
     this.readOnly,
+    this.showLoader = false,
   }) : super(key: key);
 
   /// Describes the purpose of the select field.
@@ -42,7 +46,11 @@ class OptimusSelectInput<T> extends StatefulWidget {
   final List<OptimusDropdownTile<T>> items;
   final bool isEnabled;
   final bool isRequired;
+  final Widget? leading;
   final Widget? prefix;
+  final Widget? trailing;
+  final Widget? suffix;
+  final bool showLoader;
   final FocusNode? focusNode;
 
   /// Serves as a helper text for informative or descriptive purposes.
@@ -163,12 +171,15 @@ class _OptimusSelectInput<T> extends State<OptimusSelectInput<T>>
         size: widget.size,
         onChanged: widget.onChanged,
         prefix: widget.prefix,
-        suffix: _icon,
+        leading: widget.leading,
+        suffix: widget.suffix,
+        trailing: _icon,
         focusNode: _effectiveFocusNode,
         placeholderStyle: _textStyle,
         controller: _effectiveController,
         readOnly: widget.readOnly ?? !_isSearchable,
         showCursor: _isSearchable,
+        showLoader: widget.showLoader,
         shouldCloseOnInputTap: !_isSearchable,
       );
 }

--- a/storybook/lib/stories/select_input.dart
+++ b/storybook/lib/stories/select_input.dart
@@ -34,13 +34,24 @@ class _SelectInputStoryState extends State<SelectInputStory> {
   Widget build(BuildContext context) {
     final k = widget.knobs;
 
+    final prefix = k.text(label: 'Prefix');
+    final suffix = k.text(label: 'Suffix');
+    final trailing =
+        k.options(label: 'Trailing Icon', options: exampleIcons, initial: null);
+    final showLoader = k.boolean(label: 'Show loader', initial: false);
+
     return OptimusSelectInput<String>(
       value: _selectedValue,
       isEnabled: k.boolean(label: 'Enabled', initial: true),
       isRequired: k.boolean(label: 'Required'),
-      prefix:
-          k.boolean(label: 'Prefix') ? const Icon(OptimusIcons.search) : null,
+      leading: k.boolean(label: 'Leading Icon')
+          ? const Icon(OptimusIcons.search)
+          : null,
       onTextChanged: k.boolean(label: 'Searchable') ? _onTextChanged : null,
+      prefix: prefix.isNotEmpty ? Text(prefix) : null,
+      suffix: suffix.isNotEmpty ? Text(suffix) : null,
+      trailing: trailing != null ? Icon(trailing) : null,
+      showLoader: showLoader,
       onChanged: (i) => setState(() => _selectedValue = i),
       size: k.options(
         label: 'Size',


### PR DESCRIPTION
#### Summary

RND-103470

### Update Select component.
Most of the changes are based on the changes to the `Input` component, that were merged in https://github.com/MewsSystems/mews-flutter/pull/228

- added missing `leading`, `trailing`, and `suffix` properties.
- some code refactoring: extracted widget for the `OptimusDropdown`.
- added showLoader property.
- updated story
- [**BREAKING CHANGE**] changes in the signature that are continuing the changes from #228. Mainly:
  - `prefix` and `suffix` are meant to be used for the `Text` widgets.
  - for `Icon` and `Image` widgets use `leading` and `trailing` properties.

<details><summary>Screenshots</summary>

New `Select` component with everything enabled.

![CleanShot 2022-08-01 at 13 35 32](https://user-images.githubusercontent.com/9210422/182141603-f2acebe6-a179-4418-8a9f-c6e7369070db.png)

Current `Select` component. The Search icon was displayed because of the breaking change in #228. 

![CleanShot 2022-08-01 at 13 42 47](https://user-images.githubusercontent.com/9210422/182141669-ccfcedd0-f360-4937-bb7c-6831f55f1990.png)


</details> 


#### Testing steps

1. Open Storybook with the `Select` component story.
2. Change the properties of the `Select` component in knobs.
3. The layout of the `Select` component should math the design on the [Select Input Component](https://www.mews.design/7b4bb574e/p/123b08-select-input/)

#### Follow-up issues

RND-111259 - update the usage of the components that had breaking changes.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
