### PR TITLE
feat(optimus): [RND-165619] Add OptimusTooltipWrapper

### DIFF
--- a/optimus/lib/optimus.dart
+++ b/optimus/lib/optimus.dart
@@ -78,6 +78,7 @@ export 'src/tag.dart';
 export 'src/theme/theme.dart';
 export 'src/theme/theme_data.dart';
 export 'src/tooltip/tooltip.dart';
+export 'src/tooltip/tooltip_wrapper.dart';
 export 'src/typography/caption.dart';
 export 'src/typography/fonts.dart';
 export 'src/typography/highlight.dart';

--- a/optimus/lib/src/tooltip/tooltip.dart
+++ b/optimus/lib/src/tooltip/tooltip.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/tooltip/tooltip_alignment.dart';
+import 'package:optimus/src/tooltip/tooltip_overlay.dart';
 import 'package:optimus/src/typography/presets.dart';
 
 /// Tooltip displays contextual content upon the click or focus of a UI trigger
@@ -12,7 +13,7 @@ class OptimusTooltip extends StatelessWidget {
     Key? key,
     required this.content,
     this.size = OptimusToolTipSize.small,
-    this.tooltipPosition = OptimusTooltipPosition.top,
+    this.tooltipPosition,
   }) : super(key: key);
 
   /// The content of the tooltip. Typically a [Text] widget.
