### PR TITLE
fix(optimus): [RND-164340] `OptimusNestedCard` does not have contrasting colour in dark mode

### DIFF
--- a/optimus/lib/src/card.dart
+++ b/optimus/lib/src/card.dart
@@ -156,7 +156,7 @@ class OptimusNestedCard extends StatelessWidget {
     switch (variant) {
       case OptimusNestedCardVariant.emphasized:
         return theme.isDark
-            ? theme.colors.neutral400.withOpacity(0.2)
+            ? theme.colors.neutral400t24
             : theme.colors.neutral500t8;
       case OptimusNestedCardVariant.highlighted:
         return theme.colors.primary500t8;

--- a/optimus/lib/src/card.dart
+++ b/optimus/lib/src/card.dart
@@ -156,7 +156,7 @@ class OptimusNestedCard extends StatelessWidget {
     switch (variant) {
       case OptimusNestedCardVariant.emphasized:
         return theme.isDark
-            ? theme.colors.neutral500t48
+            ? theme.colors.neutral400.withOpacity(0.2)
             : theme.colors.neutral500t8;
       case OptimusNestedCardVariant.highlighted:
         return theme.colors.primary500t8;

--- a/optimus/lib/src/colors/colors.dart
+++ b/optimus/lib/src/colors/colors.dart
@@ -57,6 +57,8 @@ abstract class OptimusSemanticColors {
   static const night800 = Color(0xFF4A4959);
   static const night900 = Color(0xFF242435);
 
+  static const night600t24 = Color(0x3D72717D);
+
   static const night700t8 = Color(0x145E5D6B);
   static const night700t16 = Color(0x285E5D6B);
   static const night700t24 = Color(0x3D5E5D6B);
@@ -78,6 +80,8 @@ abstract class OptimusSemanticColors {
   static const grey900 = Color(0xFF1E1C2B);
   static const grey1000 = Color(0xFF181621);
   static const grey1100 = Color(0xFF08070C);
+
+  static const grey700t24 = Color(0x3D403E4F);
 
   static const grey1000t8 = Color(0x14181621);
   static const grey1000t16 = Color(0x28181621);
@@ -228,6 +232,7 @@ abstract class OptimusLightColors {
 
   static const neutral0t32 = OptimusSemanticColors.whitet32;
   static const neutral0t64 = OptimusSemanticColors.whitet64;
+  static const neutral400t24 = OptimusSemanticColors.night600t24;
   static const neutral500t8 = OptimusSemanticColors.night700t8;
   static const neutral500t16 = OptimusSemanticColors.night700t16;
   static const neutral500t24 = OptimusSemanticColors.night700t24;
@@ -348,7 +353,7 @@ abstract class OptimusDarkColors {
 
   static const neutral0t32 = OptimusSemanticColors.whitet32;
   static const neutral0t64 = OptimusSemanticColors.whitet64;
-
+  static const neutral400t24 = OptimusSemanticColors.grey700t24;
   static const neutral500t8 = OptimusSemanticColors.grey1000t8;
   static const neutral500t16 = OptimusSemanticColors.grey1000t16;
   static const neutral500t24 = OptimusSemanticColors.grey1000t24;
@@ -524,6 +529,10 @@ class OptimusColors {
 
   Color get neutral0t64 =>
       _isLight ? OptimusLightColors.neutral0t64 : OptimusDarkColors.neutral0t64;
+
+  Color get neutral400t24 => _isLight
+      ? OptimusLightColors.neutral400t24
+      : OptimusDarkColors.neutral400t24;
 
   Color get neutral500t8 => _isLight
       ? OptimusLightColors.neutral500t8


### PR DESCRIPTION
#### Summary

RND-164340

Changes the dark mode color to be more suitable on an OptimusCard in dark mode.

| Before | After |
| ------| ------ |
| ![image](https://user-images.githubusercontent.com/45460964/221574118-d1e1a359-21a3-4a05-9368-488a4a935d8c.png) | <img width="502" alt="image" src="https://user-images.githubusercontent.com/45460964/221574336-6a036599-dfd1-4262-afdc-a02b5323465f.png"> |

#### Testing steps

According to the issue.

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
