### PR TITLE
build(deps): bump dart_code_metrics from 5.5.0 to 5.7.2 in /mews_pedantic

### DIFF
--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > Note: This release has breaking changes.
 
-- **BREAKING** **FEAT**: Upgrage dart_code_metrics to 5.7.2.
+- **BREAKING** **FEAT**: Upgrade dart_code_metrics to 5.7.2.
 
 ## 0.13.0
 
@@ -46,7 +46,7 @@
 
 > Note: This release has breaking changes.
 
- - **BREAKING** **FEAT**: Upgrage dart_code_metrics to 4.18.3.
+ - **BREAKING** **FEAT**: Upgrade dart_code_metrics to 4.18.3.
 
 ## 0.7.0
 

--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > Note: This release has breaking changes.
 
-- **BREAKING** **FEAT**: Upgrade dart_code_metrics to 5.7.2.
+- **BREAKING** **FEAT**: Upgrage dart_code_metrics to 5.7.2.
 
 ## 0.13.0
 
@@ -46,7 +46,7 @@
 
 > Note: This release has breaking changes.
 
- - **BREAKING** **FEAT**: Upgrade dart_code_metrics to 4.18.3.
+ - **BREAKING** **FEAT**: Upgrage dart_code_metrics to 4.18.3.
 
 ## 0.7.0
 

--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.14.0
+
+> Note: This release has breaking changes.
+
+- **BREAKING** **FEAT**: Upgrage dart_code_metrics to 5.7.2.
+
 ## 0.13.0
 
 > Note: This release has breaking changes.

--- a/mews_pedantic/CHANGELOG.md
+++ b/mews_pedantic/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > Note: This release has breaking changes.
 
-- **BREAKING** **FEAT**: Upgrage dart_code_metrics to 5.7.2.
+- **BREAKING** **FEAT**: Upgrade dart_code_metrics to 5.7.2.
 
 ## 0.13.0
 

--- a/mews_pedantic/pubspec.yaml
+++ b/mews_pedantic/pubspec.yaml
@@ -1,11 +1,11 @@
 name: mews_pedantic
 description: Dart and Flutter static analysis and lint rules incorporated in Mews.
-version: 0.13.0
+version: 0.14.0
 repository: https://github.com/MewsSystems/mews-flutter
 
 environment:
   sdk: ">=2.19.0 <4.0.0"
 
 dependencies:
-  dart_code_metrics: 5.5.0
+  dart_code_metrics: 5.7.2
   meta: ^1.7.0


### PR DESCRIPTION
#### Summary

- Upgrades `dart_code_metrics` to `5.7.2`

#### Testing steps

None.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