@@ -24,14 +25,20 @@ class OptimusTooltip extends StatelessWidget {
   final OptimusToolTipSize size;
 
   /// The position of the tooltip. Defaults to [OptimusTooltipPosition.top].
-  final OptimusTooltipPosition tooltipPosition;
+  /// If wrapped with [OptimusTooltipWrapper], the position will be set
+  /// by the wrapper.
+  final OptimusTooltipPosition? tooltipPosition;
 
   Color tooltipColor(OptimusThemeData theme) => theme.colors.neutral1000;
+
+  OptimusTooltipPosition get _fallbackPosition =>
+      tooltipPosition ?? OptimusTooltipPosition.top;
 
   @override
   Widget build(BuildContext context) {
     final theme = OptimusTheme.of(context);
-    final alignment = tooltipPosition.toTooltipAlignment();
+    final alignment = TooltipOverlay.of(context)?.alignment ??
+        _fallbackPosition.toTooltipAlignment();
 
     return Padding(
       padding: const EdgeInsets.all(_arrowHeight),

--- a/optimus/lib/src/tooltip/tooltip_controller.dart
+++ b/optimus/lib/src/tooltip/tooltip_controller.dart
@@ -1,0 +1,82 @@
+import 'package:dfunc/dfunc.dart';
+import 'package:flutter/material.dart';
+import 'package:optimus/optimus.dart';
+import 'package:optimus/src/tooltip/tooltip_overlay.dart';
+
+/// Controller for the tooltip widget. It is responsible for showing and hiding
+/// the tooltip overlay entry.
+class TooltipController extends StatefulWidget {
+  const TooltipController({
+    Key? key,
+    required this.anchorKey,
+    required this.child,
+    required this.tooltip,
+    required this.tooltipKey,
+    this.autoHideDuration = const Duration(seconds: 1),
+    this.tooltipPosition,
+  }) : super(key: key);
+
+  /// Key of the widget that should be wrapped with the tooltip.
+  final GlobalKey anchorKey;
+
+  /// Key of the tooltip widget.
+  final GlobalKey tooltipKey;
+
+  /// Widget that should be wrapped with the tooltip.
+  final Widget child;
+
+  /// Tooltip widget.
+  final OptimusTooltip tooltip;
+
+  /// Position of the tooltip relative to the child widget. If not specified,
+  /// the tooltip will be positioned automatically. Depending on the space
+  /// available will be set to [OptimusTooltipPosition.top] or
+  /// [OptimusTooltipPosition.bottom].
+  final OptimusTooltipPosition? tooltipPosition;
+
+  /// Duration for which the tooltip will be shown. Defaults to 1 second.
+  final Duration autoHideDuration;
+
+  @override
+  State<TooltipController> createState() => _TooltipControllerState();
+}
+
+class _TooltipControllerState extends State<TooltipController> {
+  OverlayEntry? _entry;
+
+  OverlayEntry createEntry() => OverlayEntry(
+        builder: (context) => GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTapDown: (_) => hideTooltip(),
+          child: Stack(
+            alignment: AlignmentDirectional.topCenter,
+            children: <Widget>[
+              TooltipOverlay(
+                anchorKey: widget.anchorKey,
+                tooltipKey: widget.tooltipKey,
+                position: widget.tooltipPosition,
+                tooltip: widget.tooltip,
+              ),
+            ],
+          ),
+        ),
+      );
+
+  void showTooltip() {
+    _entry = createEntry().also((it) {
+      Overlay.of(context).insert(it);
+      Future.delayed(widget.autoHideDuration, hideTooltip);
+    });
+  }
+
+  void hideTooltip() {
+    _entry?.remove();
+    _entry = null;
+  }
+
+  @override
+  Widget build(BuildContext context) => GestureDetector(
+        onTap: showTooltip,
+        child: widget.child,
+      );
+}

--- a/optimus/lib/src/tooltip/tooltip_overlay.dart
+++ b/optimus/lib/src/tooltip/tooltip_overlay.dart
@@ -1,0 +1,292 @@
+import 'package:flutter/material.dart';
+import 'package:optimus/optimus.dart';
+import 'package:optimus/src/tooltip/tooltip_alignment.dart';
+
+abstract class TooltipOverlayController {
+  TooltipAlignment get alignment;
+}
+
+class TooltipOverlayData extends InheritedWidget {
+  const TooltipOverlayData({
+    Key? key,
+    required Widget child,
+    required this.controller,
+  }) : super(key: key, child: child);
+
+  final TooltipOverlayController controller;
+
+  @override
+  bool updateShouldNotify(TooltipOverlayData oldWidget) => true;
+}
+
+class TooltipOverlay extends StatefulWidget {
+  const TooltipOverlay({
+    Key? key,
+    required this.anchorKey,
+    required this.tooltip,
+    this.rootOverlay = false,
+    required this.tooltipKey,
+    this.position,
+  }) : super(key: key);
+
+  /// Key of the widget that should be wrapped with the tooltip.
+  final GlobalKey anchorKey;
+
+  /// Key of the tooltip widget.
+  final GlobalKey tooltipKey;
+
+  /// Tooltip widget.
+  final OptimusTooltip tooltip;
+
+  /// Whether the tooltip should use the root overlay.
+  final bool rootOverlay;
+
+  /// Position of the tooltip relative to the child widget. If not specified,
+  /// the tooltip will be positioned automatically. Depending on the space
+  /// available will be set to [OptimusTooltipPosition.top] or
+  /// [OptimusTooltipPosition.bottom].
+  final OptimusTooltipPosition? position;
+
+  static TooltipOverlayController? of(BuildContext context) => context
+      .dependOnInheritedWidgetOfExactType<TooltipOverlayData>()
+      ?.controller;
+
+  @override
+  State<TooltipOverlay> createState() => TooltipOverlayState();
+}
+
+class TooltipOverlayState extends State<TooltipOverlay>
+    implements TooltipOverlayController {
+  late Rect _savedRect = _calculateRect(widget.anchorKey);
+  late Rect _tooltipRect = _calculateRect(widget.tooltipKey);
+  late Size? _overlaySize = _getOverlaySize();
+  double _opacity = 0.0;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback(_afterFirstLayoutCallback);
+  }
+
+  @override
+  void didUpdateWidget(TooltipOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    WidgetsBinding.instance.addPostFrameCallback(_updateRect);
+  }
+
+  double get _overlayWidth => _overlaySize?.width ?? 0;
+
+  double get _overlayHeight => _overlaySize?.height ?? 0;
+
+  bool get _isOnTop => _spaceTop > _spaceBottom;
+
+  double get _spaceLeft => _savedRect.left - _widgetPadding;
+
+  double get _spaceRight => _overlayWidth - _widgetPadding - _savedRect.right;
+
+  double get _spaceTop => _savedRect.top - _screenPadding;
+
+  double get _spaceBottom =>
+      _overlayHeight - _screenPadding - _savedRect.bottom;
+
+  double get _horizontalCenterLeft =>
+      _savedRect.left + _savedRect.width / 2 - _tooltipRect.width / 2;
+
+  double get _horizontalCenterRight =>
+      _savedRect.left + _savedRect.width / 2 + _tooltipRect.width / 2;
+
+  double get _verticalCenterTop =>
+      _savedRect.top - _savedRect.height / 2 - _tooltipRect.height / 2;
+
+  double get _verticalCenterBottom =>
+      _savedRect.top - _savedRect.height / 2 + _tooltipRect.height / 2;
+
+  OptimusTooltipPosition get _getPreferredPosition =>
+      widget.position ??
+      (_isOnTop ? OptimusTooltipPosition.top : OptimusTooltipPosition.bottom);
+
+  double? get _leftOffset {
+    switch (alignment) {
+      case TooltipAlignment.leftTop:
+      case TooltipAlignment.leftCenter:
+      case TooltipAlignment.leftBottom:
+        return _savedRect.left - _tooltipRect.width - _sideAlignOffset;
+      case TooltipAlignment.rightTop:
+      case TooltipAlignment.rightCenter:
+      case TooltipAlignment.rightBottom:
+        return _savedRect.right + _widgetPadding;
+      case TooltipAlignment.topLeft:
+      case TooltipAlignment.bottomLeft:
+        return _savedRect.right - _tooltipRect.width + _sideAlignOffset;
+      case TooltipAlignment.topCenter:
+      case TooltipAlignment.bottomCenter:
+        return _savedRect.left +
+            (_savedRect.width / 2 - _tooltipRect.width / 2);
+      case TooltipAlignment.topRight:
+      case TooltipAlignment.bottomRight:
+        return _savedRect.left - _sideAlignOffset;
+    }
+  }
+
+  double? get _topOffset {
+    switch (alignment) {
+      case TooltipAlignment.rightTop:
+      case TooltipAlignment.leftTop:
+        return null;
+      case TooltipAlignment.leftBottom:
+      case TooltipAlignment.rightBottom:
+        return _savedRect.top + _savedRect.height / 2 - _tooltipAlignOffset;
+      case TooltipAlignment.rightCenter:
+      case TooltipAlignment.leftCenter:
+        return _savedRect.top +
+            (_savedRect.height / 2 - _tooltipRect.height / 2);
+      case TooltipAlignment.topCenter:
+      case TooltipAlignment.topLeft:
+      case TooltipAlignment.topRight:
+        return _savedRect.top - _tooltipRect.height - _widgetPadding;
+      case TooltipAlignment.bottomLeft:
+      case TooltipAlignment.bottomCenter:
+      case TooltipAlignment.bottomRight:
+        return _savedRect.bottom + _widgetPadding;
+    }
+  }
+
+  double? get _bottomOffset {
+    switch (alignment) {
+      case TooltipAlignment.rightTop:
+      case TooltipAlignment.leftTop:
+        return _overlayHeight -
+            _savedRect.top -
+            _savedRect.height / 2 -
+            _tooltipAlignOffset;
+      case TooltipAlignment.leftBottom:
+      case TooltipAlignment.rightBottom:
+      case TooltipAlignment.rightCenter:
+      case TooltipAlignment.leftCenter:
+      case TooltipAlignment.topCenter:
+      case TooltipAlignment.topLeft:
+      case TooltipAlignment.topRight:
+      case TooltipAlignment.bottomLeft:
+      case TooltipAlignment.bottomCenter:
+      case TooltipAlignment.bottomRight:
+        return null;
+    }
+  }
+
+  @override
+  TooltipAlignment get alignment {
+    switch (_getPreferredPosition) {
+      case OptimusTooltipPosition.top:
+        return _calculateHorizontalAlignment(
+          TooltipAlignment.topLeft,
+          TooltipAlignment.topCenter,
+          TooltipAlignment.topRight,
+        );
+      case OptimusTooltipPosition.bottom:
+        return _calculateHorizontalAlignment(
+          TooltipAlignment.bottomLeft,
+          TooltipAlignment.bottomCenter,
+          TooltipAlignment.bottomRight,
+        );
+      case OptimusTooltipPosition.left:
+        return _calculateVerticalAlignment(
+          TooltipAlignment.leftTop,
+          TooltipAlignment.leftCenter,
+          TooltipAlignment.leftBottom,
+        );
+      case OptimusTooltipPosition.right:
+        return _calculateVerticalAlignment(
+          TooltipAlignment.rightTop,
+          TooltipAlignment.rightCenter,
+          TooltipAlignment.rightBottom,
+        );
+    }
+  }
+
+  TooltipAlignment _calculateHorizontalAlignment(
+    TooltipAlignment start,
+    TooltipAlignment center,
+    TooltipAlignment end,
+  ) {
+    if (_horizontalCenterLeft < _screenPadding ||
+        _horizontalCenterRight > _overlayWidth - _screenPadding) {
+      return _spaceLeft > _spaceRight ? start : end;
+    }
+
+    return center;
+  }
+
+  TooltipAlignment _calculateVerticalAlignment(
+    TooltipAlignment start,
+    TooltipAlignment center,
+    TooltipAlignment end,
+  ) {
+    if (_verticalCenterTop < _screenPadding ||
+        _verticalCenterBottom > _overlayHeight - _screenPadding) {
+      return _spaceTop > _spaceBottom ? start : end;
+    }
+
+    return center;
+  }
+
+  void _afterFirstLayoutCallback(dynamic _) {
+    _updateRect(_);
+    setState(() {
+      _opacity = 1.0;
+    });
+  }
+
+  void _updateRect(dynamic _) {
+    if (!mounted) return;
+    final newRect = _calculateRect(widget.anchorKey);
+    final newTooltipRect = _calculateRect(widget.tooltipKey);
+    if (newRect != _savedRect || newTooltipRect != _tooltipRect) {
+      final newSize = _getOverlaySize();
+      setState(() {
+        _savedRect = newRect;
+        _tooltipRect = newTooltipRect;
+        _overlaySize = newSize;
+      });
+    }
+  }
+
+  Rect _calculateRect(GlobalKey key) {
+    final renderObject = key.currentContext?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) return Rect.zero;
+    final size = renderObject.size;
+
+    return renderObject.localToGlobal(Offset.zero, ancestor: _getOverlay()) &
+        size;
+  }
+
+  RenderBox? _getOverlay() =>
+      Overlay.of(context, rootOverlay: widget.rootOverlay)
+          .context
+          .findRenderObject() as RenderBox;
+
+  Size? _getOverlaySize() => _getOverlay()?.size;
+
+  @override
+  Widget build(BuildContext context) => TooltipOverlayData(
+        controller: this,
+        child: Builder(
+          builder: (context) => Positioned(
+            left: _leftOffset,
+            top: _topOffset,
+            bottom: _bottomOffset,
+            child: AnimatedOpacity(
+              opacity: _opacity,
+              curve: Curves.easeIn,
+              duration: _animationDuration,
+              child: widget.tooltip,
+            ),
+          ),
+        ),
+      );
+}
+
+const double _screenPadding = spacing200;
+const double _widgetPadding = spacing100;
+const double _sideAlignOffset = spacing100;
+const double _tooltipAlignOffset = 18.0;
+const Duration _animationDuration = Duration(milliseconds: 100);

