### PR TITLE
fix(optimus): [RND-173007] Fix SegmentedControl text overflow

### DIFF
--- a/optimus/lib/src/segmented_control/segmented_control.dart
+++ b/optimus/lib/src/segmented_control/segmented_control.dart
@@ -18,6 +18,7 @@ class OptimusSegmentedControl<T> extends StatelessWidget {
     this.error,
     this.isEnabled = true,
     this.isRequired = false,
+    this.maxLines,
     this.direction = Axis.horizontal,
   })  : assert(
           items.map((i) => i.value).contains(value),
@@ -53,8 +54,14 @@ class OptimusSegmentedControl<T> extends StatelessWidget {
   /// Direction of the segmented control widget.
   final Axis direction;
 
+  /// Limits the number of lines of the segmented item text. In case of
+  /// the [Axis.horizontal] this will be set to 1.
+  final int? maxLines;
+
   late final _selectedItemIndex =
       items.map((i) => i.value).toList().indexOf(value);
+
+  int? get _maxLines => direction == Axis.horizontal ? 1 : maxLines;
 
   OptimusStackDistribution get _distribution => direction == Axis.horizontal
       ? OptimusStackDistribution.stretch
@@ -90,6 +97,7 @@ class OptimusSegmentedControl<T> extends StatelessWidget {
         groupValue: value,
         onItemSelected: onItemSelected,
         isEnabled: isEnabled,
+        maxLines: _maxLines,
         child: item.label,
       );
 
@@ -121,6 +129,7 @@ class _OptimusSegmentedControlItem<T> extends StatefulWidget {
     required this.groupValue,
     required this.onItemSelected,
     required this.isEnabled,
+    required this.maxLines,
   }) : super(key: key);
 
   final Widget child;
@@ -134,6 +143,8 @@ class _OptimusSegmentedControlItem<T> extends StatefulWidget {
   final ValueChanged<T> onItemSelected;
 
   final bool isEnabled;
+
+  final int? maxLines;
 
   @override
   _OptimusSegmentedControlItemState<T> createState() =>
@@ -199,6 +210,7 @@ class _OptimusSegmentedControlItemState<T>
                   child: DefaultTextStyle.merge(
                     overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.center,
+                    maxLines: widget.maxLines,
                     style: preset300b.copyWith(
                       color: theme.isDark
                           ? theme.colors.neutral0

--- a/storybook/lib/stories/segmented_control.dart
+++ b/storybook/lib/stories/segmented_control.dart
@@ -15,6 +15,19 @@ final Story segmentedControlStory = Story(
       initial: Axis.horizontal,
       options: Axis.values.toOptions(),
     );
+    final maxLines = k.sliderInt(
+      label: 'Max Lines:',
+      description:
+          'Max lines for the vertical layout. Horizontal layout will always be set to 1 line max.',
+      initial: 1,
+      min: 1,
+      max: 3,
+    );
+    final size = k.options(
+      label: 'Size',
+      initial: OptimusWidgetSize.large,
+      options: OptimusWidgetSize.values.toOptions(),
+    );
     final isEnabled = k.boolean(label: 'Enabled', initial: true);
     final isRequired = k.boolean(label: 'Required', initial: false);
 
@@ -28,6 +41,8 @@ final Story segmentedControlStory = Story(
               label: label,
               error: error,
               direction: direction,
+              size: size,
+              maxLines: maxLines,
               isEnabled: isEnabled,
               isRequired: isRequired,
               options: _options2,
@@ -39,6 +54,8 @@ final Story segmentedControlStory = Story(
               label: label,
               error: error,
               direction: direction,
+              size: size,
+              maxLines: maxLines,
               isEnabled: isEnabled,
               isRequired: isRequired,
               options: _options3,
@@ -50,6 +67,8 @@ final Story segmentedControlStory = Story(
               label: label,
               error: error,
               direction: direction,
+              size: size,
+              maxLines: maxLines,
               isEnabled: isEnabled,
               isRequired: isRequired,
               options: _options4,
@@ -61,6 +80,8 @@ final Story segmentedControlStory = Story(
               label: label,
               error: error,
               direction: direction,
+              size: size,
+              maxLines: maxLines,
               isEnabled: isEnabled,
               isRequired: isRequired,
               options: _options5,
@@ -81,6 +102,8 @@ class _SegmentedControlExample extends StatefulWidget {
     required this.isRequired,
     required this.options,
     required this.direction,
+    required this.size,
+    required this.maxLines,
   }) : super(key: key);
 
   final String label;
@@ -89,6 +112,8 @@ class _SegmentedControlExample extends StatefulWidget {
   final bool isRequired;
   final List<String> options;
   final Axis direction;
+  final OptimusWidgetSize size;
+  final int maxLines;
 
   @override
   _SegmentedControlExampleState createState() =>
@@ -102,6 +127,8 @@ class _SegmentedControlExampleState extends State<_SegmentedControlExample> {
   Widget build(BuildContext context) => OptimusSegmentedControl<String>(
         value: _value,
         label: widget.label,
+        size: widget.size,
+        maxLines: widget.maxLines,
         isRequired: widget.isRequired,
         error: widget.error,
         isEnabled: widget.isEnabled,


### PR DESCRIPTION
[RND-173007]

#### Summary

- Added a possibility to limit the lines count to the SegmentedControl. By design, the horizontal SegmentedControl should respect the height it's given. Vertical Segmented control should respect the width but height could be whatever, depending on the text length.
- Updated story. Exposed more options.

#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
