### PR TITLE
build: Remove pinned test_api

### DIFF
--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -17,4 +17,3 @@ dev_dependencies:
   mews_pedantic: ^0.13.0
   mockito: ^5.0.16
   test: ^1.18.0
-  test_api: 0.4.18 # https://github.com/dart-lang/test/issues/1977

--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -17,4 +17,3 @@ dev_dependencies:
   mews_pedantic: ^0.13.0
   mockito: ^5.0.16
   test: ^1.18.0
-  

--- a/remote_logger/pubspec.yaml
+++ b/remote_logger/pubspec.yaml
@@ -17,3 +17,4 @@ dev_dependencies:
   mews_pedantic: ^0.13.0
   mockito: ^5.0.16
   test: ^1.18.0
+  


### PR DESCRIPTION
#### Summary

The [issue](https://github.com/dart-lang/test/issues/1977) was resolved and there is no need to pin the `test_api` version anymore.

#### Testing steps

None. Build change.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
