### PR TITLE
feat(mews_pedantic): Remove deprecated linter rule

### DIFF
--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -75,7 +75,6 @@ linter:
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields
     - prefer_final_in_for_each


### PR DESCRIPTION
#### Summary

- Removed the lint rule that was deprecated in Flutter 3.10. There is no other option now, so this rule is enforced by [default](https://dart.dev/resources/dart-3-migration#colon-syntax-for-default-values).

#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
