### PR TITLE
build(storybook): Update optimus version in Storybook

### DIFF
--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -302,7 +302,7 @@ packages:
       path: "../optimus"
       relative: true
     source: path
-    version: "0.24.1"
+    version: "0.24.2"
   package_config:
     dependency: transitive
     description:


### PR DESCRIPTION
#### Summary

Bumped `optimus` version in the `storybook`.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
