### PR TITLE
fix: [RND-164305] Fix OptimusCircleLoader glitch after Flutter 3.7.3

### DIFF
--- a/optimus/lib/src/loader/loader.dart
+++ b/optimus/lib/src/loader/loader.dart
@@ -93,15 +93,6 @@ class OptimusCircleLoader extends StatelessWidget {
     }
   }
 
-  Widget _getCirclePainter(OptimusThemeData theme, double progress) =>
-      CustomPaint(
-        foregroundPainter: CirclePainter(
-          trackColor: _getTrackColor(theme),
-          indicatorColor: _getIndicatorColor(theme),
-          progress: progress,
-        ),
-      );
-
   @override
   Widget build(BuildContext context) {
     final theme = OptimusTheme.of(context);
@@ -110,9 +101,18 @@ class OptimusCircleLoader extends StatelessWidget {
       height: _loaderSize,
       width: _loaderSize,
       child: variant.map(
-        indeterminate: (_) =>
-            SpinningContainer(child: _getCirclePainter(theme, 25)),
-        determinate: (v) => _getCirclePainter(theme, v.progress),
+        indeterminate: (_) => SpinningLoader(
+          progress: 25,
+          trackColor: _getTrackColor(theme),
+          indicatorColor: _getIndicatorColor(theme),
+        ),
+        determinate: (v) => CustomPaint(
+          foregroundPainter: CirclePainter(
+            trackColor: _getTrackColor(theme),
+            indicatorColor: _getIndicatorColor(theme),
+            progress: v.progress,
+          ),
+        ),
       ),
     );
   }

--- a/optimus/lib/src/loader/painter.dart
+++ b/optimus/lib/src/loader/painter.dart
@@ -8,6 +8,7 @@ class CirclePainter extends CustomPainter {
     required this.trackColor,
     required this.indicatorColor,
     required this.progress,
+    this.baseAngle = 0,
   }) : assert(
           progress >= 0 && progress <= 100,
           'progress should be in [0, 100] range',
@@ -16,6 +17,12 @@ class CirclePainter extends CustomPainter {
   final Color trackColor;
   final Color indicatorColor;
   final double progress;
+  final double baseAngle;
+
+  static const _twoPi = 2 * pi;
+  static const _topStartAngle = 3 * pi / 2;
+
+  double get _startAngle => _twoPi * baseAngle + _topStartAngle;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -38,13 +45,17 @@ class CirclePainter extends CustomPainter {
 
     canvas.drawArc(
       Rect.fromCircle(center: center, radius: radius),
-      3 * pi / 2,
-      2 * pi * (progress / 100),
+      _startAngle,
+      _twoPi * (progress / 100),
       false,
       indicatorArc,
     );
   }
 
   @override
-  bool shouldRepaint(CustomPainter oldDelegate) => true;
+  bool shouldRepaint(CirclePainter oldDelegate) =>
+      trackColor != oldDelegate.trackColor ||
+      indicatorColor != oldDelegate.indicatorColor ||
+      progress != oldDelegate.progress ||
+      baseAngle != oldDelegate.baseAngle;
 }

--- a/optimus/lib/src/loader/spinning_container.dart
+++ b/optimus/lib/src/loader/spinning_container.dart
@@ -1,26 +1,35 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:optimus/src/loader/painter.dart';
 
-class SpinningContainer extends StatefulWidget {
-  const SpinningContainer({Key? key, required this.child}) : super(key: key);
+class SpinningLoader extends StatefulWidget {
+  const SpinningLoader({
+    Key? key,
+    required this.progress,
+    required this.trackColor,
+    required this.indicatorColor,
+  }) : super(key: key);
 
-  final Widget child;
+  final double progress;
+  final Color trackColor;
+  final Color indicatorColor;
 
   @override
-  State<SpinningContainer> createState() => _SpinningContainerState();
+  State<SpinningLoader> createState() => _SpinningLoaderState();
 }
 
-class _SpinningContainerState extends State<SpinningContainer>
-    with TickerProviderStateMixin {
+class _SpinningLoaderState extends State<SpinningLoader>
+    with SingleTickerProviderStateMixin {
   late AnimationController _controller;
+
+  static final Animatable<double> _rotationTween =
+      CurveTween(curve: const SawTooth(_rotationCount));
 
   @override
   void initState() {
     super.initState();
     _controller = AnimationController(
-      duration: const Duration(milliseconds: 1500),
+      duration: const Duration(milliseconds: _spinningDuration),
       vsync: this,
     )..repeat();
   }
@@ -32,22 +41,18 @@ class _SpinningContainerState extends State<SpinningContainer>
   }
 
   @override
-  Widget build(BuildContext context) =>
-      _SpinningContainer(widget.child, controller: _controller);
+  Widget build(BuildContext context) => AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) => CustomPaint(
+          foregroundPainter: CirclePainter(
+            trackColor: widget.trackColor,
+            indicatorColor: widget.indicatorColor,
+            progress: widget.progress,
+            baseAngle: _rotationTween.evaluate(_controller),
+          ),
+        ),
+      );
 }
 
-class _SpinningContainer extends AnimatedWidget {
-  const _SpinningContainer(
-    this.child, {
-    Key? key,
-    required AnimationController controller,
-  }) : super(key: key, listenable: controller);
-
-  final Widget child;
-
-  Animation<double> get _progress => listenable as Animation<double>;
-
-  @override
-  Widget build(BuildContext context) =>
-      Transform.rotate(angle: _progress.value * 2.0 * pi, child: child);
-}
+const int _spinningDuration = 15000;
+const int _rotationCount = 15;


### PR DESCRIPTION
[RND-164305]

#### Summary

- After `Flutter v3.7.2` the `OptimuscircleLoader` was glitching when there was a heavy load in the background.
- I've updated the way we spinn the loader, replacing `Transform.rotate` with a bit more complex `CustomPainter` and `AnimatedBuilder` instead.
<details><summary>Video</summary>
Before:

https://github.com/MewsSystems/mews-flutter/assets/9210422/3f4cac70-8e61-4b93-a723-a3679ae19bf0

After:

https://github.com/MewsSystems/mews-flutter/assets/9210422/3fa3b878-c9e3-4ec3-b334-10214447a799

</details>


#### Testing steps

- This wasn't happening in the Storyboard, since we have nearly no load in the background. This glitch was happening in `Kiosk` only. 
- You can build Kiosk with this new version and test that it's not glitching anymore.

#### Follow-up issues

None.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
