### PR TITLE
fix(optimus): [RND-98858] Incorrect rendering of dropdown button in storybook

### DIFF
--- a/optimus/lib/src/common/dropdown.dart
+++ b/optimus/lib/src/common/dropdown.dart
@@ -99,7 +99,10 @@ class _OptimusDropdownState<T> extends State<OptimusDropdown<T>>
 
     final size = renderObject.size;
 
-    return renderObject.localToGlobal(Offset.zero) & size;
+    final overlay =
+        Overlay.of(context)?.context.findRenderObject() as RenderBox?;
+
+    return renderObject.localToGlobal(Offset.zero, ancestor: overlay) & size;
   }
 
   Widget _buildListView(bool isReversed) => Material(


### PR DESCRIPTION
#### Summary

`OptimusDropdown` was counting on the fact that overlay origin can be different from the global origin. In the case of the Storybook, it was shifted to the right by the width of the section list.

<details><summary>Screenshots</summary>

Before:

![CleanShot 2022-08-02 at 15 23 37@2x](https://user-images.githubusercontent.com/9210422/182387218-a25180a3-f358-4be4-af96-47368f5db055.png)

(it's there, but out of the screen)
![CleanShot 2022-08-02 at 15 22 41@2x](https://user-images.githubusercontent.com/9210422/182387212-547ecae6-afc3-4e47-88e0-1aa269a70bf8.png)

After:

![CleanShot 2022-08-02 at 15 19 35@2x](https://user-images.githubusercontent.com/9210422/182387121-398fcf26-5e06-4137-89c3-6f0528e42c26.png)

![CleanShot 2022-08-02 at 15 24 20@2x](https://user-images.githubusercontent.com/9210422/182387221-76236e8b-ed84-4100-941a-ea8f0c938b69.png)


</details> 

#### Testing steps

1. Open Storybook.
2. Open any Story that uses `OptimusDropdown` component (for example SelectInput or OptimusSearch)
3. Test that the dropdown component is displayed correctly - aligned to the left or to the right side of the anchor widget, depending on which side has more space.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
