### PR TITLE
feat(kiosk_mode): [RND-125108] Implement `startKioskMode` on iOS

### DIFF
--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -54,7 +54,6 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
             }
         } ?: result.success(false)
-
     }
 
     private fun stopKioskMode(result: MethodChannel.Result) {

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -55,7 +55,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     private fun stopKioskMode(result: MethodChannel.Result) {
         activity?.stopLockTask()
-        result.success(isInKioskMode() ?: false)
+        result.success(true)
     }
 
 

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -54,7 +54,9 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     private fun stopKioskMode(result: MethodChannel.Result) {
-        val isInKioskMode = isInKioskMode() ?: false
+        // it may happen that isInKioskMode returns null when the service could not be found
+        // in this case, it's better to allow calling stopLockTask() than being stuck in kiosk mode
+        val isInKioskMode = isInKioskMode() ?: true
 
         if(isInKioskMode) {
             activity?.stopLockTask()

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -33,6 +33,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "startKioskMode" -> startKioskMode(result)
             "stopKioskMode" -> stopKioskMode(result)
             "isInKioskMode" -> isInKioskMode(result)
+            "isManagedKiosk" -> isManagedKiosk(result)
             else -> result.notImplemented()
         }
     }
@@ -55,6 +56,17 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun stopKioskMode(result: MethodChannel.Result) {
         activity?.stopLockTask()
         result.success(true)
+    }
+
+
+    private fun isManagedKiosk(result: MethodChannel.Result) {
+        val service = activity?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        if (service == null) {
+            result.success(null)
+            return
+        }
+
+        result.success(service.lockTaskModeState == ActivityManager.LOCK_TASK_MODE_LOCKED)
     }
 
     private fun isInKioskMode(result: MethodChannel.Result) {

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -33,7 +33,6 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "startKioskMode" -> startKioskMode(result)
             "stopKioskMode" -> stopKioskMode(result)
             "isInKioskMode" -> isInKioskMode(result)
-            "isManagedKiosk" -> isManagedKiosk(result)
             else -> result.notImplemented()
         }
     }
@@ -55,18 +54,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     private fun stopKioskMode(result: MethodChannel.Result) {
         activity?.stopLockTask()
-        result.success(null)
-    }
-
-
-    private fun isManagedKiosk(result: MethodChannel.Result) {
-        val service = activity?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
-        if (service == null) {
-            result.success(null)
-            return
-        }
-
-        result.success(service.lockTaskModeState == ActivityManager.LOCK_TASK_MODE_LOCKED)
+        result.success(true)
     }
 
     private fun isInKioskMode(result: MethodChannel.Result) {

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -54,15 +54,17 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     private fun stopKioskMode(result: MethodChannel.Result) {
-        // it may happen that isInKioskMode returns null when the service could not be found
-        // in this case, it's better to allow calling stopLockTask() than being stuck in kiosk mode
-        val isInKioskMode = isInKioskMode() ?: true
-
-        if(isInKioskMode) {
+        fun stopLockTask() {
             activity?.stopLockTask()
             result.success(true)
-        } else {
-            result.success(false)
+        }
+
+        when(isInKioskMode()) {
+            // it may happen that isInKioskMode returns null when the service could not be found
+            // in this case, it's better to allow calling stopLockTask() than being stuck in kiosk mode
+            null -> stopLockTask()
+            true -> stopLockTask()
+            false -> result.success(false)
         }
     }
 

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -48,7 +48,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 try {
                     a.startLockTask()
                     result.success(true)
-                    kioskModeHandler.sendUpdate(true)
+                    kioskModeHandler.setKioskModeState(true)
                 } catch (e: IllegalArgumentException) {
                     result.success(false)
                 }
@@ -61,7 +61,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         fun stopLockTask() {
             activity?.stopLockTask()
             result.success(true)
-            kioskModeHandler.sendUpdate(false)
+            kioskModeHandler.setKioskModeState(false)
         }
 
         when(isInKioskMode()) {

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -58,6 +58,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     private fun stopKioskMode(result: MethodChannel.Result) {
+        activity?.stopLockTask()
         result.success(null)
         kioskModeHandler.emit()
     }

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -55,7 +55,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     private fun stopKioskMode(result: MethodChannel.Result) {
         activity?.stopLockTask()
-        result.success(true)
+        result.success(isInKioskMode() ?: false)
     }
 
 

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -54,8 +54,14 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     private fun stopKioskMode(result: MethodChannel.Result) {
-        activity?.stopLockTask()
-        result.success(true)
+        val isInKioskMode = isInKioskMode() ?: false
+
+        if(isInKioskMode) {
+            activity?.stopLockTask()
+            result.success(true)
+        } else {
+            result.success(false)
+        }
     }
 
 

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -19,13 +19,15 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var channel: MethodChannel
     private lateinit var eventChannel: EventChannel
     private var activity: Activity? = null
+    private lateinit var kioskModeHandler: KioskModeStreamHandler
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, methodChannelName)
         channel.setMethodCallHandler(this)
+        kioskModeHandler = KioskModeStreamHandler(this::isInKioskMode)
 
         eventChannel = EventChannel(flutterPluginBinding.binaryMessenger, eventChannelName)
-        eventChannel.setStreamHandler(KioskModeStreamHandler(this::isInKioskMode))
+        eventChannel.setStreamHandler(kioskModeHandler)
     }
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -46,17 +48,20 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 try {
                     a.startLockTask()
                     result.success(true)
+                    kioskModeHandler.sendUpdate(true)
                 } catch (e: IllegalArgumentException) {
                     result.success(false)
                 }
             }
         } ?: result.success(false)
