### PR TITLE
refactor: Bump mews_pedantic to 0.13.0

### DIFF
--- a/kiosk_mode/example/pubspec.yaml
+++ b/kiosk_mode/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: kiosk_mode_example
 description: Demonstrates how to use the kiosk_mode plugin.
 
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.19.0 <3.0.0"
@@ -16,6 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.11.0
+  mews_pedantic: ^0.13.0
 flutter:
   uses-material-design: true

--- a/kiosk_mode/pubspec.yaml
+++ b/kiosk_mode/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.11.0
+  mews_pedantic: ^0.13.0
 flutter:
   plugin:
     platforms:

--- a/optimus/example/pubspec.yaml
+++ b/optimus/example/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.10.0
+  mews_pedantic: ^0.13.0

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ">=1.0.0 <3.0.0"
-  mews_pedantic: ^0.11.0
+  mews_pedantic: ^0.13.0
 flutter:
   fonts:
     - family: Inter

--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -4,8 +4,7 @@ version: 0.2.0
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
-
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   async: ^2.5.0
@@ -15,6 +14,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.2
-  mews_pedantic: ^0.11.0
+  mews_pedantic: ^0.13.0
   mockito: ^5.0.16
   test: ^1.18.0

--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -284,10 +284,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mews_pedantic
-      sha256: bd6455e24ca9ddc46e3575b35be6a47faaed66ecf817fc8eb17e9c86eed39bde
+      sha256: "770570f085580765cc683d1949da31f0c0a6b30692db8d7fa8301b9186b3e7a1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.0"
+    version: "0.13.0"
   nested:
     dependency: transitive
     description:

--- a/storybook/pubspec.yaml
+++ b/storybook/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mews_pedantic: ^0.11.0
+  mews_pedantic: ^0.13.0
 flutter:
   uses-material-design: true


### PR DESCRIPTION
#### Summary

Bumped `mews_pedantic` version.

#### Testing steps

No, linter update.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
