### PR TITLE
fix(optimus): [RND-148068] Fix tags vertical alignment

### DIFF
--- a/optimus/lib/src/typography/presets.dart
+++ b/optimus/lib/src/typography/presets.dart
@@ -41,6 +41,7 @@ const TextStyle baseTextStyle = TextStyle(
     FontFeature('cv10'),
   ],
   height: 1.5,
+  leadingDistribution: TextLeadingDistribution.even,
 );
 
 TextStyle preset700b(Breakpoint breakpoint) {


### PR DESCRIPTION
RND-148068

#### Summary

The default preset `leadDistribution` was set to `proportional`, which led to some misalignments in components. With `leadDistribution.even` this problem should be fixed. This will affect all presets, but the change is most noticeable in the components, like `tags` and `buttons`, where the borders of the component are very distinct. 

**tldr;** Font will reserve even amount of space above and below chars. Before it was a bit shifted to the bottom.

<details><summary>Tags</summary>

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/9210422/211304046-acde6102-e0c7-4a5e-8b4e-808593e8aed2.gif)
</details>

<details><summary>Buttons</summary>

![ezgif com-gif-maker](https://user-images.githubusercontent.com/9210422/211304055-2f21b834-eb23-4745-a0b6-85d8719192ce.gif)

</details>


#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
