### PR TITLE
feat(optimus): [RND-176793] Add custom content padding to the OptimusListTile

### DIFF
--- a/optimus/lib/src/expansion/expansion_tile.dart
+++ b/optimus/lib/src/expansion/expansion_tile.dart
@@ -24,6 +24,7 @@ class OptimusExpansionTile extends StatefulWidget {
     this.hasBorders = true,
     this.actionsWidth = 0,
     this.slidableActions = const <Widget>[],
+    this.contentPadding,
   }) : super(key: key);
 
   /// A widget to display before the title.
@@ -71,6 +72,9 @@ class OptimusExpansionTile extends StatefulWidget {
 
   /// List of actions on list tile left swipe.
   final List<Widget> slidableActions;
+
+  /// The padding of the tile's inner content.
+  final EdgeInsets? contentPadding;
 
   @override
   State<OptimusExpansionTile> createState() => _OptimusExpansionTileState();
@@ -154,6 +158,7 @@ class _OptimusExpansionTileState extends State<OptimusExpansionTile>
         onTap: _handleTap,
         prefix: widget.leading,
         title: widget.title,
+        contentPadding: widget.contentPadding,
         subtitle: widget.subtitle,
         suffix: widget.trailing ??
             RotationTransition(

--- a/optimus/lib/src/lists/list_tile.dart
+++ b/optimus/lib/src/lists/list_tile.dart
@@ -26,6 +26,7 @@ class OptimusListTile extends StatelessWidget {
     this.infoWidget,
     this.onTap,
     this.fontVariant = FontVariant.normal,
+    this.contentPadding,
   }) : super(key: key);
 
   /// Communicates the subject of the list item.
@@ -60,6 +61,14 @@ class OptimusListTile extends StatelessWidget {
   /// Font variant, which will determine the text style. See [FontVariant] for
   /// more details.
   final FontVariant fontVariant;
+
+  /// The padding of the list content. If not specified, the default padding
+  /// will be used.
+  final EdgeInsets? contentPadding;
+
+  EdgeInsets get _contentPadding =>
+      contentPadding ??
+      const EdgeInsets.symmetric(vertical: spacing300, horizontal: spacing200);
 
   Widget _buildPrefix(Widget prefix) => Padding(
         padding: const EdgeInsets.only(right: spacing100),
@@ -111,10 +120,7 @@ class OptimusListTile extends StatelessWidget {
     return BaseListTile(
       onTap: onTap,
       content: Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: spacing300,
-          horizontal: spacing200,
-        ),
+        padding: _contentPadding,
         child: Row(
           children: <Widget>[
             if (prefix != null) _buildPrefix(prefix),


### PR DESCRIPTION
[RND-176793]

#### Summary

- At the moment there is no proper way of setting the padding of the content inside the `OptimusListTile`, which is why `commander` is using `ListTile`. `title` is being wrapped in `Padding` to overcome this problem.
- This will add a missing feature and will enable us to use `OptimusListTile` instead of the `ListTile`, to ensure the design is consistent.

#### Testing steps

None. Added custom padding. If not provided will fall back to the previous default value.

#### Follow-up issues

- [RND-175722] - update `commander` to use updated `OptimusListTile`.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
