### PR TITLE
fix(optimus): [RND-164336] Hero transition bug in Step Bar

### DIFF
--- a/optimus/lib/src/step_bar.dart
+++ b/optimus/lib/src/step_bar.dart
@@ -91,6 +91,7 @@ class _OptimusStepBarState extends State<OptimusStepBar> with ThemeGetter {
             Flexible(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   DefaultTextStyle.merge(
                     style: preset200b,


### PR DESCRIPTION
#### Summary

RND-164336

Fixes a bug where the text would jump during a hero transition. 

| Before | After |
| -------| ----- |
| ![ezgif-3-1eae1b028f](https://user-images.githubusercontent.com/45460964/221571624-851b55e7-c24f-4d0f-ba1c-4872b47afbc9.gif) | ![ezgif-3-fe18f3f0d3](https://user-images.githubusercontent.com/45460964/221571645-d666287b-b83c-417d-986e-de19c4beb83a.gif)  |


#### Testing steps

Text should not jump during a hero transition.

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