+
     }
 
     private fun stopKioskMode(result: MethodChannel.Result) {
         fun stopLockTask() {
             activity?.stopLockTask()
             result.success(true)
+            kioskModeHandler.sendUpdate(false)
         }
 
         when(isInKioskMode()) {

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModePlugin.kt
@@ -48,7 +48,7 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 try {
                     a.startLockTask()
                     result.success(true)
-                    kioskModeHandler.setKioskModeState(true)
+                    kioskModeHandler.emit()
                 } catch (e: IllegalArgumentException) {
                     result.success(false)
                 }
@@ -58,19 +58,8 @@ class KioskModePlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     private fun stopKioskMode(result: MethodChannel.Result) {
-        fun stopLockTask() {
-            activity?.stopLockTask()
-            result.success(true)
-            kioskModeHandler.setKioskModeState(false)
-        }
-
-        when(isInKioskMode()) {
-            // it may happen that isInKioskMode returns null when the service could not be found
-            // in this case, it's better to allow calling stopLockTask() than being stuck in kiosk mode
-            null -> stopLockTask()
-            true -> stopLockTask()
-            false -> result.success(false)
-        }
+        result.success(null)
+        kioskModeHandler.emit()
     }
 
 

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -37,5 +37,5 @@ class KioskModeStreamHandler(val getKioskModeState: () -> Boolean?) : EventChann
         timer = null
     }
 
-    fun sendUpdate(currentState: Boolean?) =  postEvent(currentState)
+    fun setKioskModeState(isInKioskMode: Boolean?) =  postEvent(isInKioskMode)
 }

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -17,16 +17,7 @@ class KioskModeStreamHandler(val getKioskModeState: () -> Boolean?) : EventChann
         val period: Int = (arguments as Map<*, *>)["androidQueryPeriod"] as Int
         eventSink = events
         timer = fixedRateTimer(period = period.toLong(), daemon = true) {
-           postEvent(getKioskModeState())
-        }
-    }
-
-    private fun postEvent(currentState: Boolean?) {
-        if (currentState != previousState) {
-            previousState = currentState
-            eventSink?.let {
-                mainHandler.post { it.success(currentState) }
-            }
+          emit()
         }
     }
 
@@ -37,5 +28,13 @@ class KioskModeStreamHandler(val getKioskModeState: () -> Boolean?) : EventChann
         timer = null
     }
 
-    fun setKioskModeState(isInKioskMode: Boolean?) =  postEvent(isInKioskMode)
+    fun emit() {
+        val currentState = getKioskModeState()
+        if (currentState != previousState) {
+            previousState = currentState
+            eventSink?.let {
+                mainHandler.post { it.success(currentState) }
+            }
+        }
+    }
 }

--- a/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
+++ b/kiosk_mode/android/src/main/kotlin/com/mews/kiosk_mode/KioskModeStreamHandler.kt
@@ -17,12 +17,15 @@ class KioskModeStreamHandler(val getKioskModeState: () -> Boolean?) : EventChann
         val period: Int = (arguments as Map<*, *>)["androidQueryPeriod"] as Int
         eventSink = events
         timer = fixedRateTimer(period = period.toLong(), daemon = true) {
-            val currentState = getKioskModeState()
-            if (currentState != previousState) {
-                previousState = currentState
-                eventSink?.let {
-                    mainHandler.post { it.success(currentState) }
-                }
+           postEvent(getKioskModeState())
+        }
+    }
+
+    private fun postEvent(currentState: Boolean?) {
+        if (currentState != previousState) {
+            previousState = currentState
+            eventSink?.let {
+                mainHandler.post { it.success(currentState) }
             }
         }
     }
