### PR TITLE
fix(optimus): [RND-163981] Fix icon color in OptimusDateTimeField in dark mode.

### DIFF
--- a/optimus/lib/src/date_time_field.dart
+++ b/optimus/lib/src/date_time_field.dart
@@ -82,6 +82,9 @@ class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
     }
   }
 
+  Color get _iconColor =>
+      theme.isDark ? theme.colors.neutral0 : theme.colors.neutral1000t64;
+
   @override
   Widget build(BuildContext context) => OptimusInputField(
         controller: _controller,
@@ -95,7 +98,7 @@ class _OptimusDateTimeFieldState extends State<OptimusDateTimeField>
           child: Icon(
             OptimusIcons.calendar,
             size: 20,
-            color: theme.colors.neutral1000,
+            color: _iconColor,
           ),
         ),
         placeholder: widget.placeholder,


### PR DESCRIPTION
RND-163981

#### Summary

`OptimusDateTimeField`'s icon is now changing its color depending on the actual theme.

<details><summary>Screenshots</summary>

Before:

![image](https://user-images.githubusercontent.com/9210422/219678424-7014c86c-3472-4ecf-ad1d-6fb09c06567d.png)



Now:

![CleanShot 2023-02-17 at 15 09 24](https://user-images.githubusercontent.com/9210422/219678374-0f339c93-d55a-40fa-b184-31416562c11b.png)

</details>


#### Testing steps

1. Open Storybook
2. Open the `Date time field` story
3. Check the dark theme view.

#### Follow-up issues
 
None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
