### PR TITLE
feat: Upgrade dart-code-metrics to 4.19.1 [do not squash]

### DIFF
--- a/kiosk_mode/example/pubspec.yaml
+++ b/kiosk_mode/example/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.8.0
+  mews_pedantic: ^0.9.0
 flutter:
   uses-material-design: true

--- a/kiosk_mode/pubspec.yaml
+++ b/kiosk_mode/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.8.0
+  mews_pedantic: ^0.9.0
 flutter:
   plugin:
     platforms:

--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **FEAT**: Upgrade dart-code-metrics to 4.19.1.
+
 ## 0.8.0
 
 > Note: This release has breaking changes.

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -188,8 +188,10 @@ dart_code_metrics:
     - no-equal-then-else
     - prefer-commenting-analyzer-ignores
     - prefer-const-border-radius
+    - prefer-correct-test-file-name
     - prefer-first
     - prefer-immediate-return
+    - prefer-iterable-of
     - prefer-last
 
   metrics-exclude:

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mews_pedantic
 description: Dart and Flutter static analysis and lint rules incorporated in Mews.
-version: 0.8.0
+version: 0.9.0
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  dart_code_metrics: 4.18.3
+  dart_code_metrics: 4.19.1
   meta: ^1.7.0

--- a/optimus/example/pubspec.yaml
+++ b/optimus/example/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.8.0
+  mews_pedantic: ^0.9.0

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ">=1.0.0 <3.0.0"
-  mews_pedantic: ^0.8.0
+  mews_pedantic: ^0.9.0
 flutter:
   fonts:
     - family: OpenSans

--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.2
-  mews_pedantic: ^0.8.0
+  mews_pedantic: ^0.9.0
   mockito: ^5.0.16
   test: ^1.18.0

--- a/storybook/pubspec.yaml
+++ b/storybook/pubspec.yaml
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.8.0
+  mews_pedantic: ^0.9.0
 flutter:
   uses-material-design: true


### PR DESCRIPTION
#### Summary

Upgraded `dart_code_metrics` to 4.19.1, enabled new rules:

- [prefer-iterable-of](https://dartcodemetrics.dev/docs/rules/common/prefer-iterable-of)
- [prefer-correct-test-file-name](https://dartcodemetrics.dev/docs/rules/common/prefer-correct-test-file-name)

#### Testing steps

No, analyzer update.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
