### PR TITLE
build: bump mews_pedantic and storybook_flutter

### DIFF
--- a/kiosk_mode/pubspec.yaml
+++ b/kiosk_mode/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.10.0
+  mews_pedantic: ^0.11.0
 flutter:
   plugin:
     platforms:

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ">=1.0.0 <3.0.0"
-  mews_pedantic: ^0.10.0
+  mews_pedantic: ^0.11.0
 flutter:
   fonts:
     - family: Inter

--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.2
-  mews_pedantic: ^0.10.0
+  mews_pedantic: ^0.11.0
   mockito: ^5.0.16
   test: ^1.18.0

--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -98,7 +98,14 @@ packages:
       name: dart_code_metrics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.21.2"
+    version: "5.5.0"
+  dart_code_metrics_presets:
+    dependency: transitive
+    description:
+      name: dart_code_metrics_presets
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   dart_style:
     dependency: transitive
     description:
@@ -246,7 +253,7 @@ packages:
       name: mews_pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.0"
+    version: "0.11.0"
   nested:
     dependency: transitive
     description:

--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -440,7 +440,7 @@ packages:
       name: storybook_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "0.12.0"
   stream_channel:
     dependency: transitive
     description:

--- a/storybook/pubspec.yaml
+++ b/storybook/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.10.0
+  mews_pedantic: ^0.11.0
 flutter:
   uses-material-design: true

--- a/storybook/pubspec.yaml
+++ b/storybook/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   optimus:
     path: ../optimus
   shared_preferences: ^2.0.16
-  storybook_flutter: ^0.11.0
+  storybook_flutter: ^0.12.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#### Summary

Bumped `mews_pedantic` `0.11.0`
Bumped `storybook_flutter `to `0.12.0`

#### Testing steps

None, linter update.

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
