### PR TITLE
fix(optimus): [RND-176636] DropdownButton color not updating after dropdown hides

### DIFF
--- a/optimus/lib/src/button/base_dropdown_button.dart
+++ b/optimus/lib/src/button/base_dropdown_button.dart
@@ -50,17 +50,23 @@ class _BaseDropDownButtonState<T> extends State<BaseDropDownButton<T>>
       vsync: this,
     );
     _iconTurns = _controller.drive(_halfTween.chain(_easeInTween));
+    _node.addListener(_onFocusChanged);
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    _node
+      ..removeListener(_onFocusChanged)
+      ..dispose();
     super.dispose();
   }
 
   void _onHoverChanged(bool isHovering) {
     setState(() => _isHovering = isHovering);
   }
+
+  void _onFocusChanged() => setState(() {});
 
   bool get _isEnabled => widget.onItemSelected != null;
 


### PR DESCRIPTION
 [RND-176636] 

#### Summary

- Fixed `OptimusDropdownButton` not updating its color after the interaction with the dropdown.

#### Testing steps

- Open the `Dropdown Button` story and fiddle with it.

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
