### PR TITLE
fix(optimus): [RND-131920] Fixed null exception in the dropdown

### DIFF
--- a/optimus/lib/src/dropdown/dropdown_select.dart
+++ b/optimus/lib/src/dropdown/dropdown_select.dart
@@ -92,7 +92,7 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>> {
     if (_effectiveFocusNode.hasFocus) {
       WidgetsBinding.instance.addPostFrameCallback(_afterLayoutWithShow);
     } else {
-      setState(_removeOverlay);
+      _removeOverlay();
     }
   }
 


### PR DESCRIPTION
RND-131920

#### Summary

Fixed exception when removing `overlay` in components that were using dropdown select.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
