### PR TITLE
fix(optimus): [RND-170692] Dialog is overlapping with screen safe area

### DIFF
--- a/optimus/lib/src/dialogs/dialog.dart
+++ b/optimus/lib/src/dialogs/dialog.dart
@@ -37,6 +37,7 @@ Future<T?> showOptimusDialog<T>({
   OptimusDialogSize size = OptimusDialogSize.regular,
   OptimusDialogType type = OptimusDialogType.common,
   bool isDismissible = true,
+  bool useSafeArea = false,
   bool useRootNavigator = true,
 }) =>
     showGeneralDialog(
@@ -47,6 +48,7 @@ Future<T?> showOptimusDialog<T>({
         content: content,
         contentWrapperBuilder: contentWrapperBuilder,
         actions: actions,
+        useSafeArea: useSafeArea,
         size: size,
         type: type,
       ),
@@ -75,6 +77,7 @@ class OptimusDialog extends StatelessWidget {
     this.close,
     this.isDismissible,
     this.position = OptimusDialogPosition.center,
+    this.useSafeArea = false,
   }) : super(key: key);
 
   const OptimusDialog.modal({
@@ -86,6 +89,7 @@ class OptimusDialog extends StatelessWidget {
     OptimusDialogSize size = OptimusDialogSize.regular,
     OptimusDialogType type = OptimusDialogType.common,
     bool? isDismissible,
+    bool useSafeArea = false,
   }) : this._(
           key: key,
           title: title,
@@ -95,6 +99,7 @@ class OptimusDialog extends StatelessWidget {
           size: size,
           type: type,
           isDismissible: isDismissible,
+          useSafeArea: useSafeArea,
         );
 
   const OptimusDialog.nonModal({
@@ -105,6 +110,7 @@ class OptimusDialog extends StatelessWidget {
     List<OptimusDialogAction> actions = const [],
     OptimusDialogSize size = OptimusDialogSize.regular,
     bool? isDismissible,
+    bool useSafeArea = false,
     required VoidCallback close,
   }) : this._(
           key: key,
@@ -116,6 +122,7 @@ class OptimusDialog extends StatelessWidget {
               ? OptimusDialogSize.regular
               : size,
           isDismissible: isDismissible,
+          useSafeArea: useSafeArea,
           close: close,
           position: OptimusDialogPosition.corner,
         );
@@ -160,6 +167,8 @@ class OptimusDialog extends StatelessWidget {
   final OptimusDialogSize size;
 
   final OptimusDialogType type;
+
+  final bool useSafeArea;
 
   OptimusDialogSize _autoSize(BuildContext context) {
     switch (MediaQuery.of(context).screenBreakpoint) {
@@ -206,22 +215,27 @@ class OptimusDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final size = _autoSize(context);
+    Widget dialogContent = DialogContent(
+      title: title,
+      content: content,
+      actions: actions,
+      type: type,
+      size: size,
+      maxWidth: size.width,
+      spacing: spacing300,
+      margin: MediaQuery.of(context).viewInsets,
+      contentWrapperBuilder: contentWrapperBuilder,
+      isDismissible: isDismissible,
+      close: close,
+    );
+
+    if (useSafeArea) {
+      dialogContent = SafeArea(child: dialogContent);
+    }
 
     return Align(
       alignment: _alignment(context),
-      child: DialogContent(
-        title: title,
-        content: content,
-        actions: actions,
-        type: type,
-        size: size,
-        maxWidth: size.width,
-        spacing: spacing300,
-        margin: MediaQuery.of(context).viewInsets,
-        contentWrapperBuilder: contentWrapperBuilder,
-        isDismissible: isDismissible,
-        close: close,
-      ),
+      child: dialogContent,
     );
   }
 }

--- a/optimus/lib/src/dialogs/dialog.dart
+++ b/optimus/lib/src/dialogs/dialog.dart
@@ -37,7 +37,6 @@ Future<T?> showOptimusDialog<T>({
   OptimusDialogSize size = OptimusDialogSize.regular,
   OptimusDialogType type = OptimusDialogType.common,
   bool isDismissible = true,
-  bool useSafeArea = false,
   bool useRootNavigator = true,
 }) =>
     showGeneralDialog(
@@ -48,7 +47,6 @@ Future<T?> showOptimusDialog<T>({
         content: content,
         contentWrapperBuilder: contentWrapperBuilder,
         actions: actions,
-        useSafeArea: useSafeArea,
         size: size,
         type: type,
       ),
@@ -77,7 +75,6 @@ class OptimusDialog extends StatelessWidget {
     this.close,
     this.isDismissible,
     this.position = OptimusDialogPosition.center,
-    this.useSafeArea = false,
   }) : super(key: key);
 
   const OptimusDialog.modal({
@@ -89,7 +86,6 @@ class OptimusDialog extends StatelessWidget {
     OptimusDialogSize size = OptimusDialogSize.regular,
     OptimusDialogType type = OptimusDialogType.common,
     bool? isDismissible,
-    bool useSafeArea = false,
   }) : this._(
           key: key,
           title: title,
@@ -99,7 +95,6 @@ class OptimusDialog extends StatelessWidget {
           size: size,
           type: type,
           isDismissible: isDismissible,
-          useSafeArea: useSafeArea,
         );
 
   const OptimusDialog.nonModal({
@@ -110,7 +105,6 @@ class OptimusDialog extends StatelessWidget {
     List<OptimusDialogAction> actions = const [],
     OptimusDialogSize size = OptimusDialogSize.regular,
     bool? isDismissible,
-    bool useSafeArea = false,
     required VoidCallback close,
   }) : this._(
           key: key,
@@ -122,7 +116,6 @@ class OptimusDialog extends StatelessWidget {
               ? OptimusDialogSize.regular
               : size,
           isDismissible: isDismissible,
-          useSafeArea: useSafeArea,
           close: close,
           position: OptimusDialogPosition.corner,
         );
@@ -167,8 +160,6 @@ class OptimusDialog extends StatelessWidget {
   final OptimusDialogSize size;
 
   final OptimusDialogType type;
-
-  final bool useSafeArea;
 
   OptimusDialogSize _autoSize(BuildContext context) {
     switch (MediaQuery.of(context).screenBreakpoint) {
@@ -215,27 +206,24 @@ class OptimusDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final size = _autoSize(context);
-    Widget dialogContent = DialogContent(
-      title: title,
-      content: content,
-      actions: actions,
-      type: type,
-      size: size,
-      maxWidth: size.width,
-      spacing: spacing300,
-      margin: MediaQuery.of(context).viewInsets,
-      contentWrapperBuilder: contentWrapperBuilder,
-      isDismissible: isDismissible,
-      close: close,
-    );
 
-    if (useSafeArea) {
-      dialogContent = SafeArea(child: dialogContent);
-    }
-
-    return Align(
-      alignment: _alignment(context),
-      child: dialogContent,
+    return SafeArea(
+      child: Align(
+        alignment: _alignment(context),
+        child: DialogContent(
+          title: title,
+          content: content,
+          actions: actions,
+          type: type,
+          size: size,
+          maxWidth: size.width,
+          spacing: spacing300,
+          margin: MediaQuery.of(context).viewInsets,
+          contentWrapperBuilder: contentWrapperBuilder,
+          isDismissible: isDismissible,
+          close: close,
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
[RND-170692]

#### Summary

- Added a possibility to wrap a dialog into the `SafeArea` widget. By default, it is not wrapped (as it was before). You can change it where it is needed.
<details><summary>Screenshots</summary>

![CleanShot 2023-04-24 at 04 40 24](https://user-images.githubusercontent.com/9210422/233888635-e39ec14f-11dd-423d-bf5f-ced47bdb5d51.png)

</details>


#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
