### PR TITLE
ci: update pr-size-watcher

### DIFF
--- a/.github/workflows/pr-size-watcher.yml
+++ b/.github/workflows/pr-size-watcher.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check PR size
     runs-on: ubuntu-latest
     steps:
-      - uses: ookami-kb/gh-pr-size-watcher@v1
+      - uses: ookami-kb/gh-pr-size-watcher@v1.4.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           excludeTitle: '(^Release|\[ignore-size\])'
@@ -21,3 +21,5 @@ jobs:
             **/pubspec.lock
             optimus/lib/mews_icons.dart
             optimus/lib/fonts/
+          excludeLabels: |
+            ignore-size


### PR DESCRIPTION
#### Summary

Updated PR size watcher and added parameter to use labels instead of PR title for ignoring size.

#### Testing steps

No, CI update.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