--- a/optimus/lib/src/tooltip/tooltip_wrapper.dart
+++ b/optimus/lib/src/tooltip/tooltip_wrapper.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:optimus/src/tooltip/tooltip.dart';
+import 'package:optimus/src/tooltip/tooltip_controller.dart';
+
+/// Wrapper for the [OptimusTooltip] widget. It is responsible for showing and
+/// hiding the tooltip. Will try to position the tooltip depending on the
+/// available space.
+class OptimusTooltipWrapper extends StatefulWidget {
+  const OptimusTooltipWrapper({
+    Key? key,
+    required this.text,
+    required this.child,
+    this.tooltipPosition = OptimusTooltipPosition.top,
+    this.size = OptimusToolTipSize.small,
+    this.autoHideDuration = const Duration(seconds: 1),
+  }) : super(key: key);
+
+  /// Tooltip text. Typically a [Text] widget. This widget will be passed to the
+  /// tooltip and styled accordingly.
+  final Widget text;
+
+  /// Widget that should be wrapped with the tooltip.
+  final Widget child;
+
+  /// Size of the tooltip.
+  final OptimusToolTipSize size;
+
+  /// Position of the tooltip relative to the child widget. If not specified,
+  /// the tooltip will be positioned automatically. Defaults to
+  /// [OptimusTooltipPosition.top] or [OptimusTooltipPosition.bottom], whichever
+  /// has more space available.
+  final OptimusTooltipPosition? tooltipPosition;
+
+  /// Duration for which the tooltip will be shown.
+  final Duration autoHideDuration;
+
+  @override
+  State<OptimusTooltipWrapper> createState() => _OptimusTooltipWrapperState();
+}
+
+class _OptimusTooltipWrapperState extends State<OptimusTooltipWrapper> {
+  final GlobalKey anchorKey = GlobalKey();
+  final GlobalKey tooltipKey = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) => TooltipController(
+        anchorKey: anchorKey,
+        tooltipKey: tooltipKey,
+        tooltipPosition: widget.tooltipPosition,
+        autoHideDuration: widget.autoHideDuration,
+        tooltip: OptimusTooltip(
+          key: tooltipKey,
+          size: widget.size,
+          tooltipPosition: widget.tooltipPosition,
+          content: widget.text,
+        ),
+        child: Container(
+          key: anchorKey,
+          child: widget.child,
+        ),
+      );
+}

