### PR TITLE
refactor(optimus): Update OptimusSearch story

### DIFF
--- a/storybook/lib/stories/search_field.dart
+++ b/storybook/lib/stories/search_field.dart
@@ -71,6 +71,7 @@ class _SearchStoryState extends State<SearchStory> {
         initial: OptimusWidgetSize.large,
         options: sizeOptions,
       ),
+      isUpdating: k.boolean(label: 'Updating', initial: false),
       isClearEnabled: k.boolean(label: 'Clear enabled', initial: false),
       error: k.text(label: 'Error', initial: ''),
     );


### PR DESCRIPTION
#### Summary

- `isUpdating` and `showLoader` were doing the same. 
-  I've removed the `showLoader`, but forgot to mark it as a breaking change.
- This PR has an updated story and is marked as breaking to reflect the change in the `OptimusSearch`.

#### Testing steps

None. Refactor.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
