### PR TITLE
feat(optimus): [RND-173002] Update InputForm colors and style

### DIFF
--- a/optimus/lib/src/form/input_field.dart
+++ b/optimus/lib/src/form/input_field.dart
@@ -290,7 +290,13 @@ class _OptimusInputFieldState extends State<OptimusInputField>
               enabled: widget.isEnabled,
               padding: _prefix != null ? _textWithPrefixPadding : _textPadding,
               style: theme.getTextInputStyle(widget.size),
-              decoration: null,
+              // [CupertinoTextField] will try to resolve colors to its own theme,
+              // this will ensure the visible [BoxDecoration] is from the
+              // [FieldWrapper] above.
+              decoration: const BoxDecoration(
+                color: Color(0x00000000),
+                backgroundBlendMode: BlendMode.dst,
+              ),
               onChanged: widget.onChanged,
               keyboardType: widget.keyboardType,
               obscureText: widget.isPasswordField && !_isShowPasswordEnabled,


### PR DESCRIPTION
[RND-173002]

#### Summary

- Underlying `CupertinoTextField` was resolving disabled color from its theme. This background would cover the border if the input is disabled.
- I've added a transparent BoxDecoration that would ensure the visible decoration is correct.

ps: didn't feel right to import the whole `material.dart` to use `Colors.transparent`, so I've used the direct value there.

<details><summary>Screenshots</summary>

![CleanShot 2023-05-17 at 18 43 30](https://github.com/MewsSystems/mews-flutter/assets/9210422/1e7b4e3f-8a3f-4bc5-9192-84868bee2560)

![CleanShot 2023-05-17 at 18 39 17](https://github.com/MewsSystems/mews-flutter/assets/9210422/4940d1ef-0786-40b3-9e2d-c8e8b0f9f886)

![CleanShot 2023-05-17 at 18 45 54](https://github.com/MewsSystems/mews-flutter/assets/9210422/ce3f42da-4aa3-4a0d-ba45-af33ce0e619a)

![CleanShot 2023-05-17 at 18 46 06](https://github.com/MewsSystems/mews-flutter/assets/9210422/50dee953-a7cd-4695-a7ec-403896dbf234)

</details>


#### Testing steps

1. Open the Storybook story with a component that is using `OptimusInputField`.
2. Check if the disabled light and dark variants look as expected.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
