### PR TITLE
feat(optimus): [RND-162130] Added a dialogue variation without the content

### DIFF
--- a/optimus/lib/src/dialogs/dialog.dart
+++ b/optimus/lib/src/dialogs/dialog.dart
@@ -31,7 +31,7 @@ class OptimusDialogAction {
 Future<T?> showOptimusDialog<T>({
   required BuildContext context,
   required Widget title,
-  required Widget content,
+  Widget? content,
   ContentWrapperBuilder? contentWrapperBuilder,
   List<OptimusDialogAction> actions = const [],
   OptimusDialogSize size = OptimusDialogSize.regular,
@@ -80,7 +80,7 @@ class OptimusDialog extends StatelessWidget {
   const OptimusDialog.modal({
     Key? key,
     required Widget title,
-    required Widget content,
+    Widget? content,
     ContentWrapperBuilder? contentWrapperBuilder,
     List<OptimusDialogAction> actions = const [],
     OptimusDialogSize size = OptimusDialogSize.regular,
@@ -100,7 +100,7 @@ class OptimusDialog extends StatelessWidget {
   const OptimusDialog.nonModal({
     Key? key,
     required Widget title,
-    required Widget content,
+    Widget? content,
     ContentWrapperBuilder? contentWrapperBuilder,
     List<OptimusDialogAction> actions = const [],
     OptimusDialogSize size = OptimusDialogSize.regular,
@@ -128,7 +128,7 @@ class OptimusDialog extends StatelessWidget {
   /// a sentence, question, or just a subject.
   final Widget title;
 
-  final Widget content;
+  final Widget? content;
 
   /// {@template optimus.dialog.wrapper}
   /// Builds custom content. If content padding needed wrap in

--- a/optimus/lib/src/dialogs/dialog_content.dart
+++ b/optimus/lib/src/dialogs/dialog_content.dart
@@ -6,17 +6,21 @@ class DialogContent extends StatelessWidget {
   const DialogContent({
     Key? key,
     required this.actions,
-    required this.content,
     required this.type,
     required this.size,
     required this.maxWidth,
+    this.content,
     this.title,
     this.close,
     this.isDismissible,
     this.contentWrapperBuilder,
     this.spacing,
     this.margin,
-  }) : super(key: key);
+  })  : assert(
+          title != null || content != null,
+          'Either title or content need to be provided',
+        ),
+        super(key: key);
 
   final List<OptimusDialogAction> actions;
   final Widget? title;
@@ -24,7 +28,7 @@ class DialogContent extends StatelessWidget {
   final double maxWidth;
   final EdgeInsetsGeometry? margin;
 
-  final Widget content;
+  final Widget? content;
   final VoidCallback? close;
   final OptimusDialogSize size;
   final bool? isDismissible;
@@ -38,7 +42,8 @@ class DialogContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = OptimusTheme.of(context);
-    final titleValue = title;
+    final title = this.title;
+    final content = this.content;
 
     return Container(
       margin: margin,
@@ -57,21 +62,22 @@ class DialogContent extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  if (titleValue != null)
+                  if (title != null)
                     _Title(
-                      title: titleValue,
+                      title: title,
                       close: close ?? () => Navigator.pop(context),
                       isDismissible: isDismissible ??
                           ModalRoute.of(context)?.barrierDismissible ??
                           true,
                     ),
-                  if (titleValue != null) _divider(theme),
-                  OptimusParagraph(
-                    child: _Content(
-                      content: content,
-                      contentWrapperBuilder: contentWrapperBuilder,
+                  if (title != null && content != null) _divider(theme),
+                  if (content != null)
+                    OptimusParagraph(
+                      child: _Content(
+                        content: content,
+                        contentWrapperBuilder: contentWrapperBuilder,
+                      ),
                     ),
-                  ),
                   if (actions.isNotEmpty) _divider(theme),
                   if (actions.isNotEmpty)
                     _Actions(


### PR DESCRIPTION
RND-162130

#### Summary

Made `content` nullable and updated the dialog view when it was not provided. Could be useful when the `content` is not needed and action buttons are sufficient.

<details><summary>Screenshots</summary>
Before:

![image](https://user-images.githubusercontent.com/9210422/217628879-232e35cd-5b2e-4fb0-a3f0-14310932d73b.png)

Now: 

![CleanShot 2023-02-08 at 20 14 38](https://user-images.githubusercontent.com/9210422/217629295-cad5ea13-2198-49b3-b645-0ed605796227.png)


</details>

#### Testing steps

None.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
