### PR TITLE
feat(mews_pedantic)!: bump code metrics and remove deprecated lints

### DIFF
--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -43,7 +43,6 @@ linter:
     - flutter_style_todos
     - hash_and_equals
     - implementation_imports
-    - invariant_booleans
     - iterable_contains_unrelated_type
     - join_return_with_assignment
     - library_names

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -7,5 +7,5 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  dart_code_metrics: 4.21.2
+  dart_code_metrics: 5.5.0
   meta: ^1.7.0

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.10.0
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   dart_code_metrics: 5.5.0


### PR DESCRIPTION
#### Summary

This update does the following:
- loosens up SDK requirements to future-proof the package for Dart 3.0
- bumps `dart_code_metrics` version
- removes [deprecated rule](https://dart-lang.github.io/linter/lints/invariant_booleans.html)

#### Testing steps

None.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
