### PR TITLE
fix(optimus): [RND-122387] Fix onChange behaviour for the DateInput component.

### DIFF
--- a/optimus/lib/src/form/date_input_field.dart
+++ b/optimus/lib/src/form/date_input_field.dart
@@ -65,6 +65,7 @@ class OptimusDateInputField extends StatefulWidget {
 class _OptimusDateInputFieldState extends State<OptimusDateInputField>
     with ThemeGetter {
   late StyledInputController _styleController;
+  String _previousValue = '';
 
   @override
   void didChangeDependencies() {
@@ -111,6 +112,18 @@ class _OptimusDateInputFieldState extends State<OptimusDateInputField>
     if (value != null) {
       return _formatOutput(value);
     }
+  }
+
+  String _onChanged(String value) {
+    if (_previousValue != value) {
+      final result = _styleController.isInputComplete
+          ? _getDateTime(widget.format, value)
+          : null;
+      widget.onChanged?.call(result);
+      _previousValue = value;
+    }
+
+    return value;
   }
 
   String _formatOutput(DateTime value) =>
@@ -183,6 +196,7 @@ class _OptimusDateInputFieldState extends State<OptimusDateInputField>
         controller: _styleController,
         error: widget.error,
         onSubmitted: _handleSubmitted,
+        onChanged: widget.onChanged != null ? _onChanged : null,
         keyboardType: TextInputType.number,
         isRequired: widget.isRequired,
         onTap: widget.onTap,

--- a/optimus/lib/src/form/styled_input_controller.dart
+++ b/optimus/lib/src/form/styled_input_controller.dart
@@ -37,6 +37,8 @@ class StyledInputController extends TextEditingController {
 
     return TextSpan(children: children.reversed.toList(), style: style);
   }
+
+  bool get isInputComplete => !_maskRegExp.hasMatch(text);
 }
 
 final RegExp _maskRegExp = RegExp('[a-zA-z]');


### PR DESCRIPTION
RND-122387

#### Summary

`onChange` wasn't working as expected. Now it would return `null` until the date is fully entered.

#### Testing steps

1. Override the `onChange` callback
2. Test if it would return `null` on an incomplete date (and after clearing) and will return the `DateTime` on a complete date.

#### Follow-up issues

Nope.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
