### PR TITLE
ci: bump PR size watcher

### DIFF
--- a/.github/workflows/pr-size-watcher.yml
+++ b/.github/workflows/pr-size-watcher.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check PR size
     runs-on: ubuntu-latest
     steps:
-      - uses: ookami-kb/gh-pr-size-watcher@v1.4.0
+      - uses: ookami-kb/gh-pr-size-watcher@v1.4.1
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           excludeTitle: '(^Release|\[ignore-size\])'


### PR DESCRIPTION
#### Summary

Bumped PR size watcher.

#### Testing steps

No, CI update.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
