### PR TITLE
feat(optimus): Allow for customization of `OptimusDateInputField`

### DIFF
--- a/optimus/lib/optimus.dart
+++ b/optimus/lib/optimus.dart
@@ -51,6 +51,7 @@ export 'src/form/input_field.dart';
 export 'src/form/input_form_field.dart';
 export 'src/form/select_form_field.dart';
 export 'src/form/select_input_form_field.dart';
+export 'src/form/styled_input_controller.dart';
 export 'src/icon.dart';
 export 'src/icon_list.dart';
 export 'src/link/inline_link.dart';


### PR DESCRIPTION
#### Summary

This PR allows one to build his own date picker but with the same mask and its behaviour as defined by `OptimusDateInputField`. We want to use it in the new design of Mews Kiosk app. Below is how it looks:

![grab](https://github.com/MewsSystems/mews-flutter/assets/23047178/fec259ac-e6d9-4719-8288-08042a44393d)

#### Testing steps

Test the date picker.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