@@ -33,4 +36,6 @@ class KioskModeStreamHandler(val getKioskModeState: () -> Boolean?) : EventChann
         timer?.cancel()
         timer = null
     }
+
+    fun sendUpdate(currentState: Boolean?) =  postEvent(currentState)
 }

--- a/kiosk_mode/example/lib/main.dart
+++ b/kiosk_mode/example/lib/main.dart
@@ -37,16 +37,42 @@ class _HomeState extends State<_Home> {
   Widget build(BuildContext context) => Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (Platform.isAndroid) ...[
-            const MaterialButton(
-              onPressed: startKioskMode,
-              child: Text('Start Kiosk Mode'),
+          MaterialButton(
+            onPressed: () => startKioskMode().then(
+              (value) => ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    value
+                        ? 'Kiosk mode started'
+                        : Platform.isIOS
+                            ? 'Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM) and the app itself must be enabled for this mode by MDM.'
+                            : 'Kiosk mode could not be started.',
+                  ),
+                ),
+              ),
             ),
-            const MaterialButton(
-              onPressed: stopKioskMode,
-              child: Text('Stop Kiosk Mode'),
+            child: const Text('Start Kiosk Mode'),
+          ),
+          MaterialButton(
+            onPressed: () => stopKioskMode().then(
+              (value) => ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    value ? 'Kiosk mode stopped.' : 'Kiosk mode could not be stopped or wasn\'t active to begin with.',
+                  ),
+                ),
+              ),
             ),