--- a/storybook/lib/main.dart
+++ b/storybook/lib/main.dart
@@ -44,6 +44,7 @@ import 'package:storybook/stories/step_bar.dart';
 import 'package:storybook/stories/tabs.dart';
 import 'package:storybook/stories/tags.dart';
 import 'package:storybook/stories/tooltip.dart';
+import 'package:storybook/stories/tooltip_wrapper.dart';
 import 'package:storybook/stories/typography/caption.dart';
 import 'package:storybook/stories/typography/highlight.dart';
 import 'package:storybook/stories/typography/label.dart';
@@ -150,6 +151,7 @@ class _MyAppState extends State<MyApp> {
                   dateTimeFieldStory,
                   notificationStory,
                   tooltipStory,
+                  tooltipWrapperStory,
                 ],
               );
           }

--- a/storybook/lib/stories/inline_dialog.dart
+++ b/storybook/lib/stories/inline_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
+import 'package:storybook/utils.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
 
 final Story inlineDialogStory = Story(
@@ -22,7 +23,7 @@ class InlineDialogStory extends StatelessWidget {
     final hasActions = k.boolean(label: 'Has actions', initial: false);
     final position = k.options(
       label: 'Button Position',
-      options: _alignments,
+      options: alignments,
       initial: Alignment.center,
     );
 
@@ -119,13 +120,3 @@ class _Title extends StatelessWidget {
   @override
   Widget build(BuildContext context) => OptimusLabel(child: Text(title));
 }
-
-final List<Option<Alignment>> _alignments = [
-  const Option<Alignment>(value: Alignment.center, label: 'Center'),
-  const Option<Alignment>(value: Alignment.centerLeft, label: 'Center left'),
-  const Option<Alignment>(value: Alignment.centerRight, label: 'Center right'),
-  const Option<Alignment>(value: Alignment.topLeft, label: 'Top left'),
-  const Option<Alignment>(value: Alignment.topRight, label: 'Top right'),
-  const Option<Alignment>(value: Alignment.bottomLeft, label: 'Bottom left'),
-  const Option<Alignment>(value: Alignment.bottomRight, label: 'Bottom right'),
-];

--- a/storybook/lib/stories/tooltip_wrapper.dart
+++ b/storybook/lib/stories/tooltip_wrapper.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:optimus/optimus.dart';
+import 'package:storybook/utils.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+final Story tooltipWrapperStory = Story(
+  name: 'Feedback/Tooltip Wrapper',
+  builder: (BuildContext context) {
+    final knobs = context.knobs;
+
+    final text = knobs.text(
+      label: 'Label text:',
+      initial: 'Some helpful, but not essential, information',
+    );
+    final position = knobs.options(
+      label: 'Position',
+      initial: OptimusTooltipPosition.top,
+      options: OptimusTooltipPosition.values.toOptions(),
+    );
+    final size = knobs.options(
+      label: 'Size',
+      initial: OptimusToolTipSize.small,
+      options: OptimusToolTipSize.values.toOptions(),
+    );
+    final duration =
+        knobs.sliderInt(label: 'Duration', initial: 1, min: 0, max: 5);
+    final contentAlign = knobs.options(
+      label: 'Alert icon align:',
+      description: 'Will replace the input field if set to the center',
+      options: alignments,
+      initial: Alignment.bottomRight,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.all(spacing200),
+      child: Stack(
+        children: [
+          Align(
+            alignment: contentAlign,
+            child: OptimusTooltipWrapper(
+              text: Text(text),
+              autoHideDuration: Duration(seconds: duration),
+              size: size,
+              tooltipPosition: position,
+              child: const Icon(OptimusIcons.alert_circle),
+            ),
+          ),
+          if (contentAlign != Alignment.center)
+            Center(
+              child: SizedBox(
+                width: 400,
+                child: OptimusInputField(
+                  label: 'Label',
+                  placeholder: 'Press info icon to show tooltip',
+                  suffix: OptimusTooltipWrapper(
+                    text: Text(text),
+                    autoHideDuration: Duration(seconds: duration),
+                    size: size,
+                    tooltipPosition: position,
+                    child: const Icon(OptimusIcons.info),
+                  ),
+                ),
+              ),
+            )
+        ],
+      ),
+    );
+  },
+);

--- a/storybook/lib/utils.dart
+++ b/storybook/lib/utils.dart
@@ -17,6 +17,16 @@ final List<Option<IconData?>> exampleIcons = [
   const Option(label: 'Chevron left', value: OptimusIcons.chevron_left),
 ];
 
+final List<Option<Alignment>> alignments = [
+  const Option<Alignment>(value: Alignment.center, label: 'Center'),
+  const Option<Alignment>(value: Alignment.centerLeft, label: 'Center left'),
+  const Option<Alignment>(value: Alignment.centerRight, label: 'Center right'),
+  const Option<Alignment>(value: Alignment.topLeft, label: 'Top left'),
+  const Option<Alignment>(value: Alignment.topRight, label: 'Top right'),
+  const Option<Alignment>(value: Alignment.bottomLeft, label: 'Bottom left'),
+  const Option<Alignment>(value: Alignment.bottomRight, label: 'Bottom right'),
+];
+
 final List<Option<OptimusWidgetSize>> sizeOptions = OptimusWidgetSize.values
     .map((e) => Option(label: e.name, value: e))
     .toList();


### PR DESCRIPTION
[RND-165619]

#### Summary

- Added `OptimusTooltipWrapper`. The wrapper will calculate. the best alignment depending on the set position and space left. 
- Added `OptimusTooltipWrapper` story.

<details><summary>Screenshots</summary>

![CleanShot 2023-03-22 at 18 17 01](https://user-images.githubusercontent.com/9210422/226986205-947d0487-7c1a-4caa-a0f6-e2248ae95e1c.gif)


![CleanShot 2023-03-22 at 18 17 35](https://user-images.githubusercontent.com/9210422/226985970-aea62ea7-665d-4a7a-ae28-3a2356110dca.gif)


</details> 

#### Testing steps

1. Open the `Tooltip Wrapper` story
2. Test different options.

#### Follow-up issues

- Create a fallback for the cases when the tooltip is set to be shown out of the screen. 

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
