### PR TITLE
fix(optimus): [RND-164339] Wrong appearance for step bar in dark mode

### DIFF
--- a/optimus/lib/src/step_bar.dart
+++ b/optimus/lib/src/step_bar.dart
@@ -92,7 +92,6 @@ class _OptimusStepBarState extends State<OptimusStepBar> with ThemeGetter {
             Flexible(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   OptimusTypography(
                     resolveStyle: (_) =>

--- a/optimus/lib/src/step_bar.dart
+++ b/optimus/lib/src/step_bar.dart
@@ -4,6 +4,7 @@ import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/typography/presets.dart';
+import 'package:optimus/src/typography/typography.dart';
 
 /// Step-bars are used to communicate a sense of progress visually through
 /// a sequence of either numbered or logical steps.
@@ -91,17 +92,18 @@ class _OptimusStepBarState extends State<OptimusStepBar> with ThemeGetter {
             Flexible(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  DefaultTextStyle.merge(
-                    style: preset200b,
-                    overflow: TextOverflow.ellipsis,
+                  OptimusTypography(
+                    resolveStyle: (_) =>
+                        preset200b.copyWith(overflow: TextOverflow.ellipsis),
                     maxLines: 1,
                     child: item.label,
                   ),
                   if (description != null)
-                    DefaultTextStyle.merge(
-                      overflow: TextOverflow.ellipsis,
-                      style: preset200s.copyWith(
+                    OptimusTypography(
+                      resolveStyle: (_) => preset200s.copyWith(
+                        overflow: TextOverflow.ellipsis,
                         color: theme.isDark
                             ? theme.colors.neutral0t64
                             : theme.colors.neutral1000t64,
@@ -293,9 +295,13 @@ extension on OptimusStepBarItemState {
       case OptimusStepBarItemState.active:
         return theme.colors.primary;
       case OptimusStepBarItemState.enabled:
-        return theme.isDark ? theme.colors.neutral400 : theme.colors.neutral50;
+        return theme.isDark
+            ? theme.colors.neutral500t40
+            : theme.colors.neutral50;
       case OptimusStepBarItemState.disabled:
-        return theme.isDark ? theme.colors.neutral400 : theme.colors.neutral50;
+        return theme.isDark
+            ? theme.colors.neutral500t40
+            : theme.colors.neutral50;
     }
   }
 

--- a/optimus/lib/src/typography/typography.dart
+++ b/optimus/lib/src/typography/typography.dart
@@ -11,12 +11,14 @@ class OptimusTypography extends StatelessWidget {
     required this.resolveStyle,
     this.color = OptimusTypographyColor.primary,
     required this.child,
+    this.maxLines,
     this.align,
   }) : super(key: key);
 
   final ResolveStyle resolveStyle;
   final Widget child;
   final OptimusTypographyColor color;
+  final int? maxLines;
   final TextAlign? align;
 
   @override
@@ -27,6 +29,7 @@ class OptimusTypography extends StatelessWidget {
     return DefaultTextStyle.merge(
       child: child,
       textAlign: align,
+      maxLines: maxLines,
       style: resolveStyle(screenSize).copyWith(color: _color(theme)),
     );
   }


### PR DESCRIPTION
#### Summary

RND-164339

Fixes a bug where the label and circle backdrop of Step Bar does not use the correct color in dark mode.


| Before | After|
| -------|------|
| ![image](https://user-images.githubusercontent.com/45460964/221569745-ad1a58c8-56c7-4f9c-8471-e66e2dd2011c.png) | <img width="585" alt="image" src="https://user-images.githubusercontent.com/45460964/221569664-f1f81619-eceb-4569-ad24-0f30f647755f.png">|


#### Testing steps

Step bar should have white text in dark mode.

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
