### PR TITLE
feat(optimus): expose `useRootNavigator` in showOptimusDialog

### DIFF
--- a/optimus/lib/src/dialogs/dialog.dart
+++ b/optimus/lib/src/dialogs/dialog.dart
@@ -37,6 +37,7 @@ Future<T?> showOptimusDialog<T>({
   OptimusDialogSize size = OptimusDialogSize.regular,
   OptimusDialogType type = OptimusDialogType.common,
   bool isDismissible = true,
+  bool useRootNavigator = true,
 }) =>
     showGeneralDialog(
       context: context,
@@ -57,7 +58,7 @@ Future<T?> showOptimusDialog<T>({
         opacity: CurvedAnimation(parent: animation, curve: Curves.easeOut),
         child: child,
       ),
-      useRootNavigator: true,
+      useRootNavigator: useRootNavigator,
     );
 
 /// A dialog is an overlay on top of a main page which lets a user perform


### PR DESCRIPTION
#### Summary

Exposes `useRootNavigator` argument in showOptimusDialog method.

Use case: To use the nearest navigator that has dependencies injected into its context. (See this bug: https://github.com/MewsSystems/tech-mo/pull/1454)

#### Testing steps

No, just exposing an argument.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
