### PR TITLE
feat(optimus): [RND-126798] Implement new elevations and border radiuses for mobile

### DIFF
--- a/optimus/lib/src/banner.dart
+++ b/optimus/lib/src/banner.dart
@@ -75,7 +75,7 @@ class OptimusBanner extends StatelessWidget {
     return DecoratedBox(
       decoration: BoxDecoration(
         color: _backgroundColor(theme),
-        borderRadius: const BorderRadius.all(borderRadius50),
+        borderRadius: const BorderRadius.all(borderRadius100),
       ),
       child: Padding(
         padding: const EdgeInsets.only(left: 18),

--- a/optimus/lib/src/border_radius.dart
+++ b/optimus/lib/src/border_radius.dart
@@ -4,3 +4,4 @@ const Radius borderRadius0 = Radius.zero;
 const Radius borderRadius25 = Radius.circular(2);
 const Radius borderRadius50 = Radius.circular(4);
 const Radius borderRadius100 = Radius.circular(8);
+const Radius borderRadius200 = Radius.circular(16);

--- a/optimus/lib/src/button/base_button.dart
+++ b/optimus/lib/src/button/base_button.dart
@@ -16,7 +16,7 @@ class BaseButton extends StatelessWidget {
     this.badgeLabel,
     this.size = OptimusWidgetSize.large,
     this.variant = OptimusButtonVariant.defaultButton,
-    this.borderRadius = const BorderRadius.all(borderRadius50),
+    this.borderRadius = const BorderRadius.all(borderRadius100),
   }) : super(key: key);
 
   final VoidCallback? onPressed;
@@ -46,7 +46,7 @@ class BaseButton extends StatelessWidget {
   Widget _buildBadgeLabel(String badgeLabel, OptimusThemeData theme) =>
       SizedBox(
         child: ClipRRect(
-          borderRadius: const BorderRadius.all(Radius.circular(16)),
+          borderRadius: const BorderRadius.all(borderRadius200),
           child: Container(
             height: 16,
             color: _textColor(theme),

--- a/optimus/lib/src/card.dart
+++ b/optimus/lib/src/card.dart
@@ -209,26 +209,26 @@ class _Card extends StatelessWidget {
   BorderRadius get _borderRadius {
     switch (attachment) {
       case OptimusCardAttachment.none:
-        return const BorderRadius.all(borderRadius100);
+        return const BorderRadius.all(borderRadius200);
       case OptimusCardAttachment.left:
         return const BorderRadius.only(
-          topRight: borderRadius100,
-          bottomRight: borderRadius100,
+          topRight: borderRadius200,
+          bottomRight: borderRadius200,
         );
       case OptimusCardAttachment.right:
         return const BorderRadius.only(
-          topLeft: borderRadius100,
-          bottomLeft: borderRadius100,
+          topLeft: borderRadius200,
+          bottomLeft: borderRadius200,
         );
       case OptimusCardAttachment.top:
         return const BorderRadius.only(
-          bottomLeft: borderRadius100,
-          bottomRight: borderRadius100,
+          bottomLeft: borderRadius200,
+          bottomRight: borderRadius200,
         );
       case OptimusCardAttachment.bottom:
         return const BorderRadius.only(
-          topLeft: borderRadius100,
-          topRight: borderRadius100,
+          topLeft: borderRadius200,
+          topRight: borderRadius200,
         );
     }
   }

--- a/optimus/lib/src/chat/chat.dart
+++ b/optimus/lib/src/chat/chat.dart
@@ -1,6 +1,7 @@
 import 'package:dfunc/dfunc.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
+import 'package:optimus/src/border_radius.dart';
 import 'package:optimus/src/chat/optimus_chat_input.dart';
 import 'package:optimus/src/typography/presets.dart';
 
@@ -318,7 +319,7 @@ class _StatusCircle extends StatelessWidget {
       width: 13,
       height: 13,
       decoration: BoxDecoration(
-        borderRadius: const BorderRadius.all(Radius.circular(8)),
+        borderRadius: const BorderRadius.all(borderRadius100),
         border: Border.all(
           width: 1.2,
           color: theme.isDark

--- a/optimus/lib/src/common/field_wrapper.dart
+++ b/optimus/lib/src/common/field_wrapper.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
+import 'package:optimus/src/border_radius.dart';
 import 'package:optimus/src/common/field_error.dart';
 import 'package:optimus/src/common/field_label.dart';
 import 'package:optimus/src/constants.dart';
@@ -109,7 +110,7 @@ class _FieldWrapper extends State<FieldWrapper> with ThemeGetter {
                         ? BoxDecoration(
                             color: _background,
                             borderRadius:
-                                const BorderRadius.all(Radius.circular(4)),
+                                const BorderRadius.all(borderRadius100),
                             border: Border.all(color: _borderColor, width: 1),
                           )
                         : null,

--- a/optimus/lib/src/dropdown/dropdown.dart
+++ b/optimus/lib/src/dropdown/dropdown.dart
@@ -51,7 +51,7 @@ class _DropdownContent<T> extends StatelessWidget {
     final theme = OptimusTheme.of(context);
 
     return BoxDecoration(
-      borderRadius: const BorderRadius.all(borderRadius50),
+      borderRadius: const BorderRadius.all(borderRadius100),
       color: theme.isDark ? theme.colors.neutral500 : theme.colors.neutral0,
       boxShadow: elevation50,
     );

--- a/optimus/lib/src/elevation.dart
+++ b/optimus/lib/src/elevation.dart
@@ -5,42 +5,49 @@ const List<BoxShadow> elevation0 = [];
 
 const List<BoxShadow> elevation25 = [
   BoxShadow(
-    color: _blackt8,
+    color: _shadowt8,
     offset: Offset(0, 4),
-    blurRadius: 8,
+    blurRadius: 4,
+    spreadRadius: -2,
   ),
   BoxShadow(
-    color: _blackt8,
+    color: _shadowt16,
     offset: Offset(0, -1),
     blurRadius: 4,
+    spreadRadius: -2,
   ),
 ];
 
 const List<BoxShadow> elevation50 = [
   BoxShadow(
-    color: _blackt8,
+    color: _shadowt10,
     offset: Offset(0, 8),
-    blurRadius: 16,
+    blurRadius: 24,
+    spreadRadius: -4,
   ),
   BoxShadow(
-    color: _blackt8,
-    offset: Offset(0, -1),
-    blurRadius: 4,
+    color: _shadowt10,
+    offset: Offset(0, 6),
+    blurRadius: 12,
+    spreadRadius: -6,
   ),
 ];
 
 const List<BoxShadow> elevation100 = [
   BoxShadow(
-    color: _blackt16,
-    offset: Offset(0, 8),
-    blurRadius: 24,
+    color: _shadowt10,
+    offset: Offset(0, 18),
+    blurRadius: 88,
+    spreadRadius: -4,
   ),
   BoxShadow(
-    color: _blackt8,
-    offset: Offset(0, -1),
-    blurRadius: 4,
+    color: _shadowt10,
+    offset: Offset(0, 12),
+    blurRadius: 28,
+    spreadRadius: -6,
   ),
 ];
 
-const _blackt8 = Color(0x14000000);
-const _blackt16 = Color(0x28000000);
+const _shadowt8 = Color(0x14242435);
+const _shadowt10 = Color(0x1a242435);
+const _shadowt16 = Color(0x29242435);

--- a/optimus/lib/src/tag.dart
+++ b/optimus/lib/src/tag.dart
@@ -109,7 +109,7 @@ class _TagState extends State<_Tag> with ThemeGetter {
         decoration: BoxDecoration(
           color: widget.onRemoved != null ? theme.colors.neutral50 : _tagColor,
           border: Border.all(color: _borderColor),
-          borderRadius: const BorderRadius.all(borderRadius25),
+          borderRadius: const BorderRadius.all(borderRadius100),
         ),
         padding: _tagPadding,
         child: Row(
@@ -328,7 +328,7 @@ class OptimusCategoricalTag extends StatelessWidget {
       decoration: BoxDecoration(
         color: colorOption.tagColor(theme),
         border: Border.all(color: colorOption.borderColor(theme)),
-        borderRadius: const BorderRadius.all(borderRadius25),
+        borderRadius: const BorderRadius.all(borderRadius100),
       ),
       padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
       child: Text(


### PR DESCRIPTION
RND-126798

#### Summary

- New `borderRadius` and `elevation` values.
- Updated those values in the components mentioned in the ticket.
<details><summary>Screenshots</summary>

Old elevation:

![old_elevation](https://user-images.githubusercontent.com/9210422/201885553-72ce3657-0589-4593-b842-0aa45cdbd359.png)

New elevation:

![new_elevation](https://user-images.githubusercontent.com/9210422/201885500-9c19eec6-91d2-4267-86bc-e36d8e34ea45.png)

Old borders:

![old_border_button](https://user-images.githubusercontent.com/9210422/201892685-6afd5906-e33b-4d65-ac87-212d3b6faeee.png)

![old_border](https://user-images.githubusercontent.com/9210422/201892689-b1fd8f6e-0df1-4598-a6f1-617653f5be19.png)

New borders:

![new_border](https://user-images.githubusercontent.com/9210422/201892743-edd345ac-d12d-4f37-8351-f08b733bd578.png)

![new_border_button](https://user-images.githubusercontent.com/9210422/201892777-6a9bc197-2192-41d1-b5d5-8c34c9e9d192.png)


</details> 

#### Testing steps

None, just updated values.

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
