### PR TITLE
feat(optimus): use constant font paths

### DIFF
--- a/optimus/lib/optimus.dart
+++ b/optimus/lib/optimus.dart
@@ -68,6 +68,7 @@ export 'src/tag.dart';
 export 'src/theme/theme.dart';
 export 'src/theme/theme_data.dart';
 export 'src/typography/caption.dart';
+export 'src/typography/fonts.dart';
 export 'src/typography/highlight.dart';
 export 'src/typography/label.dart';
 export 'src/typography/paragraph.dart';

--- a/optimus/lib/src/typography/fonts.dart
+++ b/optimus/lib/src/typography/fonts.dart
@@ -1,0 +1,5 @@
+class OptimusFonts {
+  const OptimusFonts._();
+
+  static const openSans = 'packages/optimus/OpenSans';
+}


### PR DESCRIPTION
#### Summary

This PR adds font path in a class.

For the user of this library, rather than doing the following:

```dart
 theme: ThemeData(
  fontFamily: 'packages/optimus/OpenSans',
 ),
```

They would do instead:
```dart
 theme: ThemeData(
  fontFamily: OptimusFonts.openSans,
 ),
```

#### Testing steps

No.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