-          ],
+            child: const Text('Stop Kiosk Mode'),
+          ),
+          MaterialButton(
+            onPressed: () => isManagedKiosk().then(
+              (value) => ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Kiosk is managed: $value')),
+              ),
+            ),
+            child: const Text('Is Managed Kiosk'),
+          ),
           MaterialButton(
             onPressed: () => getKioskMode().then(
               (value) => ScaffoldMessenger.of(context).showSnackBar(

--- a/kiosk_mode/example/lib/main.dart
+++ b/kiosk_mode/example/lib/main.dart
@@ -48,29 +48,29 @@ class _HomeState extends State<_Home> {
               MaterialButton(
                 onPressed: mode == KioskMode.enabled
                     ? null
-                    : () => startKioskMode()
-                        .then(
-                          (didStart) => didStart
-                              ? 'Kiosk mode started.'
-                              : Platform.isIOS
-                                  ? 'Single App mode is supported only for devices that are supervised using '
-                                      'Mobile Device Management (MDM) and the app itself must be enabled '
-                                      'for this mode by MDM.'
-                                  : 'Kiosk mode could not be started. Please try again.',
-                        )
-                        .then(_showSnackBar),
+                    : () => startKioskMode().then(
+                          (didStart) {
+                            if (!didStart && Platform.isIOS) {
+                              _showSnackBar(
+                                'Single App mode is supported only for devices that are supervised using '
+                                'Mobile Device Management (MDM) and the app itself must be enabled '
+                                'for this mode by MDM.',
+                              );
+                            }
+                          },
+                        ),
                 child: const Text('Start Kiosk Mode'),
               ),
               MaterialButton(
                 onPressed: mode == KioskMode.disabled
                     ? null
-                    : () => stopKioskMode()
-                        .then(
-                          (didStop) => didStop
-                              ? 'Kiosk mode stopped.'
-                              : 'Kiosk mode could not be stopped or wasn\'t active to begin with.',
-                        )
-                        .then(_showSnackBar),
+                    : () => stopKioskMode().then((didStop) {
+                          if (didStop == false) {
+                            _showSnackBar(
+                              'Kiosk mode could not be stopped or wasn\'t active to begin with.',
+                            );
+                          }
+                        }),
                 child: const Text('Stop Kiosk Mode'),
               ),
               MaterialButton(

--- a/kiosk_mode/example/lib/main.dart
+++ b/kiosk_mode/example/lib/main.dart
@@ -33,10 +33,8 @@ class _Home extends StatefulWidget {
 class _HomeState extends State<_Home> {
   late final Stream<KioskMode> _currentMode = watchKioskMode();
 
-  Future<void> _showSnackBar(String message) async {
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
-  }
+  void _showSnackBar(String message) => ScaffoldMessenger.of(context)
+      .showSnackBar(SnackBar(content: Text(message)));
 
   @override
   Widget build(BuildContext context) => StreamBuilder(
@@ -53,9 +51,11 @@ class _HomeState extends State<_Home> {
                     : () => startKioskMode()
                         .then(
                           (didStart) => didStart
-                              ? 'Kiosk mode started'
+                              ? 'Kiosk mode started.'
                               : Platform.isIOS
-                                  ? 'Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM) and the app itself must be enabled for this mode by MDM.'
+                                  ? 'Single App mode is supported only for devices that are supervised using '
+                                      'Mobile Device Management (MDM) and the app itself must be enabled '
+                                      'for this mode by MDM.'
                                   : 'Kiosk mode could not be started. Please try again.',
                         )
                         .then(_showSnackBar),
@@ -77,7 +77,7 @@ class _HomeState extends State<_Home> {
                 onPressed: () => isManagedKiosk()
                     .then((isManaged) => 'Kiosk is managed: $isManaged')
                     .then(_showSnackBar),
-                child: const Text('Is Managed Kiosk'),
+                child: const Text('Check if managed'),
               ),
               MaterialButton(
                 onPressed: () => getKioskMode()
@@ -85,9 +85,7 @@ class _HomeState extends State<_Home> {
                     .then(_showSnackBar),
                 child: const Text('Check mode'),
               ),
-              Text(
-                'Current mode: ${snapshot.data}',
-              ),
+              Text('Current mode: ${snapshot.data}'),
             ],
           );
         },

--- a/kiosk_mode/example/lib/main.dart
+++ b/kiosk_mode/example/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:kiosk_mode/kiosk_mode.dart';
 
@@ -34,19 +33,25 @@ class _Home extends StatefulWidget {
 class _HomeState extends State<_Home> {
   late final Stream<KioskMode> _currentMode = watchKioskMode();
 
-  void _showSnackBar(String message) => ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(message)));
+  void _showSnackBar(String message) => ScaffoldMessenger.of(context)
+      .showSnackBar(SnackBar(content: Text(message)));
 
   void _handleStart(bool didStart) {
     if (!didStart && Platform.isIOS) {
       _showSnackBar(
-        'Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM) and'
-        ' the app itself must be enabled for this mode by MDM.',
+        'Single App mode is supported only for devices that are supervised'
+        ' using Mobile Device Management (MDM) and the app itself must'
+        ' be enabled for this mode by MDM.',
       );
     }
   }
 
   void _handleStop(bool? didStop) {
-    if (didStop == false) _showSnackBar('Kiosk mode could not be stopped or was not active to begin with.');
+    if (didStop == false) {
+      _showSnackBar(
+        'Kiosk mode could not be stopped or was not active to begin with.',
+      );
+    }
   }
 
   @override
@@ -59,20 +64,27 @@ class _HomeState extends State<_Home> {
             mainAxisSize: MainAxisSize.min,
             children: [
               MaterialButton(
-                onPressed: mode == null || mode == KioskMode.enabled ? null : () => startKioskMode().then(_handleStart),
+                onPressed: mode == null || mode == KioskMode.enabled
+                    ? null
+                    : () => startKioskMode().then(_handleStart),
                 child: const Text('Start Kiosk Mode'),
               ),
               MaterialButton(
-                onPressed: mode == null || mode == KioskMode.disabled ? null : () => stopKioskMode().then(_handleStop),
+                onPressed: mode == null || mode == KioskMode.disabled
+                    ? null
+                    : () => stopKioskMode().then(_handleStop),
                 child: const Text('Stop Kiosk Mode'),
               ),
               MaterialButton(
-                onPressed: () =>
-                    isManagedKiosk().then((isManaged) => 'Kiosk is managed: $isManaged').then(_showSnackBar),
+                onPressed: () => isManagedKiosk()
+                    .then((isManaged) => 'Kiosk is managed: $isManaged')
+                    .then(_showSnackBar),
                 child: const Text('Check if managed'),
               ),
               MaterialButton(
-                onPressed: () => getKioskMode().then((mode) => 'Kiosk mode: $mode').then(_showSnackBar),
+                onPressed: () => getKioskMode()
+                    .then((mode) => 'Kiosk mode: $mode')
+                    .then(_showSnackBar),
                 child: const Text('Check mode'),
               ),
               Text('Current mode: ${snapshot.data}'),

--- a/kiosk_mode/example/lib/main.dart
+++ b/kiosk_mode/example/lib/main.dart
@@ -58,7 +58,9 @@ class _HomeState extends State<_Home> {
               (value) => ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: Text(
-                    value ? 'Kiosk mode stopped.' : 'Kiosk mode could not be stopped or wasn\'t active to begin with.',
+                    value
+                        ? 'Kiosk mode stopped.'
+                        : 'Kiosk mode could not be stopped or wasn\'t active to begin with.',
                   ),
                 ),
               ),

--- a/kiosk_mode/example/lib/main.dart
+++ b/kiosk_mode/example/lib/main.dart
@@ -56,7 +56,7 @@ class _HomeState extends State<_Home> {
                               ? 'Kiosk mode started'
                               : Platform.isIOS
                                   ? 'Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM) and the app itself must be enabled for this mode by MDM.'
-                                  : 'Kiosk mode could not be started.',
+                                  : 'Kiosk mode could not be started. Please try again.',
                         )
                         .then(_showSnackBar),
                 child: const Text('Start Kiosk Mode'),

--- a/kiosk_mode/ios/Classes/SwiftKioskModePlugin.swift
+++ b/kiosk_mode/ios/Classes/SwiftKioskModePlugin.swift
@@ -12,13 +12,32 @@ public class SwiftKioskModePlugin: NSObject, FlutterPlugin {
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        if (call.method == "isInKioskMode") {
-            result(UIAccessibility.isGuidedAccessEnabled)
-        } else if (call.method == "isManagedKiosk") {
-            result(false)
-        } else {
+        switch call.method {
+        case "isInKioskMode":
+            isInKioskMode(result)
+        case "startKioskMode":
+            startKioskMode(result)
+        case "stopKioskMode":
+            stopKioskMode(result)
+        default:
             result(FlutterMethodNotImplemented)
         }
+    }
+    
+    private func isInKioskMode(_ result: @escaping FlutterResult) {
+        result(UIAccessibility.isGuidedAccessEnabled)
+    }
+
+    private func startKioskMode(_ result: @escaping FlutterResult) {
+        requestGuidedAccessSession(enabled: true, completionHandler: { result($0) })
+    }
+    
+    private func stopKioskMode(_ result: @escaping FlutterResult) {
+        requestGuidedAccessSession(enabled: false, completionHandler: { result($0) })
+    }
+    
+    private func requestGuidedAccessSession(enabled: Bool, completionHandler: @escaping (Bool) -> Void) {
+        UIAccessibility.requestGuidedAccessSession(enabled: enabled, completionHandler: completionHandler)
     }
 }
 

--- a/kiosk_mode/ios/Classes/SwiftKioskModePlugin.swift
+++ b/kiosk_mode/ios/Classes/SwiftKioskModePlugin.swift
@@ -15,6 +15,8 @@ public class SwiftKioskModePlugin: NSObject, FlutterPlugin {
         switch call.method {
         case "isInKioskMode":
             isInKioskMode(result)
+        case "isManagedKiosk":
+            isManagedKiosk(result)
         case "startKioskMode":
             startKioskMode(result)
         case "stopKioskMode":
@@ -26,6 +28,10 @@ public class SwiftKioskModePlugin: NSObject, FlutterPlugin {
     
     private func isInKioskMode(_ result: @escaping FlutterResult) {
         result(UIAccessibility.isGuidedAccessEnabled)
+    }
+    
+    private func isManagedKiosk(_ result: @escaping FlutterResult) {
+        result(false)
     }
 
     private func startKioskMode(_ result: @escaping FlutterResult) {

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -25,7 +25,7 @@ enum KioskMode {
 /// On Android, [Activity.startLockTask()](https://developer.android.com/reference/android/app/Activity#startLockTask())
 /// is used.
 ///
-/// For iOS,
+/// On iOS,
 /// [UIAccessibility.requestGuidedAccessSession](https://developer.apple.com/documentation/uikit/uiaccessibility/1615186-requestguidedaccesssession) is used.
 /// Entering Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM), and
 /// the app itself must be enabled for this mode by MDM. Otherwise the result will always be `false`.
@@ -33,8 +33,7 @@ Future<bool> startKioskMode() => _channel
     .invokeMethod<bool>('startKioskMode')
     .then((value) => value ?? false);
 
-/// On Android, stops the current task from being locked. For iOS, exits the Single App mode.
-///
+/// On Android, stops the current task from being locked. On iOS, exits the Single App mode.
 Future<bool> stopKioskMode() => _channel
     .invokeMethod<bool>('stopKioskMode')
     .then((value) => value ?? false);

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -18,23 +18,26 @@ enum KioskMode {
   disabled,
 }
 
-/// Request to put this activity in a mode where the user is locked to a
-/// restricted set of applications.
+/// Requests the platform to restrict the current user to the app.
 ///
-/// Returns true, if platform satisfied the request successfully,
-/// false - otherwise.
+/// Returns `true`, if platform satisfied the request successfully, `false` - otherwise.
 ///
-/// It's only supported on Android currently, where it calls `startLockTask`.
-/// It will throw `FlutterMethodNotImplemented` on iOS.
+/// On Android, [Activity.startLockTask()](https://developer.android.com/reference/android/app/Activity#startLockTask())
+/// is used.
+///
+/// For iOS, [
+/// UIAccessibility.requestGuidedAccessSession](https://developer.apple.com/documentation/uikit/uiaccessibility/1615186-requestguidedaccesssession) is used.
+/// Entering Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM), and
+/// the app itself must be enabled for this mode by MDM. Otherwise the result will always be `false`.
 Future<bool> startKioskMode() => _channel
     .invokeMethod<bool>('startKioskMode')
     .then((value) => value ?? false);
 
-/// Stop the current task from being locked.
+/// On Android, stops the current task from being locked. For iOS, exits the Single App mode.
 ///
-/// It's only supported on Android currently, where it calls `stopLockTask`.
-/// It will throw `FlutterMethodNotImplemented` on iOS.
-Future<void> stopKioskMode() => _channel.invokeMethod('stopKioskMode');
+Future<bool> stopKioskMode() => _channel
+    .invokeMethod<bool>('stopKioskMode')
+    .then((value) => value ?? false);
 
 /// Returns the current [KioskMode].
 ///
@@ -44,19 +47,6 @@ Future<void> stopKioskMode() => _channel.invokeMethod('stopKioskMode');
 Future<KioskMode> getKioskMode() => _channel
     .invokeMethod<bool>('isInKioskMode')
     .then((value) => value == true ? KioskMode.enabled : KioskMode.disabled);
-
-/// Returns `true`, if app is in a proper managed kiosk mode.
-///
-/// On Android, it checks for `LOCK_TASK_MODE_LOCKED` and may return `false`,
-/// while [getKioskMode] returns [KioskMode.enabled]. In that case it would mean
-/// that the app is only pinned by user and doesn't represent a proper kiosk,
-/// i.e. it isn't managed by Device Policy Controller on Android.
-///
-/// On iOS, it always returns `false`, as this package doesn't support
-/// detection of Apple Business Manager yet.
-Future<bool> isManagedKiosk() => _channel
-    .invokeMethod<bool>('isManagedKiosk')
-    .then((value) => value == true);
 
 /// Returns the stream with [KioskMode].
 ///

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -22,9 +22,9 @@ enum KioskMode {
 ///
 /// Returns `true`, if platform satisfied the request successfully, `false` - otherwise.
 ///
-/// On Android, [Activity.startLockTask][1] is used.
+/// On Android, [Activity.startLockTask][1] is called.
 ///
-/// On iOS, [UIAccessibility.requestGuidedAccessSession][2] is used.
+/// On iOS, [UIAccessibility.requestGuidedAccessSession][2] is called.
 /// Entering Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM), and
 /// the app itself must be enabled for this mode by MDM. Otherwise the result will always be `false`.
 ///
@@ -36,8 +36,9 @@ Future<bool> startKioskMode() => _channel
 
 /// On Android, stops the current task from being locked. On iOS, exits the Single App mode.
 ///
-/// On Android, the result will be `true` if the previous mode was [KioskMode.enabled] and [Activity.stopLockTask][1]
-/// will be called. Otherwise, the result will be `false`. Note: [Activity.stopLockTask][1] does not guaranteed LockTask
+/// On Android, the result will be `true` if the activity is locked or screen pinning is enabled
+/// and [Activity.stopLockTask][1] will be called.
+///  Otherwise, the result will be `false`. Note: [Activity.stopLockTask][1] does not guaranteed LockTask
 /// or screen pinning mode will be stopped.
 ///
 /// On iOS, the result will be `true` if the app was in Single App mode, `false` - otherwise.

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -22,22 +22,27 @@ enum KioskMode {
 ///
 /// Returns `true`, if platform satisfied the request successfully, `false` - otherwise.
 ///
-/// On Android, [Activity.startLockTask()](https://developer.android.com/reference/android/app/Activity#startLockTask())
-/// is used.
+/// On Android, [Activity.startLockTask][1] is used.
 ///
-/// On iOS,
-/// [UIAccessibility.requestGuidedAccessSession](https://developer.apple.com/documentation/uikit/uiaccessibility/1615186-requestguidedaccesssession) is used.
+/// On iOS, [UIAccessibility.requestGuidedAccessSession][2] is used.
 /// Entering Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM), and
 /// the app itself must be enabled for this mode by MDM. Otherwise the result will always be `false`.
+///
+/// [1]: https://developer.android.com/reference/android/app/Activity#startLockTask()
+/// [2]: https://developer.apple.com/documentation/uikit/uiaccessibility/1615186-requestguidedaccesssession/
 Future<bool> startKioskMode() => _channel
     .invokeMethod<bool>('startKioskMode')
     .then((value) => value ?? false);
 
 /// On Android, stops the current task from being locked. On iOS, exits the Single App mode.
 ///
-/// On Android, the result will always be `true`.
+/// On Android, the result will be `true` if the previous mode was [KioskMode.enabled] and [Activity.stopLockTask][1]
+/// was called. Otherwise, the result will be `false`. Note: [Activity.stopLockTask][1] does not guaranteed LockTask
+/// or screen pinning mode will be stopped.
 ///
 /// On iOS, the result will be `true` if the app was in Single App mode, `false` - otherwise.
+///
+/// [1]: https://developer.android.com/reference/android/app/Activity#stopLockTask()
 Future<bool> stopKioskMode() => _channel
     .invokeMethod<bool>('stopKioskMode')
     .then((value) => value ?? false);

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -36,17 +36,14 @@ Future<bool> startKioskMode() => _channel
 
 /// On Android, stops the current task from being locked. On iOS, exits the Single App mode.
 ///
-/// On Android, the result will be `true` if the activity is locked or screen pinning is enabled
-/// and [Activity.stopLockTask][1] will be called.
-///  Otherwise, the result will be `false`. Note: [Activity.stopLockTask][1] does not guaranteed LockTask
+/// On Android, the result will always be `null`.
+/// Note: [Activity.stopLockTask][1] does not guaranteed LockTask
 /// or screen pinning mode will be stopped.
 ///
-/// On iOS, the result will be `true` if the app was in Single App mode, `false` - otherwise.
+/// On iOS, the result will be `true` if the request was fulfilled, `false` - otherwise.
 ///
 /// [1]: https://developer.android.com/reference/android/app/Activity#stopLockTask()
-Future<bool> stopKioskMode() => _channel
-    .invokeMethod<bool>('stopKioskMode')
-    .then((value) => value ?? false);
+Future<bool?> stopKioskMode() => _channel.invokeMethod<bool>('stopKioskMode');
 
 /// Returns the current [KioskMode].
 ///

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -37,7 +37,7 @@ Future<bool> startKioskMode() => _channel
 /// On Android, stops the current task from being locked. On iOS, exits the Single App mode.
 ///
 /// On Android, the result will be `true` if the previous mode was [KioskMode.enabled] and [Activity.stopLockTask][1]
-/// was called. Otherwise, the result will be `false`. Note: [Activity.stopLockTask][1] does not guaranteed LockTask
+/// will be called. Otherwise, the result will be `false`. Note: [Activity.stopLockTask][1] does not guaranteed LockTask
 /// or screen pinning mode will be stopped.
 ///
 /// On iOS, the result will be `true` if the app was in Single App mode, `false` - otherwise.

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -34,6 +34,10 @@ Future<bool> startKioskMode() => _channel
     .then((value) => value ?? false);
 
 /// On Android, stops the current task from being locked. On iOS, exits the Single App mode.
+///
+/// On Android, the result will always be `true`.
+///
+/// On iOS, the result will be `true` if the app was in Single App mode, `false` - otherwise.
 Future<bool> stopKioskMode() => _channel
     .invokeMethod<bool>('stopKioskMode')
     .then((value) => value ?? false);

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -47,6 +47,19 @@ Future<KioskMode> getKioskMode() => _channel
     .invokeMethod<bool>('isInKioskMode')
     .then((value) => value == true ? KioskMode.enabled : KioskMode.disabled);
 
+/// Returns `true`, if app is in a proper managed kiosk mode.
+///
+/// On Android, it checks for `LOCK_TASK_MODE_LOCKED` and may return `false`,
+/// while [getKioskMode] returns [KioskMode.enabled]. In that case it would mean
+/// that the app is only pinned by user and doesn't represent a proper kiosk,
+/// i.e. it isn't managed by Device Policy Controller on Android.
+///
+/// On iOS, it always returns `false`, as this package doesn't support
+/// detection of Apple Business Manager yet.
+Future<bool> isManagedKiosk() => _channel
+    .invokeMethod<bool>('isManagedKiosk')
+    .then((value) => value == true);
+
 /// Returns the stream with [KioskMode].
 ///
 /// The initial value of the stream will always be from [getKioskMode].

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -36,9 +36,8 @@ Future<bool> startKioskMode() => _channel
 
 /// On Android, stops the current task from being locked. On iOS, exits the Single App mode.
 ///
-/// On Android, the result will always be `null`.
-/// Note: [Activity.stopLockTask][1] does not guaranteed LockTask
-/// or screen pinning mode will be stopped.
+/// On Android, the result will always be `null`, as [Activity.stopLockTask][1] does not guaranteed that a task will be
+/// unlocked, or screen pinning will be stopped.
 ///
 /// On iOS, the result will be `true` if the request was fulfilled, `false` - otherwise.
 ///

--- a/kiosk_mode/lib/kiosk_mode.dart
+++ b/kiosk_mode/lib/kiosk_mode.dart
@@ -25,8 +25,8 @@ enum KioskMode {
 /// On Android, [Activity.startLockTask()](https://developer.android.com/reference/android/app/Activity#startLockTask())
 /// is used.
 ///
-/// For iOS, [
-/// UIAccessibility.requestGuidedAccessSession](https://developer.apple.com/documentation/uikit/uiaccessibility/1615186-requestguidedaccesssession) is used.
+/// For iOS,
+/// [UIAccessibility.requestGuidedAccessSession](https://developer.apple.com/documentation/uikit/uiaccessibility/1615186-requestguidedaccesssession) is used.
 /// Entering Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM), and
 /// the app itself must be enabled for this mode by MDM. Otherwise the result will always be `false`.
 Future<bool> startKioskMode() => _channel

--- a/kiosk_mode/test/kiosk_mode_test.dart
+++ b/kiosk_mode/test/kiosk_mode_test.dart
@@ -31,4 +31,9 @@ void main() {
     await getKioskMode();
     expect(calls, ['isInKioskMode']);
   });
+
+  test('isManagedKiosk', () async {
+    await isManagedKiosk();
+    expect(calls, ['isManagedKiosk']);
+  });
 }

--- a/kiosk_mode/test/kiosk_mode_test.dart
+++ b/kiosk_mode/test/kiosk_mode_test.dart
@@ -31,9 +31,4 @@ void main() {
     await getKioskMode();
     expect(calls, ['isInKioskMode']);
   });
-
-  test('isManagedKiosk', () async {
-    await isManagedKiosk();
-    expect(calls, ['isManagedKiosk']);
-  });
 }


### PR DESCRIPTION
#### Summary

RND-125108

This PR adds implementations for `startKioskMode` and `stopKioskMode` on iOS.

- `stopKioskMode` signature changed to allow querying wether the response was successful or not from iOS and for Android is changed as well
- `watchKioskMode` will be more reactive. 

From Apple's documentation, the method will work when:
- Device is supervised in Apple Business Manager
- App using this package is allowed to run under Single App Mode

>You can use this method to lock your app into Single App mode and to release it from that mode later. For example, a test-taking app might enter this mode at the beginning of a test and exit it when the user completes the test. Entering Single App mode is supported only for devices that are supervised using Mobile Device Management (MDM), and the app itself must be enabled for this mode by MDM. You must balance each call to enter Single App mode with a call to exit that mode.
Because entering or exiting Single App mode might take some time, this method executes asynchronously and notifies you of the results using the completionHandler block.

https://developer.apple.com/documentation/uikit/uiaccessibility/1615186-requestguidedaccesssession

#### Testing steps

Unfortunately, without having a supervised device, there isn't really a way to test this.  
Functionality was dev-tested with the response from the `completionHandler` mocked.
```swift
 requestGuidedAccessSession(enabled: true, completionHandler: { result($0) })
```
```swift
 requestGuidedAccessSession(enabled: true, completionHandler: { result(!$0) })
```

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
