### PR TITLE
feat: [RND-177241] Enable theming using tokens

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.freezed.dart linguist-generated=true
+*.tailor.dart linguist-generated=true

--- a/optimus/lib/optimus.dart
+++ b/optimus/lib/optimus.dart
@@ -78,6 +78,7 @@ export 'src/step_bar/step_bar_compact.dart';
 export 'src/step_bar/step_bar_item.dart';
 export 'src/tabs.dart';
 export 'src/tag.dart';
+export 'src/theme/optimus_tokens.dart';
 export 'src/theme/theme.dart';
 export 'src/theme/theme_data.dart';
 export 'src/tooltip/tooltip.dart';

--- a/optimus/lib/src/button/base_button.dart
+++ b/optimus/lib/src/button/base_button.dart
@@ -71,12 +71,13 @@ class BaseButton extends StatelessWidget {
     }
   }
 
-  Color _color(OptimusThemeData theme) {
+  Color _color(BuildContext context, OptimusThemeData theme) {
     switch (variant) {
       case OptimusButtonVariant.defaultButton:
         return theme.isDark ? theme.colors.neutral400 : theme.colors.neutral50;
       case OptimusButtonVariant.primary:
-        return theme.isDark ? theme.colors.primary700 : theme.colors.primary500;
+        // return theme.isDark ? theme.colors.primary700 : theme.colors.primary500;
+        return context.tokens.backgroundInteractivePrimaryDefault;
       case OptimusButtonVariant.text:
         return Colors.transparent;
       case OptimusButtonVariant.destructive:
@@ -100,12 +101,13 @@ class BaseButton extends StatelessWidget {
     }
   }
 
-  Color _hoverColor(OptimusThemeData theme) {
+  Color _hoverColor(BuildContext context, OptimusThemeData theme) {
     switch (variant) {
       case OptimusButtonVariant.defaultButton:
         return theme.isDark ? theme.colors.neutral300 : theme.colors.neutral100;
       case OptimusButtonVariant.primary:
-        return theme.isDark ? theme.colors.primary400 : theme.colors.primary700;
+        // return theme.isDark ? theme.colors.primary400 : theme.colors.primary700;
+        return context.tokens.backgroundInteractivePrimaryHover;
       case OptimusButtonVariant.text:
         return theme.colors.neutral500t8;
       case OptimusButtonVariant.destructive:
@@ -115,7 +117,7 @@ class BaseButton extends StatelessWidget {
     }
   }
 
-  Color _highLightColor(OptimusThemeData theme) {
+  Color _highLightColor(BuildContext context, OptimusThemeData theme) {
     switch (variant) {
       case OptimusButtonVariant.defaultButton:
         return theme.colors.neutral200;
@@ -130,10 +132,15 @@ class BaseButton extends StatelessWidget {
     }
   }
 
-  Color _textColor(OptimusThemeData theme, Set<MaterialState> states) {
+  Color _textColor(
+    BuildContext context,
+    OptimusThemeData theme,
+    Set<MaterialState> states,
+  ) {
     switch (variant) {
       case OptimusButtonVariant.primary:
-        return theme.isDark ? theme.colors.neutral1000 : theme.colors.neutral0;
+        // return theme.isDark ? theme.colors.neutral1000 : theme.colors.neutral0;
+        return context.tokens.textStaticInverse;
       case OptimusButtonVariant.defaultButton:
       case OptimusButtonVariant.text:
         return theme.isDark ? theme.colors.neutral0 : theme.colors.neutral500;
@@ -175,18 +182,21 @@ class BaseButton extends StatelessWidget {
         visualDensity: VisualDensity.standard,
         elevation: 0,
         highlightElevation: 0,
-        highlightColor: _highLightColor(theme),
-        disabledColor: _color(theme),
-        disabledTextColor:
-            MaterialStateColor.resolveWith((s) => _textColor(theme, s)),
+        highlightColor: _highLightColor(context, theme),
+        disabledColor: _color(context, theme),
+        disabledTextColor: MaterialStateColor.resolveWith(
+          (s) => _textColor(context, theme, s),
+        ),
         hoverElevation: 0,
         splashColor: Colors.transparent,
-        hoverColor: _hoverColor(theme),
+        hoverColor: _hoverColor(context, theme),
         onPressed: onPressed,
         animationDuration: buttonAnimationDuration,
         shape: RoundedRectangleBorder(borderRadius: borderRadius),
-        color: _color(theme),
-        textColor: MaterialStateColor.resolveWith((s) => _textColor(theme, s)),
+        color: _color(context, theme),
+        textColor: MaterialStateColor.resolveWith(
+          (s) => _textColor(context, theme, s),
+        ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,

--- a/optimus/lib/src/button/base_button.dart
+++ b/optimus/lib/src/button/base_button.dart
@@ -120,7 +120,7 @@ class BaseButton extends StatelessWidget {
       case OptimusButtonVariant.defaultButton:
         return theme.colors.neutral200;
       case OptimusButtonVariant.primary:
-        return theme.isDark ? theme.colors.primary500 : theme.colors.primary900;
+        return context.tokens.backgroundInteractivePrimaryActive;
       case OptimusButtonVariant.text:
         return theme.colors.neutral500t16;
       case OptimusButtonVariant.destructive:

--- a/optimus/lib/src/button/base_button.dart
+++ b/optimus/lib/src/button/base_button.dart
@@ -76,7 +76,6 @@ class BaseButton extends StatelessWidget {
       case OptimusButtonVariant.defaultButton:
         return theme.isDark ? theme.colors.neutral400 : theme.colors.neutral50;
       case OptimusButtonVariant.primary:
-        // return theme.isDark ? theme.colors.primary700 : theme.colors.primary500;
         return context.tokens.backgroundInteractivePrimaryDefault;
       case OptimusButtonVariant.text:
         return Colors.transparent;
@@ -106,7 +105,6 @@ class BaseButton extends StatelessWidget {
       case OptimusButtonVariant.defaultButton:
         return theme.isDark ? theme.colors.neutral300 : theme.colors.neutral100;
       case OptimusButtonVariant.primary:
-        // return theme.isDark ? theme.colors.primary400 : theme.colors.primary700;
         return context.tokens.backgroundInteractivePrimaryHover;
       case OptimusButtonVariant.text:
         return theme.colors.neutral500t8;
@@ -139,7 +137,6 @@ class BaseButton extends StatelessWidget {
   ) {
     switch (variant) {
       case OptimusButtonVariant.primary:
-        // return theme.isDark ? theme.colors.neutral1000 : theme.colors.neutral0;
         return context.tokens.textStaticInverse;
       case OptimusButtonVariant.defaultButton:
       case OptimusButtonVariant.text:

--- a/optimus/lib/src/button/base_button.dart
+++ b/optimus/lib/src/button/base_button.dart
@@ -71,12 +71,12 @@ class BaseButton extends StatelessWidget {
     }
   }
 
-  Color _color(BuildContext context, OptimusThemeData theme) {
+  Color _color(OptimusThemeData theme) {
     switch (variant) {
       case OptimusButtonVariant.defaultButton:
         return theme.isDark ? theme.colors.neutral400 : theme.colors.neutral50;
       case OptimusButtonVariant.primary:
-        return context.tokens.backgroundInteractivePrimaryDefault;
+        return theme.isDark ? theme.colors.primary700 : theme.colors.primary500;
       case OptimusButtonVariant.text:
         return Colors.transparent;
       case OptimusButtonVariant.destructive:
@@ -100,12 +100,12 @@ class BaseButton extends StatelessWidget {
     }
   }
 
-  Color _hoverColor(BuildContext context, OptimusThemeData theme) {
+  Color _hoverColor(OptimusThemeData theme) {
     switch (variant) {
       case OptimusButtonVariant.defaultButton:
         return theme.isDark ? theme.colors.neutral300 : theme.colors.neutral100;
       case OptimusButtonVariant.primary:
-        return context.tokens.backgroundInteractivePrimaryHover;
+        return theme.isDark ? theme.colors.primary400 : theme.colors.primary700;
       case OptimusButtonVariant.text:
         return theme.colors.neutral500t8;
       case OptimusButtonVariant.destructive:
@@ -115,12 +115,12 @@ class BaseButton extends StatelessWidget {
     }
   }
 
-  Color _highLightColor(BuildContext context, OptimusThemeData theme) {
+  Color _highLightColor(OptimusThemeData theme) {
     switch (variant) {
       case OptimusButtonVariant.defaultButton:
         return theme.colors.neutral200;
       case OptimusButtonVariant.primary:
-        return context.tokens.backgroundInteractivePrimaryActive;
+        return theme.isDark ? theme.colors.primary500 : theme.colors.primary900;
       case OptimusButtonVariant.text:
         return theme.colors.neutral500t16;
       case OptimusButtonVariant.destructive:
@@ -130,14 +130,10 @@ class BaseButton extends StatelessWidget {
     }
   }
 
-  Color _textColor(
-    BuildContext context,
-    OptimusThemeData theme,
-    Set<MaterialState> states,
-  ) {
+  Color _textColor(OptimusThemeData theme, Set<MaterialState> states) {
     switch (variant) {
       case OptimusButtonVariant.primary:
-        return context.tokens.textStaticInverse;
+        return theme.isDark ? theme.colors.neutral1000 : theme.colors.neutral0;
       case OptimusButtonVariant.defaultButton:
       case OptimusButtonVariant.text:
         return theme.isDark ? theme.colors.neutral0 : theme.colors.neutral500;
@@ -179,21 +175,18 @@ class BaseButton extends StatelessWidget {
         visualDensity: VisualDensity.standard,
         elevation: 0,
         highlightElevation: 0,
-        highlightColor: _highLightColor(context, theme),
-        disabledColor: _color(context, theme),
-        disabledTextColor: MaterialStateColor.resolveWith(
-          (s) => _textColor(context, theme, s),
-        ),
+        highlightColor: _highLightColor(theme),
+        disabledColor: _color(theme),
+        disabledTextColor:
+            MaterialStateColor.resolveWith((s) => _textColor(theme, s)),
         hoverElevation: 0,
         splashColor: Colors.transparent,
-        hoverColor: _hoverColor(context, theme),
+        hoverColor: _hoverColor(theme),
         onPressed: onPressed,
         animationDuration: buttonAnimationDuration,
         shape: RoundedRectangleBorder(borderRadius: borderRadius),
-        color: _color(context, theme),
-        textColor: MaterialStateColor.resolveWith(
-          (s) => _textColor(context, theme, s),
-        ),
+        color: _color(theme),
+        textColor: MaterialStateColor.resolveWith((s) => _textColor(theme, s)),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,

--- a/optimus/lib/src/theme/optimus_tokens.dart
+++ b/optimus/lib/src/theme/optimus_tokens.dart
@@ -242,6 +242,11 @@ class _$OptimusTokens {
     DesignTokensColorDark.borderInteractiveSecondaryActive
   ];
 
+  static List<Color> borderInteractiveSecondaryDefault = [
+    DesignTokensColorLight.borderInteractiveSecondaryDefault,
+    DesignTokensColorDark.borderInteractiveSecondaryDefault
+  ];
+
   static List<Color> borderInteractiveSecondaryHover = [
     DesignTokensColorLight.borderInteractiveSecondaryHover,
     DesignTokensColorDark.borderInteractiveSecondaryHover

--- a/optimus/lib/src/theme/optimus_tokens.dart
+++ b/optimus/lib/src/theme/optimus_tokens.dart
@@ -14,39 +14,1258 @@ class _$OptimusTokens {
     DesignTokensColorLight.backgroundAccentPrimary,
     DesignTokensColorDark.backgroundAccentPrimary
   ];
-
   static List<Color> backgroundAccentSecondary = [
     DesignTokensColorLight.backgroundAccentSecondary,
     DesignTokensColorDark.backgroundAccentSecondary
   ];
-
   static List<Color> backgroundAlertBasicPrimary = [
     DesignTokensColorLight.backgroundAlertBasicPrimary,
     DesignTokensColorDark.backgroundAlertBasicPrimary
   ];
-
-  static List<Color> backgroundInteractivePrimaryDefault = [
-    DesignTokensColorLight.backgroundInteractivePrimaryDefault,
-    DesignTokensColorDark.backgroundInteractivePrimaryDefault,
+  static List<Color> backgroundAlertBasicSecondary = [
+    DesignTokensColorLight.backgroundAlertBasicSecondary,
+    DesignTokensColorDark.backgroundAlertBasicSecondary
+  ];
+  static List<Color> backgroundAlertDangerPrimary = [
+    DesignTokensColorLight.backgroundAlertDangerPrimary,
+    DesignTokensColorDark.backgroundAlertDangerPrimary
   ];
 
-  static List<Color> textStaticInverse = [
-    DesignTokensColorLight.textStaticInverse,
-    DesignTokensColorDark.textStaticInverse,
+  static List<Color> backgroundAlertDangerSecondary = [
+    DesignTokensColorLight.backgroundAlertDangerSecondary,
+    DesignTokensColorDark.backgroundAlertDangerSecondary
   ];
 
-  static List<Color> backgroundInteractivePrimaryHover = [
-    DesignTokensColorLight.backgroundInteractivePrimaryHover,
-    DesignTokensColorDark.backgroundInteractivePrimaryHover,
+  static List<Color> backgroundAlertInfoPrimary = [
+    DesignTokensColorLight.backgroundAlertInfoPrimary,
+    DesignTokensColorDark.backgroundAlertInfoPrimary
   ];
 
-  static List<Color> backgroundInteractivePrimaryActive = [
-    DesignTokensColorLight.backgroundInteractivePrimaryActive,
-    DesignTokensColorDark.backgroundInteractivePrimaryActive,
+  static List<Color> backgroundAlertInfoSecondary = [
+    DesignTokensColorLight.backgroundAlertInfoSecondary,
+    DesignTokensColorDark.backgroundAlertInfoSecondary
+  ];
+
+  static List<Color> backgroundAlertSuccessPrimary = [
+    DesignTokensColorLight.backgroundAlertSuccessPrimary,
+    DesignTokensColorDark.backgroundAlertSuccessPrimary
+  ];
+
+  static List<Color> backgroundAlertSuccessSecondary = [
+    DesignTokensColorLight.backgroundAlertSuccessSecondary,
+    DesignTokensColorDark.backgroundAlertSuccessSecondary
+  ];
+
+  static List<Color> backgroundAlertWarningPrimary = [
+    DesignTokensColorLight.backgroundAlertWarningPrimary,
+    DesignTokensColorDark.backgroundAlertWarningPrimary
+  ];
+
+  static List<Color> backgroundAlertWarningSecondary = [
+    DesignTokensColorLight.backgroundAlertWarningSecondary,
+    DesignTokensColorDark.backgroundAlertWarningSecondary
+  ];
+
+  static List<Color> backgroundBrand = [
+    DesignTokensColorLight.backgroundBrand,
+    DesignTokensColorDark.backgroundBrand
   ];
 
   static List<Color> backgroundDisabled = [
     DesignTokensColorLight.backgroundDisabled,
-    DesignTokensColorDark.backgroundDisabled,
+    DesignTokensColorDark.backgroundDisabled
+  ];
+
+  static List<Color> backgroundInteractiveBoldActive = [
+    DesignTokensColorLight.backgroundInteractiveBoldActive,
+    DesignTokensColorDark.backgroundInteractiveBoldActive
+  ];
+
+  static List<Color> backgroundInteractiveBoldDefault = [
+    DesignTokensColorLight.backgroundInteractiveBoldDefault,
+    DesignTokensColorDark.backgroundInteractiveBoldDefault
+  ];
+
+  static List<Color> backgroundInteractiveBoldHover = [
+    DesignTokensColorLight.backgroundInteractiveBoldHover,
+    DesignTokensColorDark.backgroundInteractiveBoldHover
+  ];
+
+  static List<Color> backgroundInteractiveDangerActive = [
+    DesignTokensColorLight.backgroundInteractiveDangerActive,
+    DesignTokensColorDark.backgroundInteractiveDangerActive
+  ];
+
+  static List<Color> backgroundInteractiveDangerDefault = [
+    DesignTokensColorLight.backgroundInteractiveDangerDefault,
+    DesignTokensColorDark.backgroundInteractiveDangerDefault
+  ];
+
+  static List<Color> backgroundInteractiveDangerHover = [
+    DesignTokensColorLight.backgroundInteractiveDangerHover,
+    DesignTokensColorDark.backgroundInteractiveDangerHover
+  ];
+
+  static List<Color> backgroundInteractivePrimaryActive = [
+    DesignTokensColorLight.backgroundInteractivePrimaryActive,
+    DesignTokensColorDark.backgroundInteractivePrimaryActive
+  ];
+
+  static List<Color> backgroundInteractivePrimaryDefault = [
+    DesignTokensColorLight.backgroundInteractivePrimaryDefault,
+    DesignTokensColorDark.backgroundInteractivePrimaryDefault
+  ];
+
+  static List<Color> backgroundInteractivePrimaryHover = [
+    DesignTokensColorLight.backgroundInteractivePrimaryHover,
+    DesignTokensColorDark.backgroundInteractivePrimaryHover
+  ];
+
+  static List<Color> backgroundInteractiveSecondaryActive = [
+    DesignTokensColorLight.backgroundInteractiveSecondaryActive,
+    DesignTokensColorDark.backgroundInteractiveSecondaryActive
+  ];
+
+  static List<Color> backgroundInteractiveSecondaryDefault = [
+    DesignTokensColorLight.backgroundInteractiveSecondaryDefault,
+    DesignTokensColorDark.backgroundInteractiveSecondaryDefault
+  ];
+
+  static List<Color> backgroundInteractiveSecondaryHover = [
+    DesignTokensColorLight.backgroundInteractiveSecondaryHover,
+    DesignTokensColorDark.backgroundInteractiveSecondaryHover
+  ];
+
+  static List<Color> backgroundInteractiveSubtleActive = [
+    DesignTokensColorLight.backgroundInteractiveSubtleActive,
+    DesignTokensColorDark.backgroundInteractiveSubtleActive
+  ];
+
+  static List<Color> backgroundInteractiveSubtleDefault = [
+    DesignTokensColorLight.backgroundInteractiveSubtleDefault,
+    DesignTokensColorDark.backgroundInteractiveSubtleDefault
+  ];
+
+  static List<Color> backgroundInteractiveSubtleHover = [
+    DesignTokensColorLight.backgroundInteractiveSubtleHover,
+    DesignTokensColorDark.backgroundInteractiveSubtleHover
+  ];
+
+  static List<Color> backgroundOverlay = [
+    DesignTokensColorLight.backgroundOverlay,
+    DesignTokensColorLight.backgroundOverlay //TODO(witwash): add dark token
+  ];
+
+  static List<Color> backgroundStaticFlat = [
+    DesignTokensColorLight.backgroundStaticFlat,
+    DesignTokensColorDark.backgroundStaticFlat
+  ];
+
+  static List<Color> backgroundStaticFloating = [
+    DesignTokensColorLight.backgroundStaticFloating,
+    DesignTokensColorDark.backgroundStaticFloating
+  ];
+
+  static List<Color> backgroundStaticInverse = [
+    DesignTokensColorLight.backgroundStaticInverse,
+    DesignTokensColorDark.backgroundStaticInverse
+  ];
+
+  static List<Color> backgroundStaticRaised = [
+    DesignTokensColorLight.backgroundStaticRaised,
+    DesignTokensColorDark.backgroundStaticRaised
+  ];
+
+  static List<Color> backgroundStaticSunken = [
+    DesignTokensColorLight.backgroundStaticSunken,
+    DesignTokensColorDark.backgroundStaticSunken
+  ];
+
+  static List<Color> borderAlertBasic = [
+    DesignTokensColorLight.borderAlertBasic,
+    DesignTokensColorDark.borderAlertBasic
+  ];
+
+  static List<Color> borderAlertDanger = [
+    DesignTokensColorLight.borderAlertDanger,
+    DesignTokensColorDark.borderAlertDanger
+  ];
+
+  static List<Color> borderAlertInfo = [
+    DesignTokensColorLight.borderAlertInfo,
+    DesignTokensColorDark.borderAlertInfo
+  ];
+
+  static List<Color> borderAlertSuccess = [
+    DesignTokensColorLight.borderAlertSuccess,
+    DesignTokensColorDark.borderAlertSuccess
+  ];
+
+  static List<Color> borderAlertWarning = [
+    DesignTokensColorLight.borderAlertWarning,
+    DesignTokensColorDark.borderAlertWarning
+  ];
+
+  static List<Color> borderDisabled = [
+    DesignTokensColorLight.borderDisabled,
+    DesignTokensColorDark.borderDisabled
+  ];
+
+  static List<Color> borderInteractiveError = [
+    DesignTokensColorLight.borderInteractiveError,
+    DesignTokensColorLight
+        .borderInteractiveError //TODO(witwash): add dark token
+  ];
+
+  static List<Color> borderInteractiveFocus = [
+    DesignTokensColorLight.borderInteractiveFocus,
+    DesignTokensColorDark.borderInteractiveFocus
+  ];
+
+  static List<Color> borderInteractivePrimaryActive = [
+    DesignTokensColorLight.borderInteractivePrimaryActive,
+    DesignTokensColorDark.borderInteractivePrimaryActive
+  ];
+
+  static List<Color> borderInteractivePrimaryDefault = [
+    DesignTokensColorLight.borderInteractivePrimaryDefault,
+    DesignTokensColorDark.borderInteractivePrimaryDefault
+  ];
+
+  static List<Color> borderInteractivePrimaryHover = [
+    DesignTokensColorLight.borderInteractivePrimaryHover,
+    DesignTokensColorDark.borderInteractivePrimaryHover
+  ];
+
+  static List<Color> borderInteractiveSecondaryActive = [
+    DesignTokensColorLight.borderInteractiveSecondaryActive,
+    DesignTokensColorDark.borderInteractiveSecondaryActive
+  ];
+
+  static List<Color> borderInteractiveSecondaryHover = [
+    DesignTokensColorLight.borderInteractiveSecondaryHover,
+    DesignTokensColorDark.borderInteractiveSecondaryHover
+  ];
+
+  static List<Color> borderStaticInverse = [
+    DesignTokensColorLight.borderStaticInverse,
+    DesignTokensColorDark.borderStaticInverse
+  ];
+
+  static List<Color> borderStaticPrimary = [
+    DesignTokensColorLight.borderStaticPrimary,
+    DesignTokensColorDark.borderStaticPrimary
+  ];
+
+  static List<Color> borderStaticSecondary = [
+    DesignTokensColorLight.borderStaticSecondary,
+    DesignTokensColorDark.borderStaticSecondary
+  ];
+
+  static List<Color> inputActiveColor = [
+    DesignTokensColorLight.inputActiveColor,
+    DesignTokensColorLight.inputActiveColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> inputDangerColor = [
+    DesignTokensColorLight.inputDangerColor,
+    DesignTokensColorLight.inputDangerColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> inputDefaultColor = [
+    DesignTokensColorLight.inputDefaultColor,
+    DesignTokensColorLight.inputDefaultColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> inputDisabledColor = [
+    DesignTokensColorLight.inputDisabledColor,
+    DesignTokensColorLight.inputDisabledColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> inputHoverColor = [
+    DesignTokensColorLight.inputHoverColor,
+    DesignTokensColorLight.inputHoverColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> inputInverseColor = [
+    DesignTokensColorLight.inputInverseColor,
+    DesignTokensColorLight.inputInverseColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> interactiveDangerColor = [
+    DesignTokensColorLight.interactiveDangerColor,
+    DesignTokensColorLight
+        .interactiveDangerColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> interactiveDefaultColor = [
+    DesignTokensColorLight.interactiveDefaultColor,
+    DesignTokensColorLight
+        .interactiveDefaultColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> interactiveDisabledColor = [
+    DesignTokensColorLight.interactiveDisabledColor,
+    DesignTokensColorLight
+        .interactiveDisabledColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> interactiveHoverColor = [
+    DesignTokensColorLight.interactiveHoverColor,
+    DesignTokensColorLight.interactiveHoverColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> interactiveInverseColor = [
+    DesignTokensColorLight.interactiveInverseColor,
+    DesignTokensColorLight
+        .interactiveInverseColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteBasicsBlack = [
+    DesignTokensColorLight.paletteBasicsBlack,
+    DesignTokensColorDark.paletteBasicsBlack
+  ];
+
+  static List<Color> paletteBasicsWhite = [
+    DesignTokensColorLight.paletteBasicsWhite,
+    DesignTokensColorDark.paletteBasicsWhite
+  ];
+
+  static List<Color> paletteBasicsWhite64 = [
+    DesignTokensColorLight.paletteBasicsWhite64,
+    DesignTokensColorDark.paletteBasicsWhite64
+  ];
+
+  static List<Color> paletteBrandCoral100 = [
+    DesignTokensColorLight.paletteBrandCoral100,
+    DesignTokensColorDark.paletteBrandCoral100
+  ];
+
+  static List<Color> paletteBrandCoral1000 = [
+    DesignTokensColorLight.paletteBrandCoral1000,
+    DesignTokensColorLight.paletteBrandCoral1000 //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteBrandCoral150 = [
+    DesignTokensColorLight.paletteBrandCoral150,
+    DesignTokensColorDark.paletteBrandCoral150
+  ];
+
+  static List<Color> paletteBrandCoral200 = [
+    DesignTokensColorLight.paletteBrandCoral200,
+    DesignTokensColorDark.paletteBrandCoral200
+  ];
+
+  static List<Color> paletteBrandCoral25 = [
+    DesignTokensColorLight.paletteBrandCoral25,
+    DesignTokensColorDark.paletteBrandCoral25
+  ];
+
+  static List<Color> paletteBrandCoral300 = [
+    DesignTokensColorLight.paletteBrandCoral300,
+    DesignTokensColorDark.paletteBrandCoral300
+  ];
+
+  static List<Color> paletteBrandCoral400 = [
+    DesignTokensColorLight.paletteBrandCoral400,
+    DesignTokensColorDark.paletteBrandCoral400
+  ];
+
+  static List<Color> paletteBrandCoral50 = [
+    DesignTokensColorLight.paletteBrandCoral50,
+    DesignTokensColorDark.paletteBrandCoral50
+  ];
+
+  static List<Color> paletteBrandCoral500 = [
+    DesignTokensColorLight.paletteBrandCoral500,
+    DesignTokensColorDark.paletteBrandCoral500
+  ];
+
+  static List<Color> paletteBrandCoral600 = [
+    DesignTokensColorLight.paletteBrandCoral600,
+    DesignTokensColorDark.paletteBrandCoral600
+  ];
+
+  static List<Color> paletteBrandCoral700 = [
+    DesignTokensColorLight.paletteBrandCoral700,
+    DesignTokensColorDark.paletteBrandCoral700
+  ];
+
+  static List<Color> paletteBrandCoral800 = [
+    DesignTokensColorLight.paletteBrandCoral800,
+    DesignTokensColorDark.paletteBrandCoral800
+  ];
+
+  static List<Color> paletteBrandCoral900 = [
+    DesignTokensColorLight.paletteBrandCoral900,
+    DesignTokensColorDark.paletteBrandCoral900
+  ];
+
+  static List<Color> paletteBrandGrey0 = [
+    DesignTokensColorLight.paletteBrandGrey0,
+    DesignTokensColorDark.paletteBrandGrey0
+  ];
+
+  static List<Color> paletteBrandGrey100 = [
+    DesignTokensColorLight.paletteBrandGrey100,
+    DesignTokensColorDark.paletteBrandGrey100
+  ];
+
+  static List<Color> paletteBrandGrey1000 = [
+    DesignTokensColorLight.paletteBrandGrey1000,
+    DesignTokensColorDark.paletteBrandGrey1000
+  ];
+
+  static List<Color> paletteBrandGrey150 = [
+    DesignTokensColorLight.paletteBrandGrey150,
+    DesignTokensColorDark.paletteBrandGrey150
+  ];
+
+  static List<Color> paletteBrandGrey200 = [
+    DesignTokensColorLight.paletteBrandGrey200,
+    DesignTokensColorDark.paletteBrandGrey200
+  ];
+
+  static List<Color> paletteBrandGrey25 = [
+    DesignTokensColorLight.paletteBrandGrey25,
+    DesignTokensColorDark.paletteBrandGrey25
+  ];
+
+  static List<Color> paletteBrandGrey300 = [
+    DesignTokensColorLight.paletteBrandGrey300,
+    DesignTokensColorDark.paletteBrandGrey300
+  ];
+
+  static List<Color> paletteBrandGrey400 = [
+    DesignTokensColorLight.paletteBrandGrey400,
+    DesignTokensColorDark.paletteBrandGrey400
+  ];
+
+  static List<Color> paletteBrandGrey50 = [
+    DesignTokensColorLight.paletteBrandGrey50,
+    DesignTokensColorDark.paletteBrandGrey50
+  ];
+
+  static List<Color> paletteBrandGrey500 = [
+    DesignTokensColorLight.paletteBrandGrey500,
+    DesignTokensColorDark.paletteBrandGrey500
+  ];
+
+  static List<Color> paletteBrandGrey600 = [
+    DesignTokensColorLight.paletteBrandGrey600,
+    DesignTokensColorDark.paletteBrandGrey600
+  ];
+
+  static List<Color> paletteBrandGrey700 = [
+    DesignTokensColorLight.paletteBrandGrey700,
+    DesignTokensColorDark.paletteBrandGrey700
+  ];
+
+  static List<Color> paletteBrandGrey800 = [
+    DesignTokensColorLight.paletteBrandGrey800,
+    DesignTokensColorDark.paletteBrandGrey800
+  ];
+
+  static List<Color> paletteBrandGrey900 = [
+    DesignTokensColorLight.paletteBrandGrey900,
+    DesignTokensColorDark.paletteBrandGrey900
+  ];
+
+  static List<Color> paletteBrandIndigo100 = [
+    DesignTokensColorLight.paletteBrandIndigo100,
+    DesignTokensColorDark.paletteBrandIndigo100
+  ];
+
+  static List<Color> paletteBrandIndigo1000 = [
+    DesignTokensColorLight.paletteBrandIndigo1000,
+    DesignTokensColorLight
+        .paletteBrandIndigo1000 //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteBrandIndigo150 = [
+    DesignTokensColorLight.paletteBrandIndigo150,
+    DesignTokensColorDark.paletteBrandIndigo150
+  ];
+
+  static List<Color> paletteBrandIndigo200 = [
+    DesignTokensColorLight.paletteBrandIndigo200,
+    DesignTokensColorDark.paletteBrandIndigo200
+  ];
+
+  static List<Color> paletteBrandIndigo25 = [
+    DesignTokensColorLight.paletteBrandIndigo25,
+    DesignTokensColorDark.paletteBrandIndigo25
+  ];
+
+  static List<Color> paletteBrandIndigo300 = [
+    DesignTokensColorLight.paletteBrandIndigo300,
+    DesignTokensColorDark.paletteBrandIndigo300
+  ];
+
+  static List<Color> paletteBrandIndigo400 = [
+    DesignTokensColorLight.paletteBrandIndigo400,
+    DesignTokensColorDark.paletteBrandIndigo400
+  ];
+
+  static List<Color> paletteBrandIndigo50 = [
+    DesignTokensColorLight.paletteBrandIndigo50,
+    DesignTokensColorDark.paletteBrandIndigo50
+  ];
+
+  static List<Color> paletteBrandIndigo500 = [
+    DesignTokensColorLight.paletteBrandIndigo500,
+    DesignTokensColorDark.paletteBrandIndigo500
+  ];
+
+  static List<Color> paletteBrandIndigo600 = [
+    DesignTokensColorLight.paletteBrandIndigo600,
+    DesignTokensColorDark.paletteBrandIndigo600
+  ];
+
+  static List<Color> paletteBrandIndigo700 = [
+    DesignTokensColorLight.paletteBrandIndigo700,
+    DesignTokensColorDark.paletteBrandIndigo700
+  ];
+
+  static List<Color> paletteBrandIndigo800 = [
+    DesignTokensColorLight.paletteBrandIndigo800,
+    DesignTokensColorDark.paletteBrandIndigo800
+  ];
+
+  static List<Color> paletteBrandIndigo900 = [
+    DesignTokensColorLight.paletteBrandIndigo900,
+    DesignTokensColorDark.paletteBrandIndigo900
+  ];
+
+  static List<Color> paletteBrandNight0 = [
+    DesignTokensColorLight.paletteBrandNight0,
+    DesignTokensColorDark.paletteBrandNight0
+  ];
+
+  static List<Color> paletteBrandNight100 = [
+    DesignTokensColorLight.paletteBrandNight100,
+    DesignTokensColorDark.paletteBrandNight100
+  ];
+
+  static List<Color> paletteBrandNight1000 = [
+    DesignTokensColorLight.paletteBrandNight1000,
+    DesignTokensColorDark.paletteBrandNight1000
+  ];
+
+  static List<Color> paletteBrandNight100012 = [
+    DesignTokensColorLight.paletteBrandNight100012,
+    DesignTokensColorLight
+        .paletteBrandNight100012 //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteBrandNight100016 = [
+    DesignTokensColorLight.paletteBrandNight100016,
+    DesignTokensColorLight
+        .paletteBrandNight100016 //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteBrandNight10008 = [
+    DesignTokensColorLight.paletteBrandNight10008,
+    DesignTokensColorLight
+        .paletteBrandNight10008 //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteBrandNight150 = [
+    DesignTokensColorLight.paletteBrandNight150,
+    DesignTokensColorDark.paletteBrandNight150
+  ];
+
+  static List<Color> paletteBrandNight200 = [
+    DesignTokensColorLight.paletteBrandNight200,
+    DesignTokensColorDark.paletteBrandNight200
+  ];
+
+  static List<Color> paletteBrandNight25 = [
+    DesignTokensColorLight.paletteBrandNight25,
+    DesignTokensColorDark.paletteBrandNight25
+  ];
+
+  static List<Color> paletteBrandNight300 = [
+    DesignTokensColorLight.paletteBrandNight300,
+    DesignTokensColorDark.paletteBrandNight300
+  ];
+
+  static List<Color> paletteBrandNight400 = [
+    DesignTokensColorLight.paletteBrandNight400,
+    DesignTokensColorDark.paletteBrandNight400
+  ];
+
+  static List<Color> paletteBrandNight50 = [
+    DesignTokensColorLight.paletteBrandNight50,
+    DesignTokensColorDark.paletteBrandNight50
+  ];
+
+  static List<Color> paletteBrandNight500 = [
+    DesignTokensColorLight.paletteBrandNight500,
+    DesignTokensColorDark.paletteBrandNight500
+  ];
+
+  static List<Color> paletteBrandNight600 = [
+    DesignTokensColorLight.paletteBrandNight600,
+    DesignTokensColorDark.paletteBrandNight600
+  ];
+
+  static List<Color> paletteBrandNight700 = [
+    DesignTokensColorLight.paletteBrandNight700,
+    DesignTokensColorDark.paletteBrandNight700
+  ];
+
+  static List<Color> paletteBrandNight800 = [
+    DesignTokensColorLight.paletteBrandNight800,
+    DesignTokensColorDark.paletteBrandNight800
+  ];
+
+  static List<Color> paletteBrandNight900 = [
+    DesignTokensColorLight.paletteBrandNight900,
+    DesignTokensColorDark.paletteBrandNight900
+  ];
+
+  static List<Color> paletteDatavizDenim100 = [
+    DesignTokensColorLight.paletteDatavizDenim100,
+    DesignTokensColorDark.paletteDatavizDenim100
+  ];
+
+  static List<Color> paletteDatavizDenim200 = [
+    DesignTokensColorLight.paletteDatavizDenim200,
+    DesignTokensColorDark.paletteDatavizDenim200
+  ];
+
+  static List<Color> paletteDatavizDenim300 = [
+    DesignTokensColorLight.paletteDatavizDenim300,
+    DesignTokensColorDark.paletteDatavizDenim300
+  ];
+
+  static List<Color> paletteDatavizDenim400 = [
+    DesignTokensColorLight.paletteDatavizDenim400,
+    DesignTokensColorDark.paletteDatavizDenim400
+  ];
+
+  static List<Color> paletteDatavizDenim50 = [
+    DesignTokensColorLight.paletteDatavizDenim50,
+    DesignTokensColorDark.paletteDatavizDenim50
+  ];
+
+  static List<Color> paletteDatavizDenim500 = [
+    DesignTokensColorLight.paletteDatavizDenim500,
+    DesignTokensColorDark.paletteDatavizDenim500
+  ];
+
+  static List<Color> paletteDatavizDenim600 = [
+    DesignTokensColorLight.paletteDatavizDenim600,
+    DesignTokensColorDark.paletteDatavizDenim600
+  ];
+
+  static List<Color> paletteDatavizDenim700 = [
+    DesignTokensColorLight.paletteDatavizDenim700,
+    DesignTokensColorDark.paletteDatavizDenim700
+  ];
+
+  static List<Color> paletteDatavizDenim800 = [
+    DesignTokensColorLight.paletteDatavizDenim800,
+    DesignTokensColorDark.paletteDatavizDenim800
+  ];
+
+  static List<Color> paletteDatavizDenim900 = [
+    DesignTokensColorLight.paletteDatavizDenim900,
+    DesignTokensColorDark.paletteDatavizDenim900
+  ];
+
+  static List<Color> paletteDatavizLavender100 = [
+    DesignTokensColorLight.paletteDatavizLavender100,
+    DesignTokensColorDark.paletteDatavizLavender100
+  ];
+
+  static List<Color> paletteDatavizLavender200 = [
+    DesignTokensColorLight.paletteDatavizLavender200,
+    DesignTokensColorDark.paletteDatavizLavender200
+  ];
+
+  static List<Color> paletteDatavizLavender300 = [
+    DesignTokensColorLight.paletteDatavizLavender300,
+    DesignTokensColorDark.paletteDatavizLavender300
+  ];
+
+  static List<Color> paletteDatavizLavender400 = [
+    DesignTokensColorLight.paletteDatavizLavender400,
+    DesignTokensColorDark.paletteDatavizLavender400
+  ];
+
+  static List<Color> paletteDatavizLavender50 = [
+    DesignTokensColorLight.paletteDatavizLavender50,
+    DesignTokensColorDark.paletteDatavizLavender50
+  ];
+
+  static List<Color> paletteDatavizLavender500 = [
+    DesignTokensColorLight.paletteDatavizLavender500,
+    DesignTokensColorDark.paletteDatavizLavender500
+  ];
+
+  static List<Color> paletteDatavizLavender600 = [
+    DesignTokensColorLight.paletteDatavizLavender600,
+    DesignTokensColorDark.paletteDatavizLavender600
+  ];
+
+  static List<Color> paletteDatavizLavender700 = [
+    DesignTokensColorLight.paletteDatavizLavender700,
+    DesignTokensColorDark.paletteDatavizLavender700
+  ];
+
+  static List<Color> paletteDatavizLavender800 = [
+    DesignTokensColorLight.paletteDatavizLavender800,
+    DesignTokensColorDark.paletteDatavizLavender800
+  ];
+
+  static List<Color> paletteDatavizLavender900 = [
+    DesignTokensColorLight.paletteDatavizLavender900,
+    DesignTokensColorDark.paletteDatavizLavender900
+  ];
+
+  static List<Color> paletteDatavizLime100 = [
+    DesignTokensColorLight.paletteDatavizLime100,
+    DesignTokensColorDark.paletteDatavizLime100
+  ];
+
+  static List<Color> paletteDatavizLime200 = [
+    DesignTokensColorLight.paletteDatavizLime200,
+    DesignTokensColorDark.paletteDatavizLime200
+  ];
+
+  static List<Color> paletteDatavizLime300 = [
+    DesignTokensColorLight.paletteDatavizLime300,
+    DesignTokensColorDark.paletteDatavizLime300
+  ];
+
+  static List<Color> paletteDatavizLime400 = [
+    DesignTokensColorLight.paletteDatavizLime400,
+    DesignTokensColorDark.paletteDatavizLime400
+  ];
+
+  static List<Color> paletteDatavizLime50 = [
+    DesignTokensColorLight.paletteDatavizLime50,
+    DesignTokensColorDark.paletteDatavizLime50
+  ];
+
+  static List<Color> paletteDatavizLime500 = [
+    DesignTokensColorLight.paletteDatavizLime500,
+    DesignTokensColorDark.paletteDatavizLime500
+  ];
+
+  static List<Color> paletteDatavizLime600 = [
+    DesignTokensColorLight.paletteDatavizLime600,
+    DesignTokensColorDark.paletteDatavizLime600
+  ];
+
+  static List<Color> paletteDatavizLime700 = [
+    DesignTokensColorLight.paletteDatavizLime700,
+    DesignTokensColorDark.paletteDatavizLime700
+  ];
+
+  static List<Color> paletteDatavizLime800 = [
+    DesignTokensColorLight.paletteDatavizLime800,
+    DesignTokensColorDark.paletteDatavizLime800
+  ];
+
+  static List<Color> paletteDatavizLime900 = [
+    DesignTokensColorLight.paletteDatavizLime900,
+    DesignTokensColorDark.paletteDatavizLime900
+  ];
+
+  static List<Color> paletteDatavizMustard100 = [
+    DesignTokensColorLight.paletteDatavizMustard100,
+    DesignTokensColorDark.paletteDatavizMustard100
+  ];
+
+  static List<Color> paletteDatavizMustard200 = [
+    DesignTokensColorLight.paletteDatavizMustard200,
+    DesignTokensColorDark.paletteDatavizMustard200
+  ];
+
+  static List<Color> paletteDatavizMustard300 = [
+    DesignTokensColorLight.paletteDatavizMustard300,
+    DesignTokensColorDark.paletteDatavizMustard300
+  ];
+
+  static List<Color> paletteDatavizMustard400 = [
+    DesignTokensColorLight.paletteDatavizMustard400,
+    DesignTokensColorDark.paletteDatavizMustard400
+  ];
+
+  static List<Color> paletteDatavizMustard50 = [
+    DesignTokensColorLight.paletteDatavizMustard50,
+    DesignTokensColorDark.paletteDatavizMustard50
+  ];
+
+  static List<Color> paletteDatavizMustard500 = [
+    DesignTokensColorLight.paletteDatavizMustard500,
+    DesignTokensColorDark.paletteDatavizMustard500
+  ];
+
+  static List<Color> paletteDatavizMustard600 = [
+    DesignTokensColorLight.paletteDatavizMustard600,
+    DesignTokensColorDark.paletteDatavizMustard600
+  ];
+
+  static List<Color> paletteDatavizMustard700 = [
+    DesignTokensColorLight.paletteDatavizMustard700,
+    DesignTokensColorDark.paletteDatavizMustard700
+  ];
+
+  static List<Color> paletteDatavizMustard800 = [
+    DesignTokensColorLight.paletteDatavizMustard800,
+    DesignTokensColorDark.paletteDatavizMustard800
+  ];
+
+  static List<Color> paletteDatavizMustard900 = [
+    DesignTokensColorLight.paletteDatavizMustard900,
+    DesignTokensColorDark.paletteDatavizMustard900
+  ];
+
+  static List<Color> paletteDatavizRuby100 = [
+    DesignTokensColorLight.paletteDatavizRuby100,
+    DesignTokensColorDark.paletteDatavizRuby100
+  ];
+
+  static List<Color> paletteDatavizRuby200 = [
+    DesignTokensColorLight.paletteDatavizRuby200,
+    DesignTokensColorDark.paletteDatavizRuby200
+  ];
+
+  static List<Color> paletteDatavizRuby300 = [
+    DesignTokensColorLight.paletteDatavizRuby300,
+    DesignTokensColorDark.paletteDatavizRuby300
+  ];
+
+  static List<Color> paletteDatavizRuby400 = [
+    DesignTokensColorLight.paletteDatavizRuby400,
+    DesignTokensColorDark.paletteDatavizRuby400
+  ];
+
+  static List<Color> paletteDatavizRuby50 = [
+    DesignTokensColorLight.paletteDatavizRuby50,
+    DesignTokensColorDark.paletteDatavizRuby50
+  ];
+
+  static List<Color> paletteDatavizRuby500 = [
+    DesignTokensColorLight.paletteDatavizRuby500,
+    DesignTokensColorDark.paletteDatavizRuby500
+  ];
+
+  static List<Color> paletteDatavizRuby600 = [
+    DesignTokensColorLight.paletteDatavizRuby600,
+    DesignTokensColorDark.paletteDatavizRuby600
+  ];
+
+  static List<Color> paletteDatavizRuby700 = [
+    DesignTokensColorLight.paletteDatavizRuby700,
+    DesignTokensColorDark.paletteDatavizRuby700
+  ];
+
+  static List<Color> paletteDatavizRuby800 = [
+    DesignTokensColorLight.paletteDatavizRuby800,
+    DesignTokensColorDark.paletteDatavizRuby800
+  ];
+
+  static List<Color> paletteDatavizRuby900 = [
+    DesignTokensColorLight.paletteDatavizRuby900,
+    DesignTokensColorDark.paletteDatavizRuby900
+  ];
+
+  static List<Color> paletteDatavizTangerine100 = [
+    DesignTokensColorLight.paletteDatavizTangerine100,
+    DesignTokensColorDark.paletteDatavizTangerine100
+  ];
+
+  static List<Color> paletteDatavizTangerine200 = [
+    DesignTokensColorLight.paletteDatavizTangerine200,
+    DesignTokensColorDark.paletteDatavizTangerine200
+  ];
+
+  static List<Color> paletteDatavizTangerine300 = [
+    DesignTokensColorLight.paletteDatavizTangerine300,
+    DesignTokensColorDark.paletteDatavizTangerine300
+  ];
+
+  static List<Color> paletteDatavizTangerine400 = [
+    DesignTokensColorLight.paletteDatavizTangerine400,
+    DesignTokensColorDark.paletteDatavizTangerine400
+  ];
+
+  static List<Color> paletteDatavizTangerine50 = [
+    DesignTokensColorLight.paletteDatavizTangerine50,
+    DesignTokensColorDark.paletteDatavizTangerine50
+  ];
+
+  static List<Color> paletteDatavizTangerine500 = [
+    DesignTokensColorLight.paletteDatavizTangerine500,
+    DesignTokensColorDark.paletteDatavizTangerine500
+  ];
+
+  static List<Color> paletteDatavizTangerine600 = [
+    DesignTokensColorLight.paletteDatavizTangerine600,
+    DesignTokensColorDark.paletteDatavizTangerine600
+  ];
+
+  static List<Color> paletteDatavizTangerine700 = [
+    DesignTokensColorLight.paletteDatavizTangerine700,
+    DesignTokensColorDark.paletteDatavizTangerine700
+  ];
+
+  static List<Color> paletteDatavizTangerine800 = [
+    DesignTokensColorLight.paletteDatavizTangerine800,
+    DesignTokensColorDark.paletteDatavizTangerine800
+  ];
+
+  static List<Color> paletteDatavizTangerine900 = [
+    DesignTokensColorLight.paletteDatavizTangerine900,
+    DesignTokensColorDark.paletteDatavizTangerine900
+  ];
+
+  static List<Color> paletteSemanticBlue100 = [
+    DesignTokensColorLight.paletteSemanticBlue100,
+    DesignTokensColorDark.paletteSemanticBlue100
+  ];
+
+  static List<Color> paletteSemanticBlue1000 = [
+    DesignTokensColorLight.paletteSemanticBlue1000,
+    DesignTokensColorLight
+        .paletteSemanticBlue1000 //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteSemanticBlue150 = [
+    DesignTokensColorLight.paletteSemanticBlue150,
+    DesignTokensColorDark.paletteSemanticBlue150
+  ];
+
+  static List<Color> paletteSemanticBlue200 = [
+    DesignTokensColorLight.paletteSemanticBlue200,
+    DesignTokensColorDark.paletteSemanticBlue200
+  ];
+
+  static List<Color> paletteSemanticBlue25 = [
+    DesignTokensColorLight.paletteSemanticBlue25,
+    DesignTokensColorDark.paletteSemanticBlue25
+  ];
+
+  static List<Color> paletteSemanticBlue300 = [
+    DesignTokensColorLight.paletteSemanticBlue300,
+    DesignTokensColorDark.paletteSemanticBlue300
+  ];
+
+  static List<Color> paletteSemanticBlue400 = [
+    DesignTokensColorLight.paletteSemanticBlue400,
+    DesignTokensColorDark.paletteSemanticBlue400
+  ];
+
+  static List<Color> paletteSemanticBlue50 = [
+    DesignTokensColorLight.paletteSemanticBlue50,
+    DesignTokensColorDark.paletteSemanticBlue50
+  ];
+
+  static List<Color> paletteSemanticBlue500 = [
+    DesignTokensColorLight.paletteSemanticBlue500,
+    DesignTokensColorDark.paletteSemanticBlue500
+  ];
+
+  static List<Color> paletteSemanticBlue600 = [
+    DesignTokensColorLight.paletteSemanticBlue600,
+    DesignTokensColorDark.paletteSemanticBlue600
+  ];
+
+  static List<Color> paletteSemanticBlue700 = [
+    DesignTokensColorLight.paletteSemanticBlue700,
+    DesignTokensColorDark.paletteSemanticBlue700
+  ];
+
+  static List<Color> paletteSemanticBlue800 = [
+    DesignTokensColorLight.paletteSemanticBlue800,
+    DesignTokensColorDark.paletteSemanticBlue800
+  ];
+
+  static List<Color> paletteSemanticBlue900 = [
+    DesignTokensColorLight.paletteSemanticBlue900,
+    DesignTokensColorDark.paletteSemanticBlue900
+  ];
+
+  static List<Color> paletteSemanticGreen100 = [
+    DesignTokensColorLight.paletteSemanticGreen100,
+    DesignTokensColorDark.paletteSemanticGreen100
+  ];
+
+  static List<Color> paletteSemanticGreen1000 = [
+    DesignTokensColorLight.paletteSemanticGreen1000,
+    DesignTokensColorLight
+        .paletteSemanticGreen1000 //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteSemanticGreen150 = [
+    DesignTokensColorLight.paletteSemanticGreen150,
+    DesignTokensColorDark.paletteSemanticGreen150
+  ];
+
+  static List<Color> paletteSemanticGreen200 = [
+    DesignTokensColorLight.paletteSemanticGreen200,
+    DesignTokensColorDark.paletteSemanticGreen200
+  ];
+
+  static List<Color> paletteSemanticGreen25 = [
+    DesignTokensColorLight.paletteSemanticGreen25,
+    DesignTokensColorDark.paletteSemanticGreen25
+  ];
+
+  static List<Color> paletteSemanticGreen300 = [
+    DesignTokensColorLight.paletteSemanticGreen300,
+    DesignTokensColorDark.paletteSemanticGreen300
+  ];
+
+  static List<Color> paletteSemanticGreen400 = [
+    DesignTokensColorLight.paletteSemanticGreen400,
+    DesignTokensColorDark.paletteSemanticGreen400
+  ];
+
+  static List<Color> paletteSemanticGreen50 = [
+    DesignTokensColorLight.paletteSemanticGreen50,
+    DesignTokensColorDark.paletteSemanticGreen50
+  ];
+
+  static List<Color> paletteSemanticGreen500 = [
+    DesignTokensColorLight.paletteSemanticGreen500,
+    DesignTokensColorDark.paletteSemanticGreen500
+  ];
+
+  static List<Color> paletteSemanticGreen600 = [
+    DesignTokensColorLight.paletteSemanticGreen600,
+    DesignTokensColorDark.paletteSemanticGreen600
+  ];
+
+  static List<Color> paletteSemanticGreen700 = [
+    DesignTokensColorLight.paletteSemanticGreen700,
+    DesignTokensColorDark.paletteSemanticGreen700
+  ];
+
+  static List<Color> paletteSemanticGreen800 = [
+    DesignTokensColorLight.paletteSemanticGreen800,
+    DesignTokensColorDark.paletteSemanticGreen800
+  ];
+
+  static List<Color> paletteSemanticGreen900 = [
+    DesignTokensColorLight.paletteSemanticGreen900,
+    DesignTokensColorDark.paletteSemanticGreen900
+  ];
+
+  static List<Color> paletteSemanticOrange100 = [
+    DesignTokensColorLight.paletteSemanticOrange100,
+    DesignTokensColorDark.paletteSemanticOrange100
+  ];
+
+  static List<Color> paletteSemanticOrange1000 = [
+    DesignTokensColorLight.paletteSemanticOrange1000,
+    DesignTokensColorLight
+        .paletteSemanticOrange1000 //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteSemanticOrange150 = [
+    DesignTokensColorLight.paletteSemanticOrange150,
+    DesignTokensColorDark.paletteSemanticOrange150
+  ];
+
+  static List<Color> paletteSemanticOrange200 = [
+    DesignTokensColorLight.paletteSemanticOrange200,
+    DesignTokensColorDark.paletteSemanticOrange200
+  ];
+
+  static List<Color> paletteSemanticOrange25 = [
+    DesignTokensColorLight.paletteSemanticOrange25,
+    DesignTokensColorDark.paletteSemanticOrange25
+  ];
+
+  static List<Color> paletteSemanticOrange300 = [
+    DesignTokensColorLight.paletteSemanticOrange300,
+    DesignTokensColorDark.paletteSemanticOrange300
+  ];
+
+  static List<Color> paletteSemanticOrange400 = [
+    DesignTokensColorLight.paletteSemanticOrange400,
+    DesignTokensColorDark.paletteSemanticOrange400
+  ];
+
+  static List<Color> paletteSemanticOrange50 = [
+    DesignTokensColorLight.paletteSemanticOrange50,
+    DesignTokensColorDark.paletteSemanticOrange50
+  ];
+
+  static List<Color> paletteSemanticOrange500 = [
+    DesignTokensColorLight.paletteSemanticOrange500,
+    DesignTokensColorDark.paletteSemanticOrange500
+  ];
+
+  static List<Color> paletteSemanticOrange600 = [
+    DesignTokensColorLight.paletteSemanticOrange600,
+    DesignTokensColorDark.paletteSemanticOrange600
+  ];
+
+  static List<Color> paletteSemanticOrange700 = [
+    DesignTokensColorLight.paletteSemanticOrange700,
+    DesignTokensColorDark.paletteSemanticOrange700
+  ];
+
+  static List<Color> paletteSemanticOrange800 = [
+    DesignTokensColorLight.paletteSemanticOrange800,
+    DesignTokensColorDark.paletteSemanticOrange800
+  ];
+
+  static List<Color> paletteSemanticOrange900 = [
+    DesignTokensColorLight.paletteSemanticOrange900,
+    DesignTokensColorDark.paletteSemanticOrange900
+  ];
+
+  static List<Color> paletteSemanticRed100 = [
+    DesignTokensColorLight.paletteSemanticRed100,
+    DesignTokensColorDark.paletteSemanticRed100
+  ];
+
+  static List<Color> paletteSemanticRed1000 = [
+    DesignTokensColorLight.paletteSemanticRed1000,
+    DesignTokensColorLight
+        .paletteSemanticRed1000 //TODO(witwash): add dark token
+  ];
+
+  static List<Color> paletteSemanticRed150 = [
+    DesignTokensColorLight.paletteSemanticRed150,
+    DesignTokensColorDark.paletteSemanticRed150
+  ];
+
+  static List<Color> paletteSemanticRed200 = [
+    DesignTokensColorLight.paletteSemanticRed200,
+    DesignTokensColorDark.paletteSemanticRed200
+  ];
+
+  static List<Color> paletteSemanticRed25 = [
+    DesignTokensColorLight.paletteSemanticRed25,
+    DesignTokensColorDark.paletteSemanticRed25
+  ];
+
+  static List<Color> paletteSemanticRed300 = [
+    DesignTokensColorLight.paletteSemanticRed300,
+    DesignTokensColorDark.paletteSemanticRed300
+  ];
+
+  static List<Color> paletteSemanticRed400 = [
+    DesignTokensColorLight.paletteSemanticRed400,
+    DesignTokensColorDark.paletteSemanticRed400
+  ];
+
+  static List<Color> paletteSemanticRed50 = [
+    DesignTokensColorLight.paletteSemanticRed50,
+    DesignTokensColorDark.paletteSemanticRed50
+  ];
+
+  static List<Color> paletteSemanticRed500 = [
+    DesignTokensColorLight.paletteSemanticRed500,
+    DesignTokensColorDark.paletteSemanticRed500
+  ];
+
+  static List<Color> paletteSemanticRed600 = [
+    DesignTokensColorLight.paletteSemanticRed600,
+    DesignTokensColorDark.paletteSemanticRed600
+  ];
+
+  static List<Color> paletteSemanticRed700 = [
+    DesignTokensColorLight.paletteSemanticRed700,
+    DesignTokensColorDark.paletteSemanticRed700
+  ];
+
+  static List<Color> paletteSemanticRed800 = [
+    DesignTokensColorLight.paletteSemanticRed800,
+    DesignTokensColorDark.paletteSemanticRed800
+  ];
+
+  static List<Color> paletteSemanticRed900 = [
+    DesignTokensColorLight.paletteSemanticRed900,
+    DesignTokensColorDark.paletteSemanticRed900
+  ];
+
+  static List<Color> staticContainerColor = [
+    DesignTokensColorLight.staticContainerColor,
+    DesignTokensColorLight.staticContainerColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> staticDividerColor = [
+    DesignTokensColorLight.staticDividerColor,
+    DesignTokensColorLight.staticDividerColor //TODO(witwash): add dark token
+  ];
+
+  static List<Color> textAlertBasic = [
+    DesignTokensColorLight.textAlertBasic,
+    DesignTokensColorDark.textAlertBasic
+  ];
+
+  static List<Color> textAlertDanger = [
+    DesignTokensColorLight.textAlertDanger,
+    DesignTokensColorLight.textAlertDanger //TODO(witwash): add dark token
+  ];
+
+  static List<Color> textAlertInfo = [
+    DesignTokensColorLight.textAlertInfo,
+    DesignTokensColorDark.textAlertInfo
+  ];
+
+  static List<Color> textAlertSuccess = [
+    DesignTokensColorLight.textAlertSuccess,
+    DesignTokensColorDark.textAlertSuccess
+  ];
+
+  static List<Color> textAlertWarning = [
+    DesignTokensColorLight.textAlertWarning,
+    DesignTokensColorDark.textAlertWarning
+  ];
+
+  static List<Color> textDisabled = [
+    DesignTokensColorLight.textDisabled,
+    DesignTokensColorDark.textDisabled
+  ];
+
+  static List<Color> textInteractiveActive = [
+    DesignTokensColorLight.textInteractiveActive,
+    DesignTokensColorDark.textInteractiveActive
+  ];
+
+  static List<Color> textInteractiveDefault = [
+    DesignTokensColorLight.textInteractiveDefault,
+    DesignTokensColorDark.textInteractiveDefault
+  ];
+
+  static List<Color> textInteractiveHover = [
+    DesignTokensColorLight.textInteractiveHover,
+    DesignTokensColorDark.textInteractiveHover
+  ];
+
+  static List<Color> textStaticError = [
+    DesignTokensColorLight.textStaticError,
+    DesignTokensColorDark.textStaticError
+  ];
+
+  static List<Color> textStaticInverse = [
+    DesignTokensColorLight.textStaticInverse,
+    DesignTokensColorDark.textStaticInverse
+  ];
+
+  static List<Color> textStaticPrimary = [
+    DesignTokensColorLight.textStaticPrimary,
+    DesignTokensColorDark.textStaticPrimary
+  ];
+
+  static List<Color> textStaticSecondary = [
+    DesignTokensColorLight.textStaticSecondary,
+    DesignTokensColorDark.textStaticSecondary
+  ];
+
+  static List<Color> textStaticTertiary = [
+    DesignTokensColorLight.textStaticTertiary,
+    DesignTokensColorDark.textStaticTertiary
   ];
 }

--- a/optimus/lib/src/theme/optimus_tokens.dart
+++ b/optimus/lib/src/theme/optimus_tokens.dart
@@ -1,0 +1,52 @@
+// ignore_for_file: avoid-global-state
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:optimus/src/tokens/tokens_color_dark.dart';
+import 'package:optimus/src/tokens/tokens_color_light.dart';
+import 'package:theme_tailor_annotation/theme_tailor_annotation.dart';
+
+part 'optimus_tokens.tailor.dart';
+
+@Tailor(themeGetter: ThemeGetter.none)
+class _$OptimusTokens {
+  static List<Color> backgroundAccentPrimary = [
+    DesignTokensColorLight.backgroundAccentPrimary,
+    DesignTokensColorDark.backgroundAccentPrimary
+  ];
+
+  static List<Color> backgroundAccentSecondary = [
+    DesignTokensColorLight.backgroundAccentSecondary,
+    DesignTokensColorDark.backgroundAccentSecondary
+  ];
+
+  static List<Color> backgroundAlertBasicPrimary = [
+    DesignTokensColorLight.backgroundAlertBasicPrimary,
+    DesignTokensColorDark.backgroundAlertBasicPrimary
+  ];
+
+  static List<Color> backgroundInteractivePrimaryDefault = [
+    DesignTokensColorLight.backgroundInteractivePrimaryDefault,
+    DesignTokensColorDark.backgroundInteractivePrimaryDefault,
+  ];
+
+  static List<Color> textStaticInverse = [
+    DesignTokensColorLight.textStaticInverse,
+    DesignTokensColorDark.textStaticInverse,
+  ];
+
+  static List<Color> backgroundInteractivePrimaryHover = [
+    DesignTokensColorLight.backgroundInteractivePrimaryHover,
+    DesignTokensColorDark.backgroundInteractivePrimaryHover,
+  ];
+
+  static List<Color> backgroundInteractivePrimaryActive = [
+    DesignTokensColorLight.backgroundInteractivePrimaryActive,
+    DesignTokensColorDark.backgroundInteractivePrimaryActive,
+  ];
+
+  static List<Color> backgroundDisabled = [
+    DesignTokensColorLight.backgroundDisabled,
+    DesignTokensColorDark.backgroundDisabled,
+  ];
+}

--- a/optimus/lib/src/theme/optimus_tokens.dart
+++ b/optimus/lib/src/theme/optimus_tokens.dart
@@ -153,7 +153,7 @@ class _$OptimusTokens {
 
   static List<Color> backgroundOverlay = [
     DesignTokensColorLight.backgroundOverlay,
-    DesignTokensColorLight.backgroundOverlay //TODO(witwash): add dark token
+    DesignTokensColorLight.backgroundOverlay // TODO(witwash): add dark token
   ];
 
   static List<Color> backgroundStaticFlat = [
@@ -214,7 +214,7 @@ class _$OptimusTokens {
   static List<Color> borderInteractiveError = [
     DesignTokensColorLight.borderInteractiveError,
     DesignTokensColorLight
-        .borderInteractiveError //TODO(witwash): add dark token
+        .borderInteractiveError // TODO(witwash): add dark token
   ];
 
   static List<Color> borderInteractiveFocus = [
@@ -264,61 +264,62 @@ class _$OptimusTokens {
 
   static List<Color> inputActiveColor = [
     DesignTokensColorLight.inputActiveColor,
-    DesignTokensColorLight.inputActiveColor //TODO(witwash): add dark token
+    DesignTokensColorLight.inputActiveColor // TODO(witwash): add dark token
   ];
 
   static List<Color> inputDangerColor = [
     DesignTokensColorLight.inputDangerColor,
-    DesignTokensColorLight.inputDangerColor //TODO(witwash): add dark token
+    DesignTokensColorLight.inputDangerColor // TODO(witwash): add dark token
   ];
 
   static List<Color> inputDefaultColor = [
     DesignTokensColorLight.inputDefaultColor,
-    DesignTokensColorLight.inputDefaultColor //TODO(witwash): add dark token
+    DesignTokensColorLight.inputDefaultColor // TODO(witwash): add dark token
   ];
 
   static List<Color> inputDisabledColor = [
     DesignTokensColorLight.inputDisabledColor,
-    DesignTokensColorLight.inputDisabledColor //TODO(witwash): add dark token
+    DesignTokensColorLight.inputDisabledColor // TODO(witwash): add dark token
   ];
 
   static List<Color> inputHoverColor = [
     DesignTokensColorLight.inputHoverColor,
-    DesignTokensColorLight.inputHoverColor //TODO(witwash): add dark token
+    DesignTokensColorLight.inputHoverColor // TODO(witwash): add dark token
   ];
 
   static List<Color> inputInverseColor = [
     DesignTokensColorLight.inputInverseColor,
-    DesignTokensColorLight.inputInverseColor //TODO(witwash): add dark token
+    DesignTokensColorLight.inputInverseColor // TODO(witwash): add dark token
   ];
 
   static List<Color> interactiveDangerColor = [
     DesignTokensColorLight.interactiveDangerColor,
     DesignTokensColorLight
-        .interactiveDangerColor //TODO(witwash): add dark token
+        .interactiveDangerColor // TODO(witwash): add dark token
   ];
 
   static List<Color> interactiveDefaultColor = [
     DesignTokensColorLight.interactiveDefaultColor,
     DesignTokensColorLight
-        .interactiveDefaultColor //TODO(witwash): add dark token
+        .interactiveDefaultColor // TODO(witwash): add dark token
   ];
 
   static List<Color> interactiveDisabledColor = [
     DesignTokensColorLight.interactiveDisabledColor,
     DesignTokensColorLight
-        .interactiveDisabledColor //TODO(witwash): add dark token
+        .interactiveDisabledColor // TODO(witwash): add dark token
   ];
 
   static List<Color> interactiveHoverColor = [
     DesignTokensColorLight.interactiveHoverColor,
-    DesignTokensColorLight.interactiveHoverColor //TODO(witwash): add dark token
+    DesignTokensColorLight
+        .interactiveHoverColor // TODO(witwash): add dark token
   ];
 
   static List<Color> interactiveInverseColor = [
     DesignTokensColorLight.interactiveInverseColor,
     DesignTokensColorLight
-        .interactiveInverseColor //TODO(witwash): add dark token
+        .interactiveInverseColor // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteBasicsBlack = [
@@ -343,7 +344,8 @@ class _$OptimusTokens {
 
   static List<Color> paletteBrandCoral1000 = [
     DesignTokensColorLight.paletteBrandCoral1000,
-    DesignTokensColorLight.paletteBrandCoral1000 //TODO(witwash): add dark token
+    DesignTokensColorLight
+        .paletteBrandCoral1000 // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteBrandCoral150 = [
@@ -479,7 +481,7 @@ class _$OptimusTokens {
   static List<Color> paletteBrandIndigo1000 = [
     DesignTokensColorLight.paletteBrandIndigo1000,
     DesignTokensColorLight
-        .paletteBrandIndigo1000 //TODO(witwash): add dark token
+        .paletteBrandIndigo1000 // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteBrandIndigo150 = [
@@ -555,19 +557,19 @@ class _$OptimusTokens {
   static List<Color> paletteBrandNight100012 = [
     DesignTokensColorLight.paletteBrandNight100012,
     DesignTokensColorLight
-        .paletteBrandNight100012 //TODO(witwash): add dark token
+        .paletteBrandNight100012 // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteBrandNight100016 = [
     DesignTokensColorLight.paletteBrandNight100016,
     DesignTokensColorLight
-        .paletteBrandNight100016 //TODO(witwash): add dark token
+        .paletteBrandNight100016 // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteBrandNight10008 = [
     DesignTokensColorLight.paletteBrandNight10008,
     DesignTokensColorLight
-        .paletteBrandNight10008 //TODO(witwash): add dark token
+        .paletteBrandNight10008 // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteBrandNight150 = [
@@ -933,7 +935,7 @@ class _$OptimusTokens {
   static List<Color> paletteSemanticBlue1000 = [
     DesignTokensColorLight.paletteSemanticBlue1000,
     DesignTokensColorLight
-        .paletteSemanticBlue1000 //TODO(witwash): add dark token
+        .paletteSemanticBlue1000 // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteSemanticBlue150 = [
@@ -999,7 +1001,7 @@ class _$OptimusTokens {
   static List<Color> paletteSemanticGreen1000 = [
     DesignTokensColorLight.paletteSemanticGreen1000,
     DesignTokensColorLight
-        .paletteSemanticGreen1000 //TODO(witwash): add dark token
+        .paletteSemanticGreen1000 // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteSemanticGreen150 = [
@@ -1065,7 +1067,7 @@ class _$OptimusTokens {
   static List<Color> paletteSemanticOrange1000 = [
     DesignTokensColorLight.paletteSemanticOrange1000,
     DesignTokensColorLight
-        .paletteSemanticOrange1000 //TODO(witwash): add dark token
+        .paletteSemanticOrange1000 // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteSemanticOrange150 = [
@@ -1131,7 +1133,7 @@ class _$OptimusTokens {
   static List<Color> paletteSemanticRed1000 = [
     DesignTokensColorLight.paletteSemanticRed1000,
     DesignTokensColorLight
-        .paletteSemanticRed1000 //TODO(witwash): add dark token
+        .paletteSemanticRed1000 // TODO(witwash): add dark token
   ];
 
   static List<Color> paletteSemanticRed150 = [
@@ -1191,12 +1193,12 @@ class _$OptimusTokens {
 
   static List<Color> staticContainerColor = [
     DesignTokensColorLight.staticContainerColor,
-    DesignTokensColorLight.staticContainerColor //TODO(witwash): add dark token
+    DesignTokensColorLight.staticContainerColor // TODO(witwash): add dark token
   ];
 
   static List<Color> staticDividerColor = [
     DesignTokensColorLight.staticDividerColor,
-    DesignTokensColorLight.staticDividerColor //TODO(witwash): add dark token
+    DesignTokensColorLight.staticDividerColor // TODO(witwash): add dark token
   ];
 
   static List<Color> textAlertBasic = [
@@ -1206,7 +1208,7 @@ class _$OptimusTokens {
 
   static List<Color> textAlertDanger = [
     DesignTokensColorLight.textAlertDanger,
-    DesignTokensColorLight.textAlertDanger //TODO(witwash): add dark token
+    DesignTokensColorLight.textAlertDanger // TODO(witwash): add dark token
   ];
 
   static List<Color> textAlertInfo = [

--- a/optimus/lib/src/theme/optimus_tokens.tailor.dart
+++ b/optimus/lib/src/theme/optimus_tokens.tailor.dart
@@ -14,48 +14,1066 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
     required this.backgroundAccentPrimary,
     required this.backgroundAccentSecondary,
     required this.backgroundAlertBasicPrimary,
+    required this.backgroundAlertBasicSecondary,
+    required this.backgroundAlertDangerPrimary,
+    required this.backgroundAlertDangerSecondary,
+    required this.backgroundAlertInfoPrimary,
+    required this.backgroundAlertInfoSecondary,
+    required this.backgroundAlertSuccessPrimary,
+    required this.backgroundAlertSuccessSecondary,
+    required this.backgroundAlertWarningPrimary,
+    required this.backgroundAlertWarningSecondary,
+    required this.backgroundBrand,
     required this.backgroundDisabled,
+    required this.backgroundInteractiveBoldActive,
+    required this.backgroundInteractiveBoldDefault,
+    required this.backgroundInteractiveBoldHover,
+    required this.backgroundInteractiveDangerActive,
+    required this.backgroundInteractiveDangerDefault,
+    required this.backgroundInteractiveDangerHover,
     required this.backgroundInteractivePrimaryActive,
     required this.backgroundInteractivePrimaryDefault,
     required this.backgroundInteractivePrimaryHover,
+    required this.backgroundInteractiveSecondaryActive,
+    required this.backgroundInteractiveSecondaryDefault,
+    required this.backgroundInteractiveSecondaryHover,
+    required this.backgroundInteractiveSubtleActive,
+    required this.backgroundInteractiveSubtleDefault,
+    required this.backgroundInteractiveSubtleHover,
+    required this.backgroundOverlay,
+    required this.backgroundStaticFlat,
+    required this.backgroundStaticFloating,
+    required this.backgroundStaticInverse,
+    required this.backgroundStaticRaised,
+    required this.backgroundStaticSunken,
+    required this.borderAlertBasic,
+    required this.borderAlertDanger,
+    required this.borderAlertInfo,
+    required this.borderAlertSuccess,
+    required this.borderAlertWarning,
+    required this.borderDisabled,
+    required this.borderInteractiveError,
+    required this.borderInteractiveFocus,
+    required this.borderInteractivePrimaryActive,
+    required this.borderInteractivePrimaryDefault,
+    required this.borderInteractivePrimaryHover,
+    required this.borderInteractiveSecondaryActive,
+    required this.borderInteractiveSecondaryHover,
+    required this.borderStaticInverse,
+    required this.borderStaticPrimary,
+    required this.borderStaticSecondary,
+    required this.inputActiveColor,
+    required this.inputDangerColor,
+    required this.inputDefaultColor,
+    required this.inputDisabledColor,
+    required this.inputHoverColor,
+    required this.inputInverseColor,
+    required this.interactiveDangerColor,
+    required this.interactiveDefaultColor,
+    required this.interactiveDisabledColor,
+    required this.interactiveHoverColor,
+    required this.interactiveInverseColor,
+    required this.paletteBasicsBlack,
+    required this.paletteBasicsWhite,
+    required this.paletteBasicsWhite64,
+    required this.paletteBrandCoral100,
+    required this.paletteBrandCoral1000,
+    required this.paletteBrandCoral150,
+    required this.paletteBrandCoral200,
+    required this.paletteBrandCoral25,
+    required this.paletteBrandCoral300,
+    required this.paletteBrandCoral400,
+    required this.paletteBrandCoral50,
+    required this.paletteBrandCoral500,
+    required this.paletteBrandCoral600,
+    required this.paletteBrandCoral700,
+    required this.paletteBrandCoral800,
+    required this.paletteBrandCoral900,
+    required this.paletteBrandGrey0,
+    required this.paletteBrandGrey100,
+    required this.paletteBrandGrey1000,
+    required this.paletteBrandGrey150,
+    required this.paletteBrandGrey200,
+    required this.paletteBrandGrey25,
+    required this.paletteBrandGrey300,
+    required this.paletteBrandGrey400,
+    required this.paletteBrandGrey50,
+    required this.paletteBrandGrey500,
+    required this.paletteBrandGrey600,
+    required this.paletteBrandGrey700,
+    required this.paletteBrandGrey800,
+    required this.paletteBrandGrey900,
+    required this.paletteBrandIndigo100,
+    required this.paletteBrandIndigo1000,
+    required this.paletteBrandIndigo150,
+    required this.paletteBrandIndigo200,
+    required this.paletteBrandIndigo25,
+    required this.paletteBrandIndigo300,
+    required this.paletteBrandIndigo400,
+    required this.paletteBrandIndigo50,
+    required this.paletteBrandIndigo500,
+    required this.paletteBrandIndigo600,
+    required this.paletteBrandIndigo700,
+    required this.paletteBrandIndigo800,
+    required this.paletteBrandIndigo900,
+    required this.paletteBrandNight0,
+    required this.paletteBrandNight100,
+    required this.paletteBrandNight1000,
+    required this.paletteBrandNight100012,
+    required this.paletteBrandNight100016,
+    required this.paletteBrandNight10008,
+    required this.paletteBrandNight150,
+    required this.paletteBrandNight200,
+    required this.paletteBrandNight25,
+    required this.paletteBrandNight300,
+    required this.paletteBrandNight400,
+    required this.paletteBrandNight50,
+    required this.paletteBrandNight500,
+    required this.paletteBrandNight600,
+    required this.paletteBrandNight700,
+    required this.paletteBrandNight800,
+    required this.paletteBrandNight900,
+    required this.paletteDatavizDenim100,
+    required this.paletteDatavizDenim200,
+    required this.paletteDatavizDenim300,
+    required this.paletteDatavizDenim400,
+    required this.paletteDatavizDenim50,
+    required this.paletteDatavizDenim500,
+    required this.paletteDatavizDenim600,
+    required this.paletteDatavizDenim700,
+    required this.paletteDatavizDenim800,
+    required this.paletteDatavizDenim900,
+    required this.paletteDatavizLavender100,
+    required this.paletteDatavizLavender200,
+    required this.paletteDatavizLavender300,
+    required this.paletteDatavizLavender400,
+    required this.paletteDatavizLavender50,
+    required this.paletteDatavizLavender500,
+    required this.paletteDatavizLavender600,
+    required this.paletteDatavizLavender700,
+    required this.paletteDatavizLavender800,
+    required this.paletteDatavizLavender900,
+    required this.paletteDatavizLime100,
+    required this.paletteDatavizLime200,
+    required this.paletteDatavizLime300,
+    required this.paletteDatavizLime400,
+    required this.paletteDatavizLime50,
+    required this.paletteDatavizLime500,
+    required this.paletteDatavizLime600,
+    required this.paletteDatavizLime700,
+    required this.paletteDatavizLime800,
+    required this.paletteDatavizLime900,
+    required this.paletteDatavizMustard100,
+    required this.paletteDatavizMustard200,
+    required this.paletteDatavizMustard300,
+    required this.paletteDatavizMustard400,
+    required this.paletteDatavizMustard50,
+    required this.paletteDatavizMustard500,
+    required this.paletteDatavizMustard600,
+    required this.paletteDatavizMustard700,
+    required this.paletteDatavizMustard800,
+    required this.paletteDatavizMustard900,
+    required this.paletteDatavizRuby100,
+    required this.paletteDatavizRuby200,
+    required this.paletteDatavizRuby300,
+    required this.paletteDatavizRuby400,
+    required this.paletteDatavizRuby50,
+    required this.paletteDatavizRuby500,
+    required this.paletteDatavizRuby600,
+    required this.paletteDatavizRuby700,
+    required this.paletteDatavizRuby800,
+    required this.paletteDatavizRuby900,
+    required this.paletteDatavizTangerine100,
+    required this.paletteDatavizTangerine200,
+    required this.paletteDatavizTangerine300,
+    required this.paletteDatavizTangerine400,
+    required this.paletteDatavizTangerine50,
+    required this.paletteDatavizTangerine500,
+    required this.paletteDatavizTangerine600,
+    required this.paletteDatavizTangerine700,
+    required this.paletteDatavizTangerine800,
+    required this.paletteDatavizTangerine900,
+    required this.paletteSemanticBlue100,
+    required this.paletteSemanticBlue1000,
+    required this.paletteSemanticBlue150,
+    required this.paletteSemanticBlue200,
+    required this.paletteSemanticBlue25,
+    required this.paletteSemanticBlue300,
+    required this.paletteSemanticBlue400,
+    required this.paletteSemanticBlue50,
+    required this.paletteSemanticBlue500,
+    required this.paletteSemanticBlue600,
+    required this.paletteSemanticBlue700,
+    required this.paletteSemanticBlue800,
+    required this.paletteSemanticBlue900,
+    required this.paletteSemanticGreen100,
+    required this.paletteSemanticGreen1000,
+    required this.paletteSemanticGreen150,
+    required this.paletteSemanticGreen200,
+    required this.paletteSemanticGreen25,
+    required this.paletteSemanticGreen300,
+    required this.paletteSemanticGreen400,
+    required this.paletteSemanticGreen50,
+    required this.paletteSemanticGreen500,
+    required this.paletteSemanticGreen600,
+    required this.paletteSemanticGreen700,
+    required this.paletteSemanticGreen800,
+    required this.paletteSemanticGreen900,
+    required this.paletteSemanticOrange100,
+    required this.paletteSemanticOrange1000,
+    required this.paletteSemanticOrange150,
+    required this.paletteSemanticOrange200,
+    required this.paletteSemanticOrange25,
+    required this.paletteSemanticOrange300,
+    required this.paletteSemanticOrange400,
+    required this.paletteSemanticOrange50,
+    required this.paletteSemanticOrange500,
+    required this.paletteSemanticOrange600,
+    required this.paletteSemanticOrange700,
+    required this.paletteSemanticOrange800,
+    required this.paletteSemanticOrange900,
+    required this.paletteSemanticRed100,
+    required this.paletteSemanticRed1000,
+    required this.paletteSemanticRed150,
+    required this.paletteSemanticRed200,
+    required this.paletteSemanticRed25,
+    required this.paletteSemanticRed300,
+    required this.paletteSemanticRed400,
+    required this.paletteSemanticRed50,
+    required this.paletteSemanticRed500,
+    required this.paletteSemanticRed600,
+    required this.paletteSemanticRed700,
+    required this.paletteSemanticRed800,
+    required this.paletteSemanticRed900,
+    required this.staticContainerColor,
+    required this.staticDividerColor,
+    required this.textAlertBasic,
+    required this.textAlertDanger,
+    required this.textAlertInfo,
+    required this.textAlertSuccess,
+    required this.textAlertWarning,
+    required this.textDisabled,
+    required this.textInteractiveActive,
+    required this.textInteractiveDefault,
+    required this.textInteractiveHover,
+    required this.textStaticError,
     required this.textStaticInverse,
+    required this.textStaticPrimary,
+    required this.textStaticSecondary,
+    required this.textStaticTertiary,
   });
 
   final Color backgroundAccentPrimary;
   final Color backgroundAccentSecondary;
   final Color backgroundAlertBasicPrimary;
+  final Color backgroundAlertBasicSecondary;
+  final Color backgroundAlertDangerPrimary;
+  final Color backgroundAlertDangerSecondary;
+  final Color backgroundAlertInfoPrimary;
+  final Color backgroundAlertInfoSecondary;
+  final Color backgroundAlertSuccessPrimary;
+  final Color backgroundAlertSuccessSecondary;
+  final Color backgroundAlertWarningPrimary;
+  final Color backgroundAlertWarningSecondary;
+  final Color backgroundBrand;
   final Color backgroundDisabled;
+  final Color backgroundInteractiveBoldActive;
+  final Color backgroundInteractiveBoldDefault;
+  final Color backgroundInteractiveBoldHover;
+  final Color backgroundInteractiveDangerActive;
+  final Color backgroundInteractiveDangerDefault;
+  final Color backgroundInteractiveDangerHover;
   final Color backgroundInteractivePrimaryActive;
   final Color backgroundInteractivePrimaryDefault;
   final Color backgroundInteractivePrimaryHover;
+  final Color backgroundInteractiveSecondaryActive;
+  final Color backgroundInteractiveSecondaryDefault;
+  final Color backgroundInteractiveSecondaryHover;
+  final Color backgroundInteractiveSubtleActive;
+  final Color backgroundInteractiveSubtleDefault;
+  final Color backgroundInteractiveSubtleHover;
+  final Color backgroundOverlay;
+  final Color backgroundStaticFlat;
+  final Color backgroundStaticFloating;
+  final Color backgroundStaticInverse;
+  final Color backgroundStaticRaised;
+  final Color backgroundStaticSunken;
+  final Color borderAlertBasic;
+  final Color borderAlertDanger;
+  final Color borderAlertInfo;
+  final Color borderAlertSuccess;
+  final Color borderAlertWarning;
+  final Color borderDisabled;
+  final Color borderInteractiveError;
+  final Color borderInteractiveFocus;
+  final Color borderInteractivePrimaryActive;
+  final Color borderInteractivePrimaryDefault;
+  final Color borderInteractivePrimaryHover;
+  final Color borderInteractiveSecondaryActive;
+  final Color borderInteractiveSecondaryHover;
+  final Color borderStaticInverse;
+  final Color borderStaticPrimary;
+  final Color borderStaticSecondary;
+  final Color inputActiveColor;
+  final Color inputDangerColor;
+  final Color inputDefaultColor;
+  final Color inputDisabledColor;
+  final Color inputHoverColor;
+  final Color inputInverseColor;
+  final Color interactiveDangerColor;
+  final Color interactiveDefaultColor;
+  final Color interactiveDisabledColor;
+  final Color interactiveHoverColor;
+  final Color interactiveInverseColor;
+  final Color paletteBasicsBlack;
+  final Color paletteBasicsWhite;
+  final Color paletteBasicsWhite64;
+  final Color paletteBrandCoral100;
+  final Color paletteBrandCoral1000;
+  final Color paletteBrandCoral150;
+  final Color paletteBrandCoral200;
+  final Color paletteBrandCoral25;
+  final Color paletteBrandCoral300;
+  final Color paletteBrandCoral400;
+  final Color paletteBrandCoral50;
+  final Color paletteBrandCoral500;
+  final Color paletteBrandCoral600;
+  final Color paletteBrandCoral700;
+  final Color paletteBrandCoral800;
+  final Color paletteBrandCoral900;
+  final Color paletteBrandGrey0;
+  final Color paletteBrandGrey100;
+  final Color paletteBrandGrey1000;
+  final Color paletteBrandGrey150;
+  final Color paletteBrandGrey200;
+  final Color paletteBrandGrey25;
+  final Color paletteBrandGrey300;
+  final Color paletteBrandGrey400;
+  final Color paletteBrandGrey50;
+  final Color paletteBrandGrey500;
+  final Color paletteBrandGrey600;
+  final Color paletteBrandGrey700;
+  final Color paletteBrandGrey800;
+  final Color paletteBrandGrey900;
+  final Color paletteBrandIndigo100;
+  final Color paletteBrandIndigo1000;
+  final Color paletteBrandIndigo150;
+  final Color paletteBrandIndigo200;
+  final Color paletteBrandIndigo25;
+  final Color paletteBrandIndigo300;
+  final Color paletteBrandIndigo400;
+  final Color paletteBrandIndigo50;
+  final Color paletteBrandIndigo500;
+  final Color paletteBrandIndigo600;
+  final Color paletteBrandIndigo700;
+  final Color paletteBrandIndigo800;
+  final Color paletteBrandIndigo900;
+  final Color paletteBrandNight0;
+  final Color paletteBrandNight100;
+  final Color paletteBrandNight1000;
+  final Color paletteBrandNight100012;
+  final Color paletteBrandNight100016;
+  final Color paletteBrandNight10008;
+  final Color paletteBrandNight150;
+  final Color paletteBrandNight200;
+  final Color paletteBrandNight25;
+  final Color paletteBrandNight300;
+  final Color paletteBrandNight400;
+  final Color paletteBrandNight50;
+  final Color paletteBrandNight500;
+  final Color paletteBrandNight600;
+  final Color paletteBrandNight700;
+  final Color paletteBrandNight800;
+  final Color paletteBrandNight900;
+  final Color paletteDatavizDenim100;
+  final Color paletteDatavizDenim200;
+  final Color paletteDatavizDenim300;
+  final Color paletteDatavizDenim400;
+  final Color paletteDatavizDenim50;
+  final Color paletteDatavizDenim500;
+  final Color paletteDatavizDenim600;
+  final Color paletteDatavizDenim700;
+  final Color paletteDatavizDenim800;
+  final Color paletteDatavizDenim900;
+  final Color paletteDatavizLavender100;
+  final Color paletteDatavizLavender200;
+  final Color paletteDatavizLavender300;
+  final Color paletteDatavizLavender400;
+  final Color paletteDatavizLavender50;
+  final Color paletteDatavizLavender500;
+  final Color paletteDatavizLavender600;
+  final Color paletteDatavizLavender700;
+  final Color paletteDatavizLavender800;
+  final Color paletteDatavizLavender900;
+  final Color paletteDatavizLime100;
+  final Color paletteDatavizLime200;
+  final Color paletteDatavizLime300;
+  final Color paletteDatavizLime400;
+  final Color paletteDatavizLime50;
+  final Color paletteDatavizLime500;
+  final Color paletteDatavizLime600;
+  final Color paletteDatavizLime700;
+  final Color paletteDatavizLime800;
+  final Color paletteDatavizLime900;
+  final Color paletteDatavizMustard100;
+  final Color paletteDatavizMustard200;
+  final Color paletteDatavizMustard300;
+  final Color paletteDatavizMustard400;
+  final Color paletteDatavizMustard50;
+  final Color paletteDatavizMustard500;
+  final Color paletteDatavizMustard600;
+  final Color paletteDatavizMustard700;
+  final Color paletteDatavizMustard800;
+  final Color paletteDatavizMustard900;
+  final Color paletteDatavizRuby100;
+  final Color paletteDatavizRuby200;
+  final Color paletteDatavizRuby300;
+  final Color paletteDatavizRuby400;
+  final Color paletteDatavizRuby50;
+  final Color paletteDatavizRuby500;
+  final Color paletteDatavizRuby600;
+  final Color paletteDatavizRuby700;
+  final Color paletteDatavizRuby800;
+  final Color paletteDatavizRuby900;
+  final Color paletteDatavizTangerine100;
+  final Color paletteDatavizTangerine200;
+  final Color paletteDatavizTangerine300;
+  final Color paletteDatavizTangerine400;
+  final Color paletteDatavizTangerine50;
+  final Color paletteDatavizTangerine500;
+  final Color paletteDatavizTangerine600;
+  final Color paletteDatavizTangerine700;
+  final Color paletteDatavizTangerine800;
+  final Color paletteDatavizTangerine900;
+  final Color paletteSemanticBlue100;
+  final Color paletteSemanticBlue1000;
+  final Color paletteSemanticBlue150;
+  final Color paletteSemanticBlue200;
+  final Color paletteSemanticBlue25;
+  final Color paletteSemanticBlue300;
+  final Color paletteSemanticBlue400;
+  final Color paletteSemanticBlue50;
+  final Color paletteSemanticBlue500;
+  final Color paletteSemanticBlue600;
+  final Color paletteSemanticBlue700;
+  final Color paletteSemanticBlue800;
+  final Color paletteSemanticBlue900;
+  final Color paletteSemanticGreen100;
+  final Color paletteSemanticGreen1000;
+  final Color paletteSemanticGreen150;
+  final Color paletteSemanticGreen200;
+  final Color paletteSemanticGreen25;
+  final Color paletteSemanticGreen300;
+  final Color paletteSemanticGreen400;
+  final Color paletteSemanticGreen50;
+  final Color paletteSemanticGreen500;
+  final Color paletteSemanticGreen600;
+  final Color paletteSemanticGreen700;
+  final Color paletteSemanticGreen800;
+  final Color paletteSemanticGreen900;
+  final Color paletteSemanticOrange100;
+  final Color paletteSemanticOrange1000;
+  final Color paletteSemanticOrange150;
+  final Color paletteSemanticOrange200;
+  final Color paletteSemanticOrange25;
+  final Color paletteSemanticOrange300;
+  final Color paletteSemanticOrange400;
+  final Color paletteSemanticOrange50;
+  final Color paletteSemanticOrange500;
+  final Color paletteSemanticOrange600;
+  final Color paletteSemanticOrange700;
+  final Color paletteSemanticOrange800;
+  final Color paletteSemanticOrange900;
+  final Color paletteSemanticRed100;
+  final Color paletteSemanticRed1000;
+  final Color paletteSemanticRed150;
+  final Color paletteSemanticRed200;
+  final Color paletteSemanticRed25;
+  final Color paletteSemanticRed300;
+  final Color paletteSemanticRed400;
+  final Color paletteSemanticRed50;
+  final Color paletteSemanticRed500;
+  final Color paletteSemanticRed600;
+  final Color paletteSemanticRed700;
+  final Color paletteSemanticRed800;
+  final Color paletteSemanticRed900;
+  final Color staticContainerColor;
+  final Color staticDividerColor;
+  final Color textAlertBasic;
+  final Color textAlertDanger;
+  final Color textAlertInfo;
+  final Color textAlertSuccess;
+  final Color textAlertWarning;
+  final Color textDisabled;
+  final Color textInteractiveActive;
+  final Color textInteractiveDefault;
+  final Color textInteractiveHover;
+  final Color textStaticError;
   final Color textStaticInverse;
+  final Color textStaticPrimary;
+  final Color textStaticSecondary;
+  final Color textStaticTertiary;
 
   static final OptimusTokens light = OptimusTokens(
     backgroundAccentPrimary: _$OptimusTokens.backgroundAccentPrimary[0],
     backgroundAccentSecondary: _$OptimusTokens.backgroundAccentSecondary[0],
     backgroundAlertBasicPrimary: _$OptimusTokens.backgroundAlertBasicPrimary[0],
+    backgroundAlertBasicSecondary:
+        _$OptimusTokens.backgroundAlertBasicSecondary[0],
+    backgroundAlertDangerPrimary:
+        _$OptimusTokens.backgroundAlertDangerPrimary[0],
+    backgroundAlertDangerSecondary:
+        _$OptimusTokens.backgroundAlertDangerSecondary[0],
+    backgroundAlertInfoPrimary: _$OptimusTokens.backgroundAlertInfoPrimary[0],
+    backgroundAlertInfoSecondary:
+        _$OptimusTokens.backgroundAlertInfoSecondary[0],
+    backgroundAlertSuccessPrimary:
+        _$OptimusTokens.backgroundAlertSuccessPrimary[0],
+    backgroundAlertSuccessSecondary:
+        _$OptimusTokens.backgroundAlertSuccessSecondary[0],
+    backgroundAlertWarningPrimary:
+        _$OptimusTokens.backgroundAlertWarningPrimary[0],
+    backgroundAlertWarningSecondary:
+        _$OptimusTokens.backgroundAlertWarningSecondary[0],
+    backgroundBrand: _$OptimusTokens.backgroundBrand[0],
     backgroundDisabled: _$OptimusTokens.backgroundDisabled[0],
+    backgroundInteractiveBoldActive:
+        _$OptimusTokens.backgroundInteractiveBoldActive[0],
+    backgroundInteractiveBoldDefault:
+        _$OptimusTokens.backgroundInteractiveBoldDefault[0],
+    backgroundInteractiveBoldHover:
+        _$OptimusTokens.backgroundInteractiveBoldHover[0],
+    backgroundInteractiveDangerActive:
+        _$OptimusTokens.backgroundInteractiveDangerActive[0],
+    backgroundInteractiveDangerDefault:
+        _$OptimusTokens.backgroundInteractiveDangerDefault[0],
+    backgroundInteractiveDangerHover:
+        _$OptimusTokens.backgroundInteractiveDangerHover[0],
     backgroundInteractivePrimaryActive:
         _$OptimusTokens.backgroundInteractivePrimaryActive[0],
     backgroundInteractivePrimaryDefault:
         _$OptimusTokens.backgroundInteractivePrimaryDefault[0],
     backgroundInteractivePrimaryHover:
         _$OptimusTokens.backgroundInteractivePrimaryHover[0],
+    backgroundInteractiveSecondaryActive:
+        _$OptimusTokens.backgroundInteractiveSecondaryActive[0],
+    backgroundInteractiveSecondaryDefault:
+        _$OptimusTokens.backgroundInteractiveSecondaryDefault[0],
+    backgroundInteractiveSecondaryHover:
+        _$OptimusTokens.backgroundInteractiveSecondaryHover[0],
+    backgroundInteractiveSubtleActive:
+        _$OptimusTokens.backgroundInteractiveSubtleActive[0],
+    backgroundInteractiveSubtleDefault:
+        _$OptimusTokens.backgroundInteractiveSubtleDefault[0],
+    backgroundInteractiveSubtleHover:
+        _$OptimusTokens.backgroundInteractiveSubtleHover[0],
+    backgroundOverlay: _$OptimusTokens.backgroundOverlay[0],
+    backgroundStaticFlat: _$OptimusTokens.backgroundStaticFlat[0],
+    backgroundStaticFloating: _$OptimusTokens.backgroundStaticFloating[0],
+    backgroundStaticInverse: _$OptimusTokens.backgroundStaticInverse[0],
+    backgroundStaticRaised: _$OptimusTokens.backgroundStaticRaised[0],
+    backgroundStaticSunken: _$OptimusTokens.backgroundStaticSunken[0],
+    borderAlertBasic: _$OptimusTokens.borderAlertBasic[0],
+    borderAlertDanger: _$OptimusTokens.borderAlertDanger[0],
+    borderAlertInfo: _$OptimusTokens.borderAlertInfo[0],
+    borderAlertSuccess: _$OptimusTokens.borderAlertSuccess[0],
+    borderAlertWarning: _$OptimusTokens.borderAlertWarning[0],
+    borderDisabled: _$OptimusTokens.borderDisabled[0],
+    borderInteractiveError: _$OptimusTokens.borderInteractiveError[0],
+    borderInteractiveFocus: _$OptimusTokens.borderInteractiveFocus[0],
+    borderInteractivePrimaryActive:
+        _$OptimusTokens.borderInteractivePrimaryActive[0],
+    borderInteractivePrimaryDefault:
+        _$OptimusTokens.borderInteractivePrimaryDefault[0],
+    borderInteractivePrimaryHover:
+        _$OptimusTokens.borderInteractivePrimaryHover[0],
+    borderInteractiveSecondaryActive:
+        _$OptimusTokens.borderInteractiveSecondaryActive[0],
+    borderInteractiveSecondaryHover:
+        _$OptimusTokens.borderInteractiveSecondaryHover[0],
+    borderStaticInverse: _$OptimusTokens.borderStaticInverse[0],
+    borderStaticPrimary: _$OptimusTokens.borderStaticPrimary[0],
+    borderStaticSecondary: _$OptimusTokens.borderStaticSecondary[0],
+    inputActiveColor: _$OptimusTokens.inputActiveColor[0],
+    inputDangerColor: _$OptimusTokens.inputDangerColor[0],
+    inputDefaultColor: _$OptimusTokens.inputDefaultColor[0],
+    inputDisabledColor: _$OptimusTokens.inputDisabledColor[0],
+    inputHoverColor: _$OptimusTokens.inputHoverColor[0],
+    inputInverseColor: _$OptimusTokens.inputInverseColor[0],
+    interactiveDangerColor: _$OptimusTokens.interactiveDangerColor[0],
+    interactiveDefaultColor: _$OptimusTokens.interactiveDefaultColor[0],
+    interactiveDisabledColor: _$OptimusTokens.interactiveDisabledColor[0],
+    interactiveHoverColor: _$OptimusTokens.interactiveHoverColor[0],
+    interactiveInverseColor: _$OptimusTokens.interactiveInverseColor[0],
+    paletteBasicsBlack: _$OptimusTokens.paletteBasicsBlack[0],
+    paletteBasicsWhite: _$OptimusTokens.paletteBasicsWhite[0],
+    paletteBasicsWhite64: _$OptimusTokens.paletteBasicsWhite64[0],
+    paletteBrandCoral100: _$OptimusTokens.paletteBrandCoral100[0],
+    paletteBrandCoral1000: _$OptimusTokens.paletteBrandCoral1000[0],
+    paletteBrandCoral150: _$OptimusTokens.paletteBrandCoral150[0],
+    paletteBrandCoral200: _$OptimusTokens.paletteBrandCoral200[0],
+    paletteBrandCoral25: _$OptimusTokens.paletteBrandCoral25[0],
+    paletteBrandCoral300: _$OptimusTokens.paletteBrandCoral300[0],
+    paletteBrandCoral400: _$OptimusTokens.paletteBrandCoral400[0],
+    paletteBrandCoral50: _$OptimusTokens.paletteBrandCoral50[0],
+    paletteBrandCoral500: _$OptimusTokens.paletteBrandCoral500[0],
+    paletteBrandCoral600: _$OptimusTokens.paletteBrandCoral600[0],
+    paletteBrandCoral700: _$OptimusTokens.paletteBrandCoral700[0],
+    paletteBrandCoral800: _$OptimusTokens.paletteBrandCoral800[0],
+    paletteBrandCoral900: _$OptimusTokens.paletteBrandCoral900[0],
+    paletteBrandGrey0: _$OptimusTokens.paletteBrandGrey0[0],
+    paletteBrandGrey100: _$OptimusTokens.paletteBrandGrey100[0],
+    paletteBrandGrey1000: _$OptimusTokens.paletteBrandGrey1000[0],
+    paletteBrandGrey150: _$OptimusTokens.paletteBrandGrey150[0],
+    paletteBrandGrey200: _$OptimusTokens.paletteBrandGrey200[0],
+    paletteBrandGrey25: _$OptimusTokens.paletteBrandGrey25[0],
+    paletteBrandGrey300: _$OptimusTokens.paletteBrandGrey300[0],
+    paletteBrandGrey400: _$OptimusTokens.paletteBrandGrey400[0],
+    paletteBrandGrey50: _$OptimusTokens.paletteBrandGrey50[0],
+    paletteBrandGrey500: _$OptimusTokens.paletteBrandGrey500[0],
+    paletteBrandGrey600: _$OptimusTokens.paletteBrandGrey600[0],
+    paletteBrandGrey700: _$OptimusTokens.paletteBrandGrey700[0],
+    paletteBrandGrey800: _$OptimusTokens.paletteBrandGrey800[0],
+    paletteBrandGrey900: _$OptimusTokens.paletteBrandGrey900[0],
+    paletteBrandIndigo100: _$OptimusTokens.paletteBrandIndigo100[0],
+    paletteBrandIndigo1000: _$OptimusTokens.paletteBrandIndigo1000[0],
+    paletteBrandIndigo150: _$OptimusTokens.paletteBrandIndigo150[0],
+    paletteBrandIndigo200: _$OptimusTokens.paletteBrandIndigo200[0],
+    paletteBrandIndigo25: _$OptimusTokens.paletteBrandIndigo25[0],
+    paletteBrandIndigo300: _$OptimusTokens.paletteBrandIndigo300[0],
+    paletteBrandIndigo400: _$OptimusTokens.paletteBrandIndigo400[0],
+    paletteBrandIndigo50: _$OptimusTokens.paletteBrandIndigo50[0],
+    paletteBrandIndigo500: _$OptimusTokens.paletteBrandIndigo500[0],
+    paletteBrandIndigo600: _$OptimusTokens.paletteBrandIndigo600[0],
+    paletteBrandIndigo700: _$OptimusTokens.paletteBrandIndigo700[0],
+    paletteBrandIndigo800: _$OptimusTokens.paletteBrandIndigo800[0],
+    paletteBrandIndigo900: _$OptimusTokens.paletteBrandIndigo900[0],
+    paletteBrandNight0: _$OptimusTokens.paletteBrandNight0[0],
+    paletteBrandNight100: _$OptimusTokens.paletteBrandNight100[0],
+    paletteBrandNight1000: _$OptimusTokens.paletteBrandNight1000[0],
+    paletteBrandNight100012: _$OptimusTokens.paletteBrandNight100012[0],
+    paletteBrandNight100016: _$OptimusTokens.paletteBrandNight100016[0],
+    paletteBrandNight10008: _$OptimusTokens.paletteBrandNight10008[0],
+    paletteBrandNight150: _$OptimusTokens.paletteBrandNight150[0],
+    paletteBrandNight200: _$OptimusTokens.paletteBrandNight200[0],
+    paletteBrandNight25: _$OptimusTokens.paletteBrandNight25[0],
+    paletteBrandNight300: _$OptimusTokens.paletteBrandNight300[0],
+    paletteBrandNight400: _$OptimusTokens.paletteBrandNight400[0],
+    paletteBrandNight50: _$OptimusTokens.paletteBrandNight50[0],
+    paletteBrandNight500: _$OptimusTokens.paletteBrandNight500[0],
+    paletteBrandNight600: _$OptimusTokens.paletteBrandNight600[0],
+    paletteBrandNight700: _$OptimusTokens.paletteBrandNight700[0],
+    paletteBrandNight800: _$OptimusTokens.paletteBrandNight800[0],
+    paletteBrandNight900: _$OptimusTokens.paletteBrandNight900[0],
+    paletteDatavizDenim100: _$OptimusTokens.paletteDatavizDenim100[0],
+    paletteDatavizDenim200: _$OptimusTokens.paletteDatavizDenim200[0],
+    paletteDatavizDenim300: _$OptimusTokens.paletteDatavizDenim300[0],
+    paletteDatavizDenim400: _$OptimusTokens.paletteDatavizDenim400[0],
+    paletteDatavizDenim50: _$OptimusTokens.paletteDatavizDenim50[0],
+    paletteDatavizDenim500: _$OptimusTokens.paletteDatavizDenim500[0],
+    paletteDatavizDenim600: _$OptimusTokens.paletteDatavizDenim600[0],
+    paletteDatavizDenim700: _$OptimusTokens.paletteDatavizDenim700[0],
+    paletteDatavizDenim800: _$OptimusTokens.paletteDatavizDenim800[0],
+    paletteDatavizDenim900: _$OptimusTokens.paletteDatavizDenim900[0],
+    paletteDatavizLavender100: _$OptimusTokens.paletteDatavizLavender100[0],
+    paletteDatavizLavender200: _$OptimusTokens.paletteDatavizLavender200[0],
+    paletteDatavizLavender300: _$OptimusTokens.paletteDatavizLavender300[0],
+    paletteDatavizLavender400: _$OptimusTokens.paletteDatavizLavender400[0],
+    paletteDatavizLavender50: _$OptimusTokens.paletteDatavizLavender50[0],
+    paletteDatavizLavender500: _$OptimusTokens.paletteDatavizLavender500[0],
+    paletteDatavizLavender600: _$OptimusTokens.paletteDatavizLavender600[0],
+    paletteDatavizLavender700: _$OptimusTokens.paletteDatavizLavender700[0],
+    paletteDatavizLavender800: _$OptimusTokens.paletteDatavizLavender800[0],
+    paletteDatavizLavender900: _$OptimusTokens.paletteDatavizLavender900[0],
+    paletteDatavizLime100: _$OptimusTokens.paletteDatavizLime100[0],
+    paletteDatavizLime200: _$OptimusTokens.paletteDatavizLime200[0],
+    paletteDatavizLime300: _$OptimusTokens.paletteDatavizLime300[0],
+    paletteDatavizLime400: _$OptimusTokens.paletteDatavizLime400[0],
+    paletteDatavizLime50: _$OptimusTokens.paletteDatavizLime50[0],
+    paletteDatavizLime500: _$OptimusTokens.paletteDatavizLime500[0],
+    paletteDatavizLime600: _$OptimusTokens.paletteDatavizLime600[0],
+    paletteDatavizLime700: _$OptimusTokens.paletteDatavizLime700[0],
+    paletteDatavizLime800: _$OptimusTokens.paletteDatavizLime800[0],
+    paletteDatavizLime900: _$OptimusTokens.paletteDatavizLime900[0],
+    paletteDatavizMustard100: _$OptimusTokens.paletteDatavizMustard100[0],
+    paletteDatavizMustard200: _$OptimusTokens.paletteDatavizMustard200[0],
+    paletteDatavizMustard300: _$OptimusTokens.paletteDatavizMustard300[0],
+    paletteDatavizMustard400: _$OptimusTokens.paletteDatavizMustard400[0],
+    paletteDatavizMustard50: _$OptimusTokens.paletteDatavizMustard50[0],
+    paletteDatavizMustard500: _$OptimusTokens.paletteDatavizMustard500[0],
+    paletteDatavizMustard600: _$OptimusTokens.paletteDatavizMustard600[0],
+    paletteDatavizMustard700: _$OptimusTokens.paletteDatavizMustard700[0],
+    paletteDatavizMustard800: _$OptimusTokens.paletteDatavizMustard800[0],
+    paletteDatavizMustard900: _$OptimusTokens.paletteDatavizMustard900[0],
+    paletteDatavizRuby100: _$OptimusTokens.paletteDatavizRuby100[0],
+    paletteDatavizRuby200: _$OptimusTokens.paletteDatavizRuby200[0],
+    paletteDatavizRuby300: _$OptimusTokens.paletteDatavizRuby300[0],
+    paletteDatavizRuby400: _$OptimusTokens.paletteDatavizRuby400[0],
+    paletteDatavizRuby50: _$OptimusTokens.paletteDatavizRuby50[0],
+    paletteDatavizRuby500: _$OptimusTokens.paletteDatavizRuby500[0],
+    paletteDatavizRuby600: _$OptimusTokens.paletteDatavizRuby600[0],
+    paletteDatavizRuby700: _$OptimusTokens.paletteDatavizRuby700[0],
+    paletteDatavizRuby800: _$OptimusTokens.paletteDatavizRuby800[0],
+    paletteDatavizRuby900: _$OptimusTokens.paletteDatavizRuby900[0],
+    paletteDatavizTangerine100: _$OptimusTokens.paletteDatavizTangerine100[0],
+    paletteDatavizTangerine200: _$OptimusTokens.paletteDatavizTangerine200[0],
+    paletteDatavizTangerine300: _$OptimusTokens.paletteDatavizTangerine300[0],
+    paletteDatavizTangerine400: _$OptimusTokens.paletteDatavizTangerine400[0],
+    paletteDatavizTangerine50: _$OptimusTokens.paletteDatavizTangerine50[0],
+    paletteDatavizTangerine500: _$OptimusTokens.paletteDatavizTangerine500[0],
+    paletteDatavizTangerine600: _$OptimusTokens.paletteDatavizTangerine600[0],
+    paletteDatavizTangerine700: _$OptimusTokens.paletteDatavizTangerine700[0],
+    paletteDatavizTangerine800: _$OptimusTokens.paletteDatavizTangerine800[0],
+    paletteDatavizTangerine900: _$OptimusTokens.paletteDatavizTangerine900[0],
+    paletteSemanticBlue100: _$OptimusTokens.paletteSemanticBlue100[0],
+    paletteSemanticBlue1000: _$OptimusTokens.paletteSemanticBlue1000[0],
+    paletteSemanticBlue150: _$OptimusTokens.paletteSemanticBlue150[0],
+    paletteSemanticBlue200: _$OptimusTokens.paletteSemanticBlue200[0],
+    paletteSemanticBlue25: _$OptimusTokens.paletteSemanticBlue25[0],
+    paletteSemanticBlue300: _$OptimusTokens.paletteSemanticBlue300[0],
+    paletteSemanticBlue400: _$OptimusTokens.paletteSemanticBlue400[0],
+    paletteSemanticBlue50: _$OptimusTokens.paletteSemanticBlue50[0],
+    paletteSemanticBlue500: _$OptimusTokens.paletteSemanticBlue500[0],
+    paletteSemanticBlue600: _$OptimusTokens.paletteSemanticBlue600[0],
+    paletteSemanticBlue700: _$OptimusTokens.paletteSemanticBlue700[0],
+    paletteSemanticBlue800: _$OptimusTokens.paletteSemanticBlue800[0],
+    paletteSemanticBlue900: _$OptimusTokens.paletteSemanticBlue900[0],
+    paletteSemanticGreen100: _$OptimusTokens.paletteSemanticGreen100[0],
+    paletteSemanticGreen1000: _$OptimusTokens.paletteSemanticGreen1000[0],
+    paletteSemanticGreen150: _$OptimusTokens.paletteSemanticGreen150[0],
+    paletteSemanticGreen200: _$OptimusTokens.paletteSemanticGreen200[0],
+    paletteSemanticGreen25: _$OptimusTokens.paletteSemanticGreen25[0],
+    paletteSemanticGreen300: _$OptimusTokens.paletteSemanticGreen300[0],
+    paletteSemanticGreen400: _$OptimusTokens.paletteSemanticGreen400[0],
+    paletteSemanticGreen50: _$OptimusTokens.paletteSemanticGreen50[0],
+    paletteSemanticGreen500: _$OptimusTokens.paletteSemanticGreen500[0],
+    paletteSemanticGreen600: _$OptimusTokens.paletteSemanticGreen600[0],
+    paletteSemanticGreen700: _$OptimusTokens.paletteSemanticGreen700[0],
+    paletteSemanticGreen800: _$OptimusTokens.paletteSemanticGreen800[0],
+    paletteSemanticGreen900: _$OptimusTokens.paletteSemanticGreen900[0],
+    paletteSemanticOrange100: _$OptimusTokens.paletteSemanticOrange100[0],
+    paletteSemanticOrange1000: _$OptimusTokens.paletteSemanticOrange1000[0],
+    paletteSemanticOrange150: _$OptimusTokens.paletteSemanticOrange150[0],
+    paletteSemanticOrange200: _$OptimusTokens.paletteSemanticOrange200[0],
+    paletteSemanticOrange25: _$OptimusTokens.paletteSemanticOrange25[0],
+    paletteSemanticOrange300: _$OptimusTokens.paletteSemanticOrange300[0],
+    paletteSemanticOrange400: _$OptimusTokens.paletteSemanticOrange400[0],
+    paletteSemanticOrange50: _$OptimusTokens.paletteSemanticOrange50[0],
+    paletteSemanticOrange500: _$OptimusTokens.paletteSemanticOrange500[0],
+    paletteSemanticOrange600: _$OptimusTokens.paletteSemanticOrange600[0],
+    paletteSemanticOrange700: _$OptimusTokens.paletteSemanticOrange700[0],
+    paletteSemanticOrange800: _$OptimusTokens.paletteSemanticOrange800[0],
+    paletteSemanticOrange900: _$OptimusTokens.paletteSemanticOrange900[0],
+    paletteSemanticRed100: _$OptimusTokens.paletteSemanticRed100[0],
+    paletteSemanticRed1000: _$OptimusTokens.paletteSemanticRed1000[0],
+    paletteSemanticRed150: _$OptimusTokens.paletteSemanticRed150[0],
+    paletteSemanticRed200: _$OptimusTokens.paletteSemanticRed200[0],
+    paletteSemanticRed25: _$OptimusTokens.paletteSemanticRed25[0],
+    paletteSemanticRed300: _$OptimusTokens.paletteSemanticRed300[0],
+    paletteSemanticRed400: _$OptimusTokens.paletteSemanticRed400[0],
+    paletteSemanticRed50: _$OptimusTokens.paletteSemanticRed50[0],
+    paletteSemanticRed500: _$OptimusTokens.paletteSemanticRed500[0],
+    paletteSemanticRed600: _$OptimusTokens.paletteSemanticRed600[0],
+    paletteSemanticRed700: _$OptimusTokens.paletteSemanticRed700[0],
+    paletteSemanticRed800: _$OptimusTokens.paletteSemanticRed800[0],
+    paletteSemanticRed900: _$OptimusTokens.paletteSemanticRed900[0],
+    staticContainerColor: _$OptimusTokens.staticContainerColor[0],
+    staticDividerColor: _$OptimusTokens.staticDividerColor[0],
+    textAlertBasic: _$OptimusTokens.textAlertBasic[0],
+    textAlertDanger: _$OptimusTokens.textAlertDanger[0],
+    textAlertInfo: _$OptimusTokens.textAlertInfo[0],
+    textAlertSuccess: _$OptimusTokens.textAlertSuccess[0],
+    textAlertWarning: _$OptimusTokens.textAlertWarning[0],
+    textDisabled: _$OptimusTokens.textDisabled[0],
+    textInteractiveActive: _$OptimusTokens.textInteractiveActive[0],
+    textInteractiveDefault: _$OptimusTokens.textInteractiveDefault[0],
+    textInteractiveHover: _$OptimusTokens.textInteractiveHover[0],
+    textStaticError: _$OptimusTokens.textStaticError[0],
     textStaticInverse: _$OptimusTokens.textStaticInverse[0],
+    textStaticPrimary: _$OptimusTokens.textStaticPrimary[0],
+    textStaticSecondary: _$OptimusTokens.textStaticSecondary[0],
+    textStaticTertiary: _$OptimusTokens.textStaticTertiary[0],
   );
 
   static final OptimusTokens dark = OptimusTokens(
     backgroundAccentPrimary: _$OptimusTokens.backgroundAccentPrimary[1],
     backgroundAccentSecondary: _$OptimusTokens.backgroundAccentSecondary[1],
     backgroundAlertBasicPrimary: _$OptimusTokens.backgroundAlertBasicPrimary[1],
+    backgroundAlertBasicSecondary:
+        _$OptimusTokens.backgroundAlertBasicSecondary[1],
+    backgroundAlertDangerPrimary:
+        _$OptimusTokens.backgroundAlertDangerPrimary[1],
+    backgroundAlertDangerSecondary:
+        _$OptimusTokens.backgroundAlertDangerSecondary[1],
+    backgroundAlertInfoPrimary: _$OptimusTokens.backgroundAlertInfoPrimary[1],
+    backgroundAlertInfoSecondary:
+        _$OptimusTokens.backgroundAlertInfoSecondary[1],
+    backgroundAlertSuccessPrimary:
+        _$OptimusTokens.backgroundAlertSuccessPrimary[1],
+    backgroundAlertSuccessSecondary:
+        _$OptimusTokens.backgroundAlertSuccessSecondary[1],
+    backgroundAlertWarningPrimary:
+        _$OptimusTokens.backgroundAlertWarningPrimary[1],
+    backgroundAlertWarningSecondary:
+        _$OptimusTokens.backgroundAlertWarningSecondary[1],
+    backgroundBrand: _$OptimusTokens.backgroundBrand[1],
     backgroundDisabled: _$OptimusTokens.backgroundDisabled[1],
+    backgroundInteractiveBoldActive:
+        _$OptimusTokens.backgroundInteractiveBoldActive[1],
+    backgroundInteractiveBoldDefault:
+        _$OptimusTokens.backgroundInteractiveBoldDefault[1],
+    backgroundInteractiveBoldHover:
+        _$OptimusTokens.backgroundInteractiveBoldHover[1],
+    backgroundInteractiveDangerActive:
+        _$OptimusTokens.backgroundInteractiveDangerActive[1],
+    backgroundInteractiveDangerDefault:
+        _$OptimusTokens.backgroundInteractiveDangerDefault[1],
+    backgroundInteractiveDangerHover:
+        _$OptimusTokens.backgroundInteractiveDangerHover[1],
     backgroundInteractivePrimaryActive:
         _$OptimusTokens.backgroundInteractivePrimaryActive[1],
     backgroundInteractivePrimaryDefault:
         _$OptimusTokens.backgroundInteractivePrimaryDefault[1],
     backgroundInteractivePrimaryHover:
         _$OptimusTokens.backgroundInteractivePrimaryHover[1],
+    backgroundInteractiveSecondaryActive:
+        _$OptimusTokens.backgroundInteractiveSecondaryActive[1],
+    backgroundInteractiveSecondaryDefault:
+        _$OptimusTokens.backgroundInteractiveSecondaryDefault[1],
+    backgroundInteractiveSecondaryHover:
+        _$OptimusTokens.backgroundInteractiveSecondaryHover[1],
+    backgroundInteractiveSubtleActive:
+        _$OptimusTokens.backgroundInteractiveSubtleActive[1],
+    backgroundInteractiveSubtleDefault:
+        _$OptimusTokens.backgroundInteractiveSubtleDefault[1],
+    backgroundInteractiveSubtleHover:
+        _$OptimusTokens.backgroundInteractiveSubtleHover[1],
+    backgroundOverlay: _$OptimusTokens.backgroundOverlay[1],
+    backgroundStaticFlat: _$OptimusTokens.backgroundStaticFlat[1],
+    backgroundStaticFloating: _$OptimusTokens.backgroundStaticFloating[1],
+    backgroundStaticInverse: _$OptimusTokens.backgroundStaticInverse[1],
+    backgroundStaticRaised: _$OptimusTokens.backgroundStaticRaised[1],
+    backgroundStaticSunken: _$OptimusTokens.backgroundStaticSunken[1],
+    borderAlertBasic: _$OptimusTokens.borderAlertBasic[1],
+    borderAlertDanger: _$OptimusTokens.borderAlertDanger[1],
+    borderAlertInfo: _$OptimusTokens.borderAlertInfo[1],
+    borderAlertSuccess: _$OptimusTokens.borderAlertSuccess[1],
+    borderAlertWarning: _$OptimusTokens.borderAlertWarning[1],
+    borderDisabled: _$OptimusTokens.borderDisabled[1],
+    borderInteractiveError: _$OptimusTokens.borderInteractiveError[1],
+    borderInteractiveFocus: _$OptimusTokens.borderInteractiveFocus[1],
+    borderInteractivePrimaryActive:
+        _$OptimusTokens.borderInteractivePrimaryActive[1],
+    borderInteractivePrimaryDefault:
+        _$OptimusTokens.borderInteractivePrimaryDefault[1],
+    borderInteractivePrimaryHover:
+        _$OptimusTokens.borderInteractivePrimaryHover[1],
+    borderInteractiveSecondaryActive:
+        _$OptimusTokens.borderInteractiveSecondaryActive[1],
+    borderInteractiveSecondaryHover:
+        _$OptimusTokens.borderInteractiveSecondaryHover[1],
+    borderStaticInverse: _$OptimusTokens.borderStaticInverse[1],
+    borderStaticPrimary: _$OptimusTokens.borderStaticPrimary[1],
+    borderStaticSecondary: _$OptimusTokens.borderStaticSecondary[1],
+    inputActiveColor: _$OptimusTokens.inputActiveColor[1],
+    inputDangerColor: _$OptimusTokens.inputDangerColor[1],
+    inputDefaultColor: _$OptimusTokens.inputDefaultColor[1],
+    inputDisabledColor: _$OptimusTokens.inputDisabledColor[1],
+    inputHoverColor: _$OptimusTokens.inputHoverColor[1],
+    inputInverseColor: _$OptimusTokens.inputInverseColor[1],
+    interactiveDangerColor: _$OptimusTokens.interactiveDangerColor[1],
+    interactiveDefaultColor: _$OptimusTokens.interactiveDefaultColor[1],
+    interactiveDisabledColor: _$OptimusTokens.interactiveDisabledColor[1],
+    interactiveHoverColor: _$OptimusTokens.interactiveHoverColor[1],
+    interactiveInverseColor: _$OptimusTokens.interactiveInverseColor[1],
+    paletteBasicsBlack: _$OptimusTokens.paletteBasicsBlack[1],
+    paletteBasicsWhite: _$OptimusTokens.paletteBasicsWhite[1],
+    paletteBasicsWhite64: _$OptimusTokens.paletteBasicsWhite64[1],
+    paletteBrandCoral100: _$OptimusTokens.paletteBrandCoral100[1],
+    paletteBrandCoral1000: _$OptimusTokens.paletteBrandCoral1000[1],
+    paletteBrandCoral150: _$OptimusTokens.paletteBrandCoral150[1],
+    paletteBrandCoral200: _$OptimusTokens.paletteBrandCoral200[1],
+    paletteBrandCoral25: _$OptimusTokens.paletteBrandCoral25[1],
+    paletteBrandCoral300: _$OptimusTokens.paletteBrandCoral300[1],
+    paletteBrandCoral400: _$OptimusTokens.paletteBrandCoral400[1],
+    paletteBrandCoral50: _$OptimusTokens.paletteBrandCoral50[1],
+    paletteBrandCoral500: _$OptimusTokens.paletteBrandCoral500[1],
+    paletteBrandCoral600: _$OptimusTokens.paletteBrandCoral600[1],
+    paletteBrandCoral700: _$OptimusTokens.paletteBrandCoral700[1],
+    paletteBrandCoral800: _$OptimusTokens.paletteBrandCoral800[1],
+    paletteBrandCoral900: _$OptimusTokens.paletteBrandCoral900[1],
+    paletteBrandGrey0: _$OptimusTokens.paletteBrandGrey0[1],
+    paletteBrandGrey100: _$OptimusTokens.paletteBrandGrey100[1],
+    paletteBrandGrey1000: _$OptimusTokens.paletteBrandGrey1000[1],
+    paletteBrandGrey150: _$OptimusTokens.paletteBrandGrey150[1],
+    paletteBrandGrey200: _$OptimusTokens.paletteBrandGrey200[1],
+    paletteBrandGrey25: _$OptimusTokens.paletteBrandGrey25[1],
+    paletteBrandGrey300: _$OptimusTokens.paletteBrandGrey300[1],
+    paletteBrandGrey400: _$OptimusTokens.paletteBrandGrey400[1],
+    paletteBrandGrey50: _$OptimusTokens.paletteBrandGrey50[1],
+    paletteBrandGrey500: _$OptimusTokens.paletteBrandGrey500[1],
+    paletteBrandGrey600: _$OptimusTokens.paletteBrandGrey600[1],
+    paletteBrandGrey700: _$OptimusTokens.paletteBrandGrey700[1],
+    paletteBrandGrey800: _$OptimusTokens.paletteBrandGrey800[1],
+    paletteBrandGrey900: _$OptimusTokens.paletteBrandGrey900[1],
+    paletteBrandIndigo100: _$OptimusTokens.paletteBrandIndigo100[1],
+    paletteBrandIndigo1000: _$OptimusTokens.paletteBrandIndigo1000[1],
+    paletteBrandIndigo150: _$OptimusTokens.paletteBrandIndigo150[1],
+    paletteBrandIndigo200: _$OptimusTokens.paletteBrandIndigo200[1],
+    paletteBrandIndigo25: _$OptimusTokens.paletteBrandIndigo25[1],
+    paletteBrandIndigo300: _$OptimusTokens.paletteBrandIndigo300[1],
+    paletteBrandIndigo400: _$OptimusTokens.paletteBrandIndigo400[1],
+    paletteBrandIndigo50: _$OptimusTokens.paletteBrandIndigo50[1],
+    paletteBrandIndigo500: _$OptimusTokens.paletteBrandIndigo500[1],
+    paletteBrandIndigo600: _$OptimusTokens.paletteBrandIndigo600[1],
+    paletteBrandIndigo700: _$OptimusTokens.paletteBrandIndigo700[1],
+    paletteBrandIndigo800: _$OptimusTokens.paletteBrandIndigo800[1],
+    paletteBrandIndigo900: _$OptimusTokens.paletteBrandIndigo900[1],
+    paletteBrandNight0: _$OptimusTokens.paletteBrandNight0[1],
+    paletteBrandNight100: _$OptimusTokens.paletteBrandNight100[1],
+    paletteBrandNight1000: _$OptimusTokens.paletteBrandNight1000[1],
+    paletteBrandNight100012: _$OptimusTokens.paletteBrandNight100012[1],
+    paletteBrandNight100016: _$OptimusTokens.paletteBrandNight100016[1],
+    paletteBrandNight10008: _$OptimusTokens.paletteBrandNight10008[1],
+    paletteBrandNight150: _$OptimusTokens.paletteBrandNight150[1],
+    paletteBrandNight200: _$OptimusTokens.paletteBrandNight200[1],
+    paletteBrandNight25: _$OptimusTokens.paletteBrandNight25[1],
+    paletteBrandNight300: _$OptimusTokens.paletteBrandNight300[1],
+    paletteBrandNight400: _$OptimusTokens.paletteBrandNight400[1],
+    paletteBrandNight50: _$OptimusTokens.paletteBrandNight50[1],
+    paletteBrandNight500: _$OptimusTokens.paletteBrandNight500[1],
+    paletteBrandNight600: _$OptimusTokens.paletteBrandNight600[1],
+    paletteBrandNight700: _$OptimusTokens.paletteBrandNight700[1],
+    paletteBrandNight800: _$OptimusTokens.paletteBrandNight800[1],
+    paletteBrandNight900: _$OptimusTokens.paletteBrandNight900[1],
+    paletteDatavizDenim100: _$OptimusTokens.paletteDatavizDenim100[1],
+    paletteDatavizDenim200: _$OptimusTokens.paletteDatavizDenim200[1],
+    paletteDatavizDenim300: _$OptimusTokens.paletteDatavizDenim300[1],
+    paletteDatavizDenim400: _$OptimusTokens.paletteDatavizDenim400[1],
+    paletteDatavizDenim50: _$OptimusTokens.paletteDatavizDenim50[1],
+    paletteDatavizDenim500: _$OptimusTokens.paletteDatavizDenim500[1],
+    paletteDatavizDenim600: _$OptimusTokens.paletteDatavizDenim600[1],
+    paletteDatavizDenim700: _$OptimusTokens.paletteDatavizDenim700[1],
+    paletteDatavizDenim800: _$OptimusTokens.paletteDatavizDenim800[1],
+    paletteDatavizDenim900: _$OptimusTokens.paletteDatavizDenim900[1],
+    paletteDatavizLavender100: _$OptimusTokens.paletteDatavizLavender100[1],
+    paletteDatavizLavender200: _$OptimusTokens.paletteDatavizLavender200[1],
+    paletteDatavizLavender300: _$OptimusTokens.paletteDatavizLavender300[1],
+    paletteDatavizLavender400: _$OptimusTokens.paletteDatavizLavender400[1],
+    paletteDatavizLavender50: _$OptimusTokens.paletteDatavizLavender50[1],
+    paletteDatavizLavender500: _$OptimusTokens.paletteDatavizLavender500[1],
+    paletteDatavizLavender600: _$OptimusTokens.paletteDatavizLavender600[1],
+    paletteDatavizLavender700: _$OptimusTokens.paletteDatavizLavender700[1],
+    paletteDatavizLavender800: _$OptimusTokens.paletteDatavizLavender800[1],
+    paletteDatavizLavender900: _$OptimusTokens.paletteDatavizLavender900[1],
+    paletteDatavizLime100: _$OptimusTokens.paletteDatavizLime100[1],
+    paletteDatavizLime200: _$OptimusTokens.paletteDatavizLime200[1],
+    paletteDatavizLime300: _$OptimusTokens.paletteDatavizLime300[1],
+    paletteDatavizLime400: _$OptimusTokens.paletteDatavizLime400[1],
+    paletteDatavizLime50: _$OptimusTokens.paletteDatavizLime50[1],
+    paletteDatavizLime500: _$OptimusTokens.paletteDatavizLime500[1],
+    paletteDatavizLime600: _$OptimusTokens.paletteDatavizLime600[1],
+    paletteDatavizLime700: _$OptimusTokens.paletteDatavizLime700[1],
+    paletteDatavizLime800: _$OptimusTokens.paletteDatavizLime800[1],
+    paletteDatavizLime900: _$OptimusTokens.paletteDatavizLime900[1],
+    paletteDatavizMustard100: _$OptimusTokens.paletteDatavizMustard100[1],
+    paletteDatavizMustard200: _$OptimusTokens.paletteDatavizMustard200[1],
+    paletteDatavizMustard300: _$OptimusTokens.paletteDatavizMustard300[1],
+    paletteDatavizMustard400: _$OptimusTokens.paletteDatavizMustard400[1],
+    paletteDatavizMustard50: _$OptimusTokens.paletteDatavizMustard50[1],
+    paletteDatavizMustard500: _$OptimusTokens.paletteDatavizMustard500[1],
+    paletteDatavizMustard600: _$OptimusTokens.paletteDatavizMustard600[1],
+    paletteDatavizMustard700: _$OptimusTokens.paletteDatavizMustard700[1],
+    paletteDatavizMustard800: _$OptimusTokens.paletteDatavizMustard800[1],
+    paletteDatavizMustard900: _$OptimusTokens.paletteDatavizMustard900[1],
+    paletteDatavizRuby100: _$OptimusTokens.paletteDatavizRuby100[1],
+    paletteDatavizRuby200: _$OptimusTokens.paletteDatavizRuby200[1],
+    paletteDatavizRuby300: _$OptimusTokens.paletteDatavizRuby300[1],
+    paletteDatavizRuby400: _$OptimusTokens.paletteDatavizRuby400[1],
+    paletteDatavizRuby50: _$OptimusTokens.paletteDatavizRuby50[1],
+    paletteDatavizRuby500: _$OptimusTokens.paletteDatavizRuby500[1],
+    paletteDatavizRuby600: _$OptimusTokens.paletteDatavizRuby600[1],
+    paletteDatavizRuby700: _$OptimusTokens.paletteDatavizRuby700[1],
+    paletteDatavizRuby800: _$OptimusTokens.paletteDatavizRuby800[1],
+    paletteDatavizRuby900: _$OptimusTokens.paletteDatavizRuby900[1],
+    paletteDatavizTangerine100: _$OptimusTokens.paletteDatavizTangerine100[1],
+    paletteDatavizTangerine200: _$OptimusTokens.paletteDatavizTangerine200[1],
+    paletteDatavizTangerine300: _$OptimusTokens.paletteDatavizTangerine300[1],
+    paletteDatavizTangerine400: _$OptimusTokens.paletteDatavizTangerine400[1],
+    paletteDatavizTangerine50: _$OptimusTokens.paletteDatavizTangerine50[1],
+    paletteDatavizTangerine500: _$OptimusTokens.paletteDatavizTangerine500[1],
+    paletteDatavizTangerine600: _$OptimusTokens.paletteDatavizTangerine600[1],
+    paletteDatavizTangerine700: _$OptimusTokens.paletteDatavizTangerine700[1],
+    paletteDatavizTangerine800: _$OptimusTokens.paletteDatavizTangerine800[1],
+    paletteDatavizTangerine900: _$OptimusTokens.paletteDatavizTangerine900[1],
+    paletteSemanticBlue100: _$OptimusTokens.paletteSemanticBlue100[1],
+    paletteSemanticBlue1000: _$OptimusTokens.paletteSemanticBlue1000[1],
+    paletteSemanticBlue150: _$OptimusTokens.paletteSemanticBlue150[1],
+    paletteSemanticBlue200: _$OptimusTokens.paletteSemanticBlue200[1],
+    paletteSemanticBlue25: _$OptimusTokens.paletteSemanticBlue25[1],
+    paletteSemanticBlue300: _$OptimusTokens.paletteSemanticBlue300[1],
+    paletteSemanticBlue400: _$OptimusTokens.paletteSemanticBlue400[1],
+    paletteSemanticBlue50: _$OptimusTokens.paletteSemanticBlue50[1],
+    paletteSemanticBlue500: _$OptimusTokens.paletteSemanticBlue500[1],
+    paletteSemanticBlue600: _$OptimusTokens.paletteSemanticBlue600[1],
+    paletteSemanticBlue700: _$OptimusTokens.paletteSemanticBlue700[1],
+    paletteSemanticBlue800: _$OptimusTokens.paletteSemanticBlue800[1],
+    paletteSemanticBlue900: _$OptimusTokens.paletteSemanticBlue900[1],
+    paletteSemanticGreen100: _$OptimusTokens.paletteSemanticGreen100[1],
+    paletteSemanticGreen1000: _$OptimusTokens.paletteSemanticGreen1000[1],
+    paletteSemanticGreen150: _$OptimusTokens.paletteSemanticGreen150[1],
+    paletteSemanticGreen200: _$OptimusTokens.paletteSemanticGreen200[1],
+    paletteSemanticGreen25: _$OptimusTokens.paletteSemanticGreen25[1],
+    paletteSemanticGreen300: _$OptimusTokens.paletteSemanticGreen300[1],
+    paletteSemanticGreen400: _$OptimusTokens.paletteSemanticGreen400[1],
+    paletteSemanticGreen50: _$OptimusTokens.paletteSemanticGreen50[1],
+    paletteSemanticGreen500: _$OptimusTokens.paletteSemanticGreen500[1],
+    paletteSemanticGreen600: _$OptimusTokens.paletteSemanticGreen600[1],
+    paletteSemanticGreen700: _$OptimusTokens.paletteSemanticGreen700[1],
+    paletteSemanticGreen800: _$OptimusTokens.paletteSemanticGreen800[1],
+    paletteSemanticGreen900: _$OptimusTokens.paletteSemanticGreen900[1],
+    paletteSemanticOrange100: _$OptimusTokens.paletteSemanticOrange100[1],
+    paletteSemanticOrange1000: _$OptimusTokens.paletteSemanticOrange1000[1],
+    paletteSemanticOrange150: _$OptimusTokens.paletteSemanticOrange150[1],
+    paletteSemanticOrange200: _$OptimusTokens.paletteSemanticOrange200[1],
+    paletteSemanticOrange25: _$OptimusTokens.paletteSemanticOrange25[1],
+    paletteSemanticOrange300: _$OptimusTokens.paletteSemanticOrange300[1],
+    paletteSemanticOrange400: _$OptimusTokens.paletteSemanticOrange400[1],
+    paletteSemanticOrange50: _$OptimusTokens.paletteSemanticOrange50[1],
+    paletteSemanticOrange500: _$OptimusTokens.paletteSemanticOrange500[1],
+    paletteSemanticOrange600: _$OptimusTokens.paletteSemanticOrange600[1],
+    paletteSemanticOrange700: _$OptimusTokens.paletteSemanticOrange700[1],
+    paletteSemanticOrange800: _$OptimusTokens.paletteSemanticOrange800[1],
+    paletteSemanticOrange900: _$OptimusTokens.paletteSemanticOrange900[1],
+    paletteSemanticRed100: _$OptimusTokens.paletteSemanticRed100[1],
+    paletteSemanticRed1000: _$OptimusTokens.paletteSemanticRed1000[1],
+    paletteSemanticRed150: _$OptimusTokens.paletteSemanticRed150[1],
+    paletteSemanticRed200: _$OptimusTokens.paletteSemanticRed200[1],
+    paletteSemanticRed25: _$OptimusTokens.paletteSemanticRed25[1],
+    paletteSemanticRed300: _$OptimusTokens.paletteSemanticRed300[1],
+    paletteSemanticRed400: _$OptimusTokens.paletteSemanticRed400[1],
+    paletteSemanticRed50: _$OptimusTokens.paletteSemanticRed50[1],
+    paletteSemanticRed500: _$OptimusTokens.paletteSemanticRed500[1],
+    paletteSemanticRed600: _$OptimusTokens.paletteSemanticRed600[1],
+    paletteSemanticRed700: _$OptimusTokens.paletteSemanticRed700[1],
+    paletteSemanticRed800: _$OptimusTokens.paletteSemanticRed800[1],
+    paletteSemanticRed900: _$OptimusTokens.paletteSemanticRed900[1],
+    staticContainerColor: _$OptimusTokens.staticContainerColor[1],
+    staticDividerColor: _$OptimusTokens.staticDividerColor[1],
+    textAlertBasic: _$OptimusTokens.textAlertBasic[1],
+    textAlertDanger: _$OptimusTokens.textAlertDanger[1],
+    textAlertInfo: _$OptimusTokens.textAlertInfo[1],
+    textAlertSuccess: _$OptimusTokens.textAlertSuccess[1],
+    textAlertWarning: _$OptimusTokens.textAlertWarning[1],
+    textDisabled: _$OptimusTokens.textDisabled[1],
+    textInteractiveActive: _$OptimusTokens.textInteractiveActive[1],
+    textInteractiveDefault: _$OptimusTokens.textInteractiveDefault[1],
+    textInteractiveHover: _$OptimusTokens.textInteractiveHover[1],
+    textStaticError: _$OptimusTokens.textStaticError[1],
     textStaticInverse: _$OptimusTokens.textStaticInverse[1],
+    textStaticPrimary: _$OptimusTokens.textStaticPrimary[1],
+    textStaticSecondary: _$OptimusTokens.textStaticSecondary[1],
+    textStaticTertiary: _$OptimusTokens.textStaticTertiary[1],
   );
 
   static final themes = [
@@ -68,11 +1086,253 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
     Color? backgroundAccentPrimary,
     Color? backgroundAccentSecondary,
     Color? backgroundAlertBasicPrimary,
+    Color? backgroundAlertBasicSecondary,
+    Color? backgroundAlertDangerPrimary,
+    Color? backgroundAlertDangerSecondary,
+    Color? backgroundAlertInfoPrimary,
+    Color? backgroundAlertInfoSecondary,
+    Color? backgroundAlertSuccessPrimary,
+    Color? backgroundAlertSuccessSecondary,
+    Color? backgroundAlertWarningPrimary,
+    Color? backgroundAlertWarningSecondary,
+    Color? backgroundBrand,
     Color? backgroundDisabled,
+    Color? backgroundInteractiveBoldActive,
+    Color? backgroundInteractiveBoldDefault,
+    Color? backgroundInteractiveBoldHover,
+    Color? backgroundInteractiveDangerActive,
+    Color? backgroundInteractiveDangerDefault,
+    Color? backgroundInteractiveDangerHover,
     Color? backgroundInteractivePrimaryActive,
     Color? backgroundInteractivePrimaryDefault,
     Color? backgroundInteractivePrimaryHover,
+    Color? backgroundInteractiveSecondaryActive,
+    Color? backgroundInteractiveSecondaryDefault,
+    Color? backgroundInteractiveSecondaryHover,
+    Color? backgroundInteractiveSubtleActive,
+    Color? backgroundInteractiveSubtleDefault,
+    Color? backgroundInteractiveSubtleHover,
+    Color? backgroundOverlay,
+    Color? backgroundStaticFlat,
+    Color? backgroundStaticFloating,
+    Color? backgroundStaticInverse,
+    Color? backgroundStaticRaised,
+    Color? backgroundStaticSunken,
+    Color? borderAlertBasic,
+    Color? borderAlertDanger,
+    Color? borderAlertInfo,
+    Color? borderAlertSuccess,
+    Color? borderAlertWarning,
+    Color? borderDisabled,
+    Color? borderInteractiveError,
+    Color? borderInteractiveFocus,
+    Color? borderInteractivePrimaryActive,
+    Color? borderInteractivePrimaryDefault,
+    Color? borderInteractivePrimaryHover,
+    Color? borderInteractiveSecondaryActive,
+    Color? borderInteractiveSecondaryHover,
+    Color? borderStaticInverse,
+    Color? borderStaticPrimary,
+    Color? borderStaticSecondary,
+    Color? inputActiveColor,
+    Color? inputDangerColor,
+    Color? inputDefaultColor,
+    Color? inputDisabledColor,
+    Color? inputHoverColor,
+    Color? inputInverseColor,
+    Color? interactiveDangerColor,
+    Color? interactiveDefaultColor,
+    Color? interactiveDisabledColor,
+    Color? interactiveHoverColor,
+    Color? interactiveInverseColor,
+    Color? paletteBasicsBlack,
+    Color? paletteBasicsWhite,
+    Color? paletteBasicsWhite64,
+    Color? paletteBrandCoral100,
+    Color? paletteBrandCoral1000,
+    Color? paletteBrandCoral150,
+    Color? paletteBrandCoral200,
+    Color? paletteBrandCoral25,
+    Color? paletteBrandCoral300,
+    Color? paletteBrandCoral400,
+    Color? paletteBrandCoral50,
+    Color? paletteBrandCoral500,
+    Color? paletteBrandCoral600,
+    Color? paletteBrandCoral700,
+    Color? paletteBrandCoral800,
+    Color? paletteBrandCoral900,
+    Color? paletteBrandGrey0,
+    Color? paletteBrandGrey100,
+    Color? paletteBrandGrey1000,
+    Color? paletteBrandGrey150,
+    Color? paletteBrandGrey200,
+    Color? paletteBrandGrey25,
+    Color? paletteBrandGrey300,
+    Color? paletteBrandGrey400,
+    Color? paletteBrandGrey50,
+    Color? paletteBrandGrey500,
+    Color? paletteBrandGrey600,
+    Color? paletteBrandGrey700,
+    Color? paletteBrandGrey800,
+    Color? paletteBrandGrey900,
+    Color? paletteBrandIndigo100,
+    Color? paletteBrandIndigo1000,
+    Color? paletteBrandIndigo150,
+    Color? paletteBrandIndigo200,
+    Color? paletteBrandIndigo25,
+    Color? paletteBrandIndigo300,
+    Color? paletteBrandIndigo400,
+    Color? paletteBrandIndigo50,
+    Color? paletteBrandIndigo500,
+    Color? paletteBrandIndigo600,
+    Color? paletteBrandIndigo700,
+    Color? paletteBrandIndigo800,
+    Color? paletteBrandIndigo900,
+    Color? paletteBrandNight0,
+    Color? paletteBrandNight100,
+    Color? paletteBrandNight1000,
+    Color? paletteBrandNight100012,
+    Color? paletteBrandNight100016,
+    Color? paletteBrandNight10008,
+    Color? paletteBrandNight150,
+    Color? paletteBrandNight200,
+    Color? paletteBrandNight25,
+    Color? paletteBrandNight300,
+    Color? paletteBrandNight400,
+    Color? paletteBrandNight50,
+    Color? paletteBrandNight500,
+    Color? paletteBrandNight600,
+    Color? paletteBrandNight700,
+    Color? paletteBrandNight800,
+    Color? paletteBrandNight900,
+    Color? paletteDatavizDenim100,
+    Color? paletteDatavizDenim200,
+    Color? paletteDatavizDenim300,
+    Color? paletteDatavizDenim400,
+    Color? paletteDatavizDenim50,
+    Color? paletteDatavizDenim500,
+    Color? paletteDatavizDenim600,
+    Color? paletteDatavizDenim700,
+    Color? paletteDatavizDenim800,
+    Color? paletteDatavizDenim900,
+    Color? paletteDatavizLavender100,
+    Color? paletteDatavizLavender200,
+    Color? paletteDatavizLavender300,
+    Color? paletteDatavizLavender400,
+    Color? paletteDatavizLavender50,
+    Color? paletteDatavizLavender500,
+    Color? paletteDatavizLavender600,
+    Color? paletteDatavizLavender700,
+    Color? paletteDatavizLavender800,
+    Color? paletteDatavizLavender900,
+    Color? paletteDatavizLime100,
+    Color? paletteDatavizLime200,
+    Color? paletteDatavizLime300,
+    Color? paletteDatavizLime400,
+    Color? paletteDatavizLime50,
+    Color? paletteDatavizLime500,
+    Color? paletteDatavizLime600,
+    Color? paletteDatavizLime700,
+    Color? paletteDatavizLime800,
+    Color? paletteDatavizLime900,
+    Color? paletteDatavizMustard100,
+    Color? paletteDatavizMustard200,
+    Color? paletteDatavizMustard300,
+    Color? paletteDatavizMustard400,
+    Color? paletteDatavizMustard50,
+    Color? paletteDatavizMustard500,
+    Color? paletteDatavizMustard600,
+    Color? paletteDatavizMustard700,
+    Color? paletteDatavizMustard800,
+    Color? paletteDatavizMustard900,
+    Color? paletteDatavizRuby100,
+    Color? paletteDatavizRuby200,
+    Color? paletteDatavizRuby300,
+    Color? paletteDatavizRuby400,
+    Color? paletteDatavizRuby50,
+    Color? paletteDatavizRuby500,
+    Color? paletteDatavizRuby600,
+    Color? paletteDatavizRuby700,
+    Color? paletteDatavizRuby800,
+    Color? paletteDatavizRuby900,
+    Color? paletteDatavizTangerine100,
+    Color? paletteDatavizTangerine200,
+    Color? paletteDatavizTangerine300,
+    Color? paletteDatavizTangerine400,
+    Color? paletteDatavizTangerine50,
+    Color? paletteDatavizTangerine500,
+    Color? paletteDatavizTangerine600,
+    Color? paletteDatavizTangerine700,
+    Color? paletteDatavizTangerine800,
+    Color? paletteDatavizTangerine900,
+    Color? paletteSemanticBlue100,
+    Color? paletteSemanticBlue1000,
+    Color? paletteSemanticBlue150,
+    Color? paletteSemanticBlue200,
+    Color? paletteSemanticBlue25,
+    Color? paletteSemanticBlue300,
+    Color? paletteSemanticBlue400,
+    Color? paletteSemanticBlue50,
+    Color? paletteSemanticBlue500,
+    Color? paletteSemanticBlue600,
+    Color? paletteSemanticBlue700,
+    Color? paletteSemanticBlue800,
+    Color? paletteSemanticBlue900,
+    Color? paletteSemanticGreen100,
+    Color? paletteSemanticGreen1000,
+    Color? paletteSemanticGreen150,
+    Color? paletteSemanticGreen200,
+    Color? paletteSemanticGreen25,
+    Color? paletteSemanticGreen300,
+    Color? paletteSemanticGreen400,
+    Color? paletteSemanticGreen50,
+    Color? paletteSemanticGreen500,
+    Color? paletteSemanticGreen600,
+    Color? paletteSemanticGreen700,
+    Color? paletteSemanticGreen800,
+    Color? paletteSemanticGreen900,
+    Color? paletteSemanticOrange100,
+    Color? paletteSemanticOrange1000,
+    Color? paletteSemanticOrange150,
+    Color? paletteSemanticOrange200,
+    Color? paletteSemanticOrange25,
+    Color? paletteSemanticOrange300,
+    Color? paletteSemanticOrange400,
+    Color? paletteSemanticOrange50,
+    Color? paletteSemanticOrange500,
+    Color? paletteSemanticOrange600,
+    Color? paletteSemanticOrange700,
+    Color? paletteSemanticOrange800,
+    Color? paletteSemanticOrange900,
+    Color? paletteSemanticRed100,
+    Color? paletteSemanticRed1000,
+    Color? paletteSemanticRed150,
+    Color? paletteSemanticRed200,
+    Color? paletteSemanticRed25,
+    Color? paletteSemanticRed300,
+    Color? paletteSemanticRed400,
+    Color? paletteSemanticRed50,
+    Color? paletteSemanticRed500,
+    Color? paletteSemanticRed600,
+    Color? paletteSemanticRed700,
+    Color? paletteSemanticRed800,
+    Color? paletteSemanticRed900,
+    Color? staticContainerColor,
+    Color? staticDividerColor,
+    Color? textAlertBasic,
+    Color? textAlertDanger,
+    Color? textAlertInfo,
+    Color? textAlertSuccess,
+    Color? textAlertWarning,
+    Color? textDisabled,
+    Color? textInteractiveActive,
+    Color? textInteractiveDefault,
+    Color? textInteractiveHover,
+    Color? textStaticError,
     Color? textStaticInverse,
+    Color? textStaticPrimary,
+    Color? textStaticSecondary,
+    Color? textStaticTertiary,
   }) {
     return OptimusTokens(
       backgroundAccentPrimary:
@@ -81,7 +1341,38 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
           backgroundAccentSecondary ?? this.backgroundAccentSecondary,
       backgroundAlertBasicPrimary:
           backgroundAlertBasicPrimary ?? this.backgroundAlertBasicPrimary,
+      backgroundAlertBasicSecondary:
+          backgroundAlertBasicSecondary ?? this.backgroundAlertBasicSecondary,
+      backgroundAlertDangerPrimary:
+          backgroundAlertDangerPrimary ?? this.backgroundAlertDangerPrimary,
+      backgroundAlertDangerSecondary:
+          backgroundAlertDangerSecondary ?? this.backgroundAlertDangerSecondary,
+      backgroundAlertInfoPrimary:
+          backgroundAlertInfoPrimary ?? this.backgroundAlertInfoPrimary,
+      backgroundAlertInfoSecondary:
+          backgroundAlertInfoSecondary ?? this.backgroundAlertInfoSecondary,
+      backgroundAlertSuccessPrimary:
+          backgroundAlertSuccessPrimary ?? this.backgroundAlertSuccessPrimary,
+      backgroundAlertSuccessSecondary: backgroundAlertSuccessSecondary ??
+          this.backgroundAlertSuccessSecondary,
+      backgroundAlertWarningPrimary:
+          backgroundAlertWarningPrimary ?? this.backgroundAlertWarningPrimary,
+      backgroundAlertWarningSecondary: backgroundAlertWarningSecondary ??
+          this.backgroundAlertWarningSecondary,
+      backgroundBrand: backgroundBrand ?? this.backgroundBrand,
       backgroundDisabled: backgroundDisabled ?? this.backgroundDisabled,
+      backgroundInteractiveBoldActive: backgroundInteractiveBoldActive ??
+          this.backgroundInteractiveBoldActive,
+      backgroundInteractiveBoldDefault: backgroundInteractiveBoldDefault ??
+          this.backgroundInteractiveBoldDefault,
+      backgroundInteractiveBoldHover:
+          backgroundInteractiveBoldHover ?? this.backgroundInteractiveBoldHover,
+      backgroundInteractiveDangerActive: backgroundInteractiveDangerActive ??
+          this.backgroundInteractiveDangerActive,
+      backgroundInteractiveDangerDefault: backgroundInteractiveDangerDefault ??
+          this.backgroundInteractiveDangerDefault,
+      backgroundInteractiveDangerHover: backgroundInteractiveDangerHover ??
+          this.backgroundInteractiveDangerHover,
       backgroundInteractivePrimaryActive: backgroundInteractivePrimaryActive ??
           this.backgroundInteractivePrimaryActive,
       backgroundInteractivePrimaryDefault:
@@ -89,7 +1380,385 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
               this.backgroundInteractivePrimaryDefault,
       backgroundInteractivePrimaryHover: backgroundInteractivePrimaryHover ??
           this.backgroundInteractivePrimaryHover,
+      backgroundInteractiveSecondaryActive:
+          backgroundInteractiveSecondaryActive ??
+              this.backgroundInteractiveSecondaryActive,
+      backgroundInteractiveSecondaryDefault:
+          backgroundInteractiveSecondaryDefault ??
+              this.backgroundInteractiveSecondaryDefault,
+      backgroundInteractiveSecondaryHover:
+          backgroundInteractiveSecondaryHover ??
+              this.backgroundInteractiveSecondaryHover,
+      backgroundInteractiveSubtleActive: backgroundInteractiveSubtleActive ??
+          this.backgroundInteractiveSubtleActive,
+      backgroundInteractiveSubtleDefault: backgroundInteractiveSubtleDefault ??
+          this.backgroundInteractiveSubtleDefault,
+      backgroundInteractiveSubtleHover: backgroundInteractiveSubtleHover ??
+          this.backgroundInteractiveSubtleHover,
+      backgroundOverlay: backgroundOverlay ?? this.backgroundOverlay,
+      backgroundStaticFlat: backgroundStaticFlat ?? this.backgroundStaticFlat,
+      backgroundStaticFloating:
+          backgroundStaticFloating ?? this.backgroundStaticFloating,
+      backgroundStaticInverse:
+          backgroundStaticInverse ?? this.backgroundStaticInverse,
+      backgroundStaticRaised:
+          backgroundStaticRaised ?? this.backgroundStaticRaised,
+      backgroundStaticSunken:
+          backgroundStaticSunken ?? this.backgroundStaticSunken,
+      borderAlertBasic: borderAlertBasic ?? this.borderAlertBasic,
+      borderAlertDanger: borderAlertDanger ?? this.borderAlertDanger,
+      borderAlertInfo: borderAlertInfo ?? this.borderAlertInfo,
+      borderAlertSuccess: borderAlertSuccess ?? this.borderAlertSuccess,
+      borderAlertWarning: borderAlertWarning ?? this.borderAlertWarning,
+      borderDisabled: borderDisabled ?? this.borderDisabled,
+      borderInteractiveError:
+          borderInteractiveError ?? this.borderInteractiveError,
+      borderInteractiveFocus:
+          borderInteractiveFocus ?? this.borderInteractiveFocus,
+      borderInteractivePrimaryActive:
+          borderInteractivePrimaryActive ?? this.borderInteractivePrimaryActive,
+      borderInteractivePrimaryDefault: borderInteractivePrimaryDefault ??
+          this.borderInteractivePrimaryDefault,
+      borderInteractivePrimaryHover:
+          borderInteractivePrimaryHover ?? this.borderInteractivePrimaryHover,
+      borderInteractiveSecondaryActive: borderInteractiveSecondaryActive ??
+          this.borderInteractiveSecondaryActive,
+      borderInteractiveSecondaryHover: borderInteractiveSecondaryHover ??
+          this.borderInteractiveSecondaryHover,
+      borderStaticInverse: borderStaticInverse ?? this.borderStaticInverse,
+      borderStaticPrimary: borderStaticPrimary ?? this.borderStaticPrimary,
+      borderStaticSecondary:
+          borderStaticSecondary ?? this.borderStaticSecondary,
+      inputActiveColor: inputActiveColor ?? this.inputActiveColor,
+      inputDangerColor: inputDangerColor ?? this.inputDangerColor,
+      inputDefaultColor: inputDefaultColor ?? this.inputDefaultColor,
+      inputDisabledColor: inputDisabledColor ?? this.inputDisabledColor,
+      inputHoverColor: inputHoverColor ?? this.inputHoverColor,
+      inputInverseColor: inputInverseColor ?? this.inputInverseColor,
+      interactiveDangerColor:
+          interactiveDangerColor ?? this.interactiveDangerColor,
+      interactiveDefaultColor:
+          interactiveDefaultColor ?? this.interactiveDefaultColor,
+      interactiveDisabledColor:
+          interactiveDisabledColor ?? this.interactiveDisabledColor,
+      interactiveHoverColor:
+          interactiveHoverColor ?? this.interactiveHoverColor,
+      interactiveInverseColor:
+          interactiveInverseColor ?? this.interactiveInverseColor,
+      paletteBasicsBlack: paletteBasicsBlack ?? this.paletteBasicsBlack,
+      paletteBasicsWhite: paletteBasicsWhite ?? this.paletteBasicsWhite,
+      paletteBasicsWhite64: paletteBasicsWhite64 ?? this.paletteBasicsWhite64,
+      paletteBrandCoral100: paletteBrandCoral100 ?? this.paletteBrandCoral100,
+      paletteBrandCoral1000:
+          paletteBrandCoral1000 ?? this.paletteBrandCoral1000,
+      paletteBrandCoral150: paletteBrandCoral150 ?? this.paletteBrandCoral150,
+      paletteBrandCoral200: paletteBrandCoral200 ?? this.paletteBrandCoral200,
+      paletteBrandCoral25: paletteBrandCoral25 ?? this.paletteBrandCoral25,
+      paletteBrandCoral300: paletteBrandCoral300 ?? this.paletteBrandCoral300,
+      paletteBrandCoral400: paletteBrandCoral400 ?? this.paletteBrandCoral400,
+      paletteBrandCoral50: paletteBrandCoral50 ?? this.paletteBrandCoral50,
+      paletteBrandCoral500: paletteBrandCoral500 ?? this.paletteBrandCoral500,
+      paletteBrandCoral600: paletteBrandCoral600 ?? this.paletteBrandCoral600,
+      paletteBrandCoral700: paletteBrandCoral700 ?? this.paletteBrandCoral700,
+      paletteBrandCoral800: paletteBrandCoral800 ?? this.paletteBrandCoral800,
+      paletteBrandCoral900: paletteBrandCoral900 ?? this.paletteBrandCoral900,
+      paletteBrandGrey0: paletteBrandGrey0 ?? this.paletteBrandGrey0,
+      paletteBrandGrey100: paletteBrandGrey100 ?? this.paletteBrandGrey100,
+      paletteBrandGrey1000: paletteBrandGrey1000 ?? this.paletteBrandGrey1000,
+      paletteBrandGrey150: paletteBrandGrey150 ?? this.paletteBrandGrey150,
+      paletteBrandGrey200: paletteBrandGrey200 ?? this.paletteBrandGrey200,
+      paletteBrandGrey25: paletteBrandGrey25 ?? this.paletteBrandGrey25,
+      paletteBrandGrey300: paletteBrandGrey300 ?? this.paletteBrandGrey300,
+      paletteBrandGrey400: paletteBrandGrey400 ?? this.paletteBrandGrey400,
+      paletteBrandGrey50: paletteBrandGrey50 ?? this.paletteBrandGrey50,
+      paletteBrandGrey500: paletteBrandGrey500 ?? this.paletteBrandGrey500,
+      paletteBrandGrey600: paletteBrandGrey600 ?? this.paletteBrandGrey600,
+      paletteBrandGrey700: paletteBrandGrey700 ?? this.paletteBrandGrey700,
+      paletteBrandGrey800: paletteBrandGrey800 ?? this.paletteBrandGrey800,
+      paletteBrandGrey900: paletteBrandGrey900 ?? this.paletteBrandGrey900,
+      paletteBrandIndigo100:
+          paletteBrandIndigo100 ?? this.paletteBrandIndigo100,
+      paletteBrandIndigo1000:
+          paletteBrandIndigo1000 ?? this.paletteBrandIndigo1000,
+      paletteBrandIndigo150:
+          paletteBrandIndigo150 ?? this.paletteBrandIndigo150,
+      paletteBrandIndigo200:
+          paletteBrandIndigo200 ?? this.paletteBrandIndigo200,
+      paletteBrandIndigo25: paletteBrandIndigo25 ?? this.paletteBrandIndigo25,
+      paletteBrandIndigo300:
+          paletteBrandIndigo300 ?? this.paletteBrandIndigo300,
+      paletteBrandIndigo400:
+          paletteBrandIndigo400 ?? this.paletteBrandIndigo400,
+      paletteBrandIndigo50: paletteBrandIndigo50 ?? this.paletteBrandIndigo50,
+      paletteBrandIndigo500:
+          paletteBrandIndigo500 ?? this.paletteBrandIndigo500,
+      paletteBrandIndigo600:
+          paletteBrandIndigo600 ?? this.paletteBrandIndigo600,
+      paletteBrandIndigo700:
+          paletteBrandIndigo700 ?? this.paletteBrandIndigo700,
+      paletteBrandIndigo800:
+          paletteBrandIndigo800 ?? this.paletteBrandIndigo800,
+      paletteBrandIndigo900:
+          paletteBrandIndigo900 ?? this.paletteBrandIndigo900,
+      paletteBrandNight0: paletteBrandNight0 ?? this.paletteBrandNight0,
+      paletteBrandNight100: paletteBrandNight100 ?? this.paletteBrandNight100,
+      paletteBrandNight1000:
+          paletteBrandNight1000 ?? this.paletteBrandNight1000,
+      paletteBrandNight100012:
+          paletteBrandNight100012 ?? this.paletteBrandNight100012,
+      paletteBrandNight100016:
+          paletteBrandNight100016 ?? this.paletteBrandNight100016,
+      paletteBrandNight10008:
+          paletteBrandNight10008 ?? this.paletteBrandNight10008,
+      paletteBrandNight150: paletteBrandNight150 ?? this.paletteBrandNight150,
+      paletteBrandNight200: paletteBrandNight200 ?? this.paletteBrandNight200,
+      paletteBrandNight25: paletteBrandNight25 ?? this.paletteBrandNight25,
+      paletteBrandNight300: paletteBrandNight300 ?? this.paletteBrandNight300,
+      paletteBrandNight400: paletteBrandNight400 ?? this.paletteBrandNight400,
+      paletteBrandNight50: paletteBrandNight50 ?? this.paletteBrandNight50,
+      paletteBrandNight500: paletteBrandNight500 ?? this.paletteBrandNight500,
+      paletteBrandNight600: paletteBrandNight600 ?? this.paletteBrandNight600,
+      paletteBrandNight700: paletteBrandNight700 ?? this.paletteBrandNight700,
+      paletteBrandNight800: paletteBrandNight800 ?? this.paletteBrandNight800,
+      paletteBrandNight900: paletteBrandNight900 ?? this.paletteBrandNight900,
+      paletteDatavizDenim100:
+          paletteDatavizDenim100 ?? this.paletteDatavizDenim100,
+      paletteDatavizDenim200:
+          paletteDatavizDenim200 ?? this.paletteDatavizDenim200,
+      paletteDatavizDenim300:
+          paletteDatavizDenim300 ?? this.paletteDatavizDenim300,
+      paletteDatavizDenim400:
+          paletteDatavizDenim400 ?? this.paletteDatavizDenim400,
+      paletteDatavizDenim50:
+          paletteDatavizDenim50 ?? this.paletteDatavizDenim50,
+      paletteDatavizDenim500:
+          paletteDatavizDenim500 ?? this.paletteDatavizDenim500,
+      paletteDatavizDenim600:
+          paletteDatavizDenim600 ?? this.paletteDatavizDenim600,
+      paletteDatavizDenim700:
+          paletteDatavizDenim700 ?? this.paletteDatavizDenim700,
+      paletteDatavizDenim800:
+          paletteDatavizDenim800 ?? this.paletteDatavizDenim800,
+      paletteDatavizDenim900:
+          paletteDatavizDenim900 ?? this.paletteDatavizDenim900,
+      paletteDatavizLavender100:
+          paletteDatavizLavender100 ?? this.paletteDatavizLavender100,
+      paletteDatavizLavender200:
+          paletteDatavizLavender200 ?? this.paletteDatavizLavender200,
+      paletteDatavizLavender300:
+          paletteDatavizLavender300 ?? this.paletteDatavizLavender300,
+      paletteDatavizLavender400:
+          paletteDatavizLavender400 ?? this.paletteDatavizLavender400,
+      paletteDatavizLavender50:
+          paletteDatavizLavender50 ?? this.paletteDatavizLavender50,
+      paletteDatavizLavender500:
+          paletteDatavizLavender500 ?? this.paletteDatavizLavender500,
+      paletteDatavizLavender600:
+          paletteDatavizLavender600 ?? this.paletteDatavizLavender600,
+      paletteDatavizLavender700:
+          paletteDatavizLavender700 ?? this.paletteDatavizLavender700,
+      paletteDatavizLavender800:
+          paletteDatavizLavender800 ?? this.paletteDatavizLavender800,
+      paletteDatavizLavender900:
+          paletteDatavizLavender900 ?? this.paletteDatavizLavender900,
+      paletteDatavizLime100:
+          paletteDatavizLime100 ?? this.paletteDatavizLime100,
+      paletteDatavizLime200:
+          paletteDatavizLime200 ?? this.paletteDatavizLime200,
+      paletteDatavizLime300:
+          paletteDatavizLime300 ?? this.paletteDatavizLime300,
+      paletteDatavizLime400:
+          paletteDatavizLime400 ?? this.paletteDatavizLime400,
+      paletteDatavizLime50: paletteDatavizLime50 ?? this.paletteDatavizLime50,
+      paletteDatavizLime500:
+          paletteDatavizLime500 ?? this.paletteDatavizLime500,
+      paletteDatavizLime600:
+          paletteDatavizLime600 ?? this.paletteDatavizLime600,
+      paletteDatavizLime700:
+          paletteDatavizLime700 ?? this.paletteDatavizLime700,
+      paletteDatavizLime800:
+          paletteDatavizLime800 ?? this.paletteDatavizLime800,
+      paletteDatavizLime900:
+          paletteDatavizLime900 ?? this.paletteDatavizLime900,
+      paletteDatavizMustard100:
+          paletteDatavizMustard100 ?? this.paletteDatavizMustard100,
+      paletteDatavizMustard200:
+          paletteDatavizMustard200 ?? this.paletteDatavizMustard200,
+      paletteDatavizMustard300:
+          paletteDatavizMustard300 ?? this.paletteDatavizMustard300,
+      paletteDatavizMustard400:
+          paletteDatavizMustard400 ?? this.paletteDatavizMustard400,
+      paletteDatavizMustard50:
+          paletteDatavizMustard50 ?? this.paletteDatavizMustard50,
+      paletteDatavizMustard500:
+          paletteDatavizMustard500 ?? this.paletteDatavizMustard500,
+      paletteDatavizMustard600:
+          paletteDatavizMustard600 ?? this.paletteDatavizMustard600,
+      paletteDatavizMustard700:
+          paletteDatavizMustard700 ?? this.paletteDatavizMustard700,
+      paletteDatavizMustard800:
+          paletteDatavizMustard800 ?? this.paletteDatavizMustard800,
+      paletteDatavizMustard900:
+          paletteDatavizMustard900 ?? this.paletteDatavizMustard900,
+      paletteDatavizRuby100:
+          paletteDatavizRuby100 ?? this.paletteDatavizRuby100,
+      paletteDatavizRuby200:
+          paletteDatavizRuby200 ?? this.paletteDatavizRuby200,
+      paletteDatavizRuby300:
+          paletteDatavizRuby300 ?? this.paletteDatavizRuby300,
+      paletteDatavizRuby400:
+          paletteDatavizRuby400 ?? this.paletteDatavizRuby400,
+      paletteDatavizRuby50: paletteDatavizRuby50 ?? this.paletteDatavizRuby50,
+      paletteDatavizRuby500:
+          paletteDatavizRuby500 ?? this.paletteDatavizRuby500,
+      paletteDatavizRuby600:
+          paletteDatavizRuby600 ?? this.paletteDatavizRuby600,
+      paletteDatavizRuby700:
+          paletteDatavizRuby700 ?? this.paletteDatavizRuby700,
+      paletteDatavizRuby800:
+          paletteDatavizRuby800 ?? this.paletteDatavizRuby800,
+      paletteDatavizRuby900:
+          paletteDatavizRuby900 ?? this.paletteDatavizRuby900,
+      paletteDatavizTangerine100:
+          paletteDatavizTangerine100 ?? this.paletteDatavizTangerine100,
+      paletteDatavizTangerine200:
+          paletteDatavizTangerine200 ?? this.paletteDatavizTangerine200,
+      paletteDatavizTangerine300:
+          paletteDatavizTangerine300 ?? this.paletteDatavizTangerine300,
+      paletteDatavizTangerine400:
+          paletteDatavizTangerine400 ?? this.paletteDatavizTangerine400,
+      paletteDatavizTangerine50:
+          paletteDatavizTangerine50 ?? this.paletteDatavizTangerine50,
+      paletteDatavizTangerine500:
+          paletteDatavizTangerine500 ?? this.paletteDatavizTangerine500,
+      paletteDatavizTangerine600:
+          paletteDatavizTangerine600 ?? this.paletteDatavizTangerine600,
+      paletteDatavizTangerine700:
+          paletteDatavizTangerine700 ?? this.paletteDatavizTangerine700,
+      paletteDatavizTangerine800:
+          paletteDatavizTangerine800 ?? this.paletteDatavizTangerine800,
+      paletteDatavizTangerine900:
+          paletteDatavizTangerine900 ?? this.paletteDatavizTangerine900,
+      paletteSemanticBlue100:
+          paletteSemanticBlue100 ?? this.paletteSemanticBlue100,
+      paletteSemanticBlue1000:
+          paletteSemanticBlue1000 ?? this.paletteSemanticBlue1000,
+      paletteSemanticBlue150:
+          paletteSemanticBlue150 ?? this.paletteSemanticBlue150,
+      paletteSemanticBlue200:
+          paletteSemanticBlue200 ?? this.paletteSemanticBlue200,
+      paletteSemanticBlue25:
+          paletteSemanticBlue25 ?? this.paletteSemanticBlue25,
+      paletteSemanticBlue300:
+          paletteSemanticBlue300 ?? this.paletteSemanticBlue300,
+      paletteSemanticBlue400:
+          paletteSemanticBlue400 ?? this.paletteSemanticBlue400,
+      paletteSemanticBlue50:
+          paletteSemanticBlue50 ?? this.paletteSemanticBlue50,
+      paletteSemanticBlue500:
+          paletteSemanticBlue500 ?? this.paletteSemanticBlue500,
+      paletteSemanticBlue600:
+          paletteSemanticBlue600 ?? this.paletteSemanticBlue600,
+      paletteSemanticBlue700:
+          paletteSemanticBlue700 ?? this.paletteSemanticBlue700,
+      paletteSemanticBlue800:
+          paletteSemanticBlue800 ?? this.paletteSemanticBlue800,
+      paletteSemanticBlue900:
+          paletteSemanticBlue900 ?? this.paletteSemanticBlue900,
+      paletteSemanticGreen100:
+          paletteSemanticGreen100 ?? this.paletteSemanticGreen100,
+      paletteSemanticGreen1000:
+          paletteSemanticGreen1000 ?? this.paletteSemanticGreen1000,
+      paletteSemanticGreen150:
+          paletteSemanticGreen150 ?? this.paletteSemanticGreen150,
+      paletteSemanticGreen200:
+          paletteSemanticGreen200 ?? this.paletteSemanticGreen200,
+      paletteSemanticGreen25:
+          paletteSemanticGreen25 ?? this.paletteSemanticGreen25,
+      paletteSemanticGreen300:
+          paletteSemanticGreen300 ?? this.paletteSemanticGreen300,
+      paletteSemanticGreen400:
+          paletteSemanticGreen400 ?? this.paletteSemanticGreen400,
+      paletteSemanticGreen50:
+          paletteSemanticGreen50 ?? this.paletteSemanticGreen50,
+      paletteSemanticGreen500:
+          paletteSemanticGreen500 ?? this.paletteSemanticGreen500,
+      paletteSemanticGreen600:
+          paletteSemanticGreen600 ?? this.paletteSemanticGreen600,
+      paletteSemanticGreen700:
+          paletteSemanticGreen700 ?? this.paletteSemanticGreen700,
+      paletteSemanticGreen800:
+          paletteSemanticGreen800 ?? this.paletteSemanticGreen800,
+      paletteSemanticGreen900:
+          paletteSemanticGreen900 ?? this.paletteSemanticGreen900,
+      paletteSemanticOrange100:
+          paletteSemanticOrange100 ?? this.paletteSemanticOrange100,
+      paletteSemanticOrange1000:
+          paletteSemanticOrange1000 ?? this.paletteSemanticOrange1000,
+      paletteSemanticOrange150:
+          paletteSemanticOrange150 ?? this.paletteSemanticOrange150,
+      paletteSemanticOrange200:
+          paletteSemanticOrange200 ?? this.paletteSemanticOrange200,
+      paletteSemanticOrange25:
+          paletteSemanticOrange25 ?? this.paletteSemanticOrange25,
+      paletteSemanticOrange300:
+          paletteSemanticOrange300 ?? this.paletteSemanticOrange300,
+      paletteSemanticOrange400:
+          paletteSemanticOrange400 ?? this.paletteSemanticOrange400,
+      paletteSemanticOrange50:
+          paletteSemanticOrange50 ?? this.paletteSemanticOrange50,
+      paletteSemanticOrange500:
+          paletteSemanticOrange500 ?? this.paletteSemanticOrange500,
+      paletteSemanticOrange600:
+          paletteSemanticOrange600 ?? this.paletteSemanticOrange600,
+      paletteSemanticOrange700:
+          paletteSemanticOrange700 ?? this.paletteSemanticOrange700,
+      paletteSemanticOrange800:
+          paletteSemanticOrange800 ?? this.paletteSemanticOrange800,
+      paletteSemanticOrange900:
+          paletteSemanticOrange900 ?? this.paletteSemanticOrange900,
+      paletteSemanticRed100:
+          paletteSemanticRed100 ?? this.paletteSemanticRed100,
+      paletteSemanticRed1000:
+          paletteSemanticRed1000 ?? this.paletteSemanticRed1000,
+      paletteSemanticRed150:
+          paletteSemanticRed150 ?? this.paletteSemanticRed150,
+      paletteSemanticRed200:
+          paletteSemanticRed200 ?? this.paletteSemanticRed200,
+      paletteSemanticRed25: paletteSemanticRed25 ?? this.paletteSemanticRed25,
+      paletteSemanticRed300:
+          paletteSemanticRed300 ?? this.paletteSemanticRed300,
+      paletteSemanticRed400:
+          paletteSemanticRed400 ?? this.paletteSemanticRed400,
+      paletteSemanticRed50: paletteSemanticRed50 ?? this.paletteSemanticRed50,
+      paletteSemanticRed500:
+          paletteSemanticRed500 ?? this.paletteSemanticRed500,
+      paletteSemanticRed600:
+          paletteSemanticRed600 ?? this.paletteSemanticRed600,
+      paletteSemanticRed700:
+          paletteSemanticRed700 ?? this.paletteSemanticRed700,
+      paletteSemanticRed800:
+          paletteSemanticRed800 ?? this.paletteSemanticRed800,
+      paletteSemanticRed900:
+          paletteSemanticRed900 ?? this.paletteSemanticRed900,
+      staticContainerColor: staticContainerColor ?? this.staticContainerColor,
+      staticDividerColor: staticDividerColor ?? this.staticDividerColor,
+      textAlertBasic: textAlertBasic ?? this.textAlertBasic,
+      textAlertDanger: textAlertDanger ?? this.textAlertDanger,
+      textAlertInfo: textAlertInfo ?? this.textAlertInfo,
+      textAlertSuccess: textAlertSuccess ?? this.textAlertSuccess,
+      textAlertWarning: textAlertWarning ?? this.textAlertWarning,
+      textDisabled: textDisabled ?? this.textDisabled,
+      textInteractiveActive:
+          textInteractiveActive ?? this.textInteractiveActive,
+      textInteractiveDefault:
+          textInteractiveDefault ?? this.textInteractiveDefault,
+      textInteractiveHover: textInteractiveHover ?? this.textInteractiveHover,
+      textStaticError: textStaticError ?? this.textStaticError,
       textStaticInverse: textStaticInverse ?? this.textStaticInverse,
+      textStaticPrimary: textStaticPrimary ?? this.textStaticPrimary,
+      textStaticSecondary: textStaticSecondary ?? this.textStaticSecondary,
+      textStaticTertiary: textStaticTertiary ?? this.textStaticTertiary,
     );
   }
 
@@ -103,8 +1772,53 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
           backgroundAccentSecondary, other.backgroundAccentSecondary, t)!,
       backgroundAlertBasicPrimary: Color.lerp(
           backgroundAlertBasicPrimary, other.backgroundAlertBasicPrimary, t)!,
+      backgroundAlertBasicSecondary: Color.lerp(backgroundAlertBasicSecondary,
+          other.backgroundAlertBasicSecondary, t)!,
+      backgroundAlertDangerPrimary: Color.lerp(
+          backgroundAlertDangerPrimary, other.backgroundAlertDangerPrimary, t)!,
+      backgroundAlertDangerSecondary: Color.lerp(backgroundAlertDangerSecondary,
+          other.backgroundAlertDangerSecondary, t)!,
+      backgroundAlertInfoPrimary: Color.lerp(
+          backgroundAlertInfoPrimary, other.backgroundAlertInfoPrimary, t)!,
+      backgroundAlertInfoSecondary: Color.lerp(
+          backgroundAlertInfoSecondary, other.backgroundAlertInfoSecondary, t)!,
+      backgroundAlertSuccessPrimary: Color.lerp(backgroundAlertSuccessPrimary,
+          other.backgroundAlertSuccessPrimary, t)!,
+      backgroundAlertSuccessSecondary: Color.lerp(
+          backgroundAlertSuccessSecondary,
+          other.backgroundAlertSuccessSecondary,
+          t)!,
+      backgroundAlertWarningPrimary: Color.lerp(backgroundAlertWarningPrimary,
+          other.backgroundAlertWarningPrimary, t)!,
+      backgroundAlertWarningSecondary: Color.lerp(
+          backgroundAlertWarningSecondary,
+          other.backgroundAlertWarningSecondary,
+          t)!,
+      backgroundBrand: Color.lerp(backgroundBrand, other.backgroundBrand, t)!,
       backgroundDisabled:
           Color.lerp(backgroundDisabled, other.backgroundDisabled, t)!,
+      backgroundInteractiveBoldActive: Color.lerp(
+          backgroundInteractiveBoldActive,
+          other.backgroundInteractiveBoldActive,
+          t)!,
+      backgroundInteractiveBoldDefault: Color.lerp(
+          backgroundInteractiveBoldDefault,
+          other.backgroundInteractiveBoldDefault,
+          t)!,
+      backgroundInteractiveBoldHover: Color.lerp(backgroundInteractiveBoldHover,
+          other.backgroundInteractiveBoldHover, t)!,
+      backgroundInteractiveDangerActive: Color.lerp(
+          backgroundInteractiveDangerActive,
+          other.backgroundInteractiveDangerActive,
+          t)!,
+      backgroundInteractiveDangerDefault: Color.lerp(
+          backgroundInteractiveDangerDefault,
+          other.backgroundInteractiveDangerDefault,
+          t)!,
+      backgroundInteractiveDangerHover: Color.lerp(
+          backgroundInteractiveDangerHover,
+          other.backgroundInteractiveDangerHover,
+          t)!,
       backgroundInteractivePrimaryActive: Color.lerp(
           backgroundInteractivePrimaryActive,
           other.backgroundInteractivePrimaryActive,
@@ -117,8 +1831,470 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
           backgroundInteractivePrimaryHover,
           other.backgroundInteractivePrimaryHover,
           t)!,
+      backgroundInteractiveSecondaryActive: Color.lerp(
+          backgroundInteractiveSecondaryActive,
+          other.backgroundInteractiveSecondaryActive,
+          t)!,
+      backgroundInteractiveSecondaryDefault: Color.lerp(
+          backgroundInteractiveSecondaryDefault,
+          other.backgroundInteractiveSecondaryDefault,
+          t)!,
+      backgroundInteractiveSecondaryHover: Color.lerp(
+          backgroundInteractiveSecondaryHover,
+          other.backgroundInteractiveSecondaryHover,
+          t)!,
+      backgroundInteractiveSubtleActive: Color.lerp(
+          backgroundInteractiveSubtleActive,
+          other.backgroundInteractiveSubtleActive,
+          t)!,
+      backgroundInteractiveSubtleDefault: Color.lerp(
+          backgroundInteractiveSubtleDefault,
+          other.backgroundInteractiveSubtleDefault,
+          t)!,
+      backgroundInteractiveSubtleHover: Color.lerp(
+          backgroundInteractiveSubtleHover,
+          other.backgroundInteractiveSubtleHover,
+          t)!,
+      backgroundOverlay:
+          Color.lerp(backgroundOverlay, other.backgroundOverlay, t)!,
+      backgroundStaticFlat:
+          Color.lerp(backgroundStaticFlat, other.backgroundStaticFlat, t)!,
+      backgroundStaticFloating: Color.lerp(
+          backgroundStaticFloating, other.backgroundStaticFloating, t)!,
+      backgroundStaticInverse: Color.lerp(
+          backgroundStaticInverse, other.backgroundStaticInverse, t)!,
+      backgroundStaticRaised:
+          Color.lerp(backgroundStaticRaised, other.backgroundStaticRaised, t)!,
+      backgroundStaticSunken:
+          Color.lerp(backgroundStaticSunken, other.backgroundStaticSunken, t)!,
+      borderAlertBasic:
+          Color.lerp(borderAlertBasic, other.borderAlertBasic, t)!,
+      borderAlertDanger:
+          Color.lerp(borderAlertDanger, other.borderAlertDanger, t)!,
+      borderAlertInfo: Color.lerp(borderAlertInfo, other.borderAlertInfo, t)!,
+      borderAlertSuccess:
+          Color.lerp(borderAlertSuccess, other.borderAlertSuccess, t)!,
+      borderAlertWarning:
+          Color.lerp(borderAlertWarning, other.borderAlertWarning, t)!,
+      borderDisabled: Color.lerp(borderDisabled, other.borderDisabled, t)!,
+      borderInteractiveError:
+          Color.lerp(borderInteractiveError, other.borderInteractiveError, t)!,
+      borderInteractiveFocus:
+          Color.lerp(borderInteractiveFocus, other.borderInteractiveFocus, t)!,
+      borderInteractivePrimaryActive: Color.lerp(borderInteractivePrimaryActive,
+          other.borderInteractivePrimaryActive, t)!,
+      borderInteractivePrimaryDefault: Color.lerp(
+          borderInteractivePrimaryDefault,
+          other.borderInteractivePrimaryDefault,
+          t)!,
+      borderInteractivePrimaryHover: Color.lerp(borderInteractivePrimaryHover,
+          other.borderInteractivePrimaryHover, t)!,
+      borderInteractiveSecondaryActive: Color.lerp(
+          borderInteractiveSecondaryActive,
+          other.borderInteractiveSecondaryActive,
+          t)!,
+      borderInteractiveSecondaryHover: Color.lerp(
+          borderInteractiveSecondaryHover,
+          other.borderInteractiveSecondaryHover,
+          t)!,
+      borderStaticInverse:
+          Color.lerp(borderStaticInverse, other.borderStaticInverse, t)!,
+      borderStaticPrimary:
+          Color.lerp(borderStaticPrimary, other.borderStaticPrimary, t)!,
+      borderStaticSecondary:
+          Color.lerp(borderStaticSecondary, other.borderStaticSecondary, t)!,
+      inputActiveColor:
+          Color.lerp(inputActiveColor, other.inputActiveColor, t)!,
+      inputDangerColor:
+          Color.lerp(inputDangerColor, other.inputDangerColor, t)!,
+      inputDefaultColor:
+          Color.lerp(inputDefaultColor, other.inputDefaultColor, t)!,
+      inputDisabledColor:
+          Color.lerp(inputDisabledColor, other.inputDisabledColor, t)!,
+      inputHoverColor: Color.lerp(inputHoverColor, other.inputHoverColor, t)!,
+      inputInverseColor:
+          Color.lerp(inputInverseColor, other.inputInverseColor, t)!,
+      interactiveDangerColor:
+          Color.lerp(interactiveDangerColor, other.interactiveDangerColor, t)!,
+      interactiveDefaultColor: Color.lerp(
+          interactiveDefaultColor, other.interactiveDefaultColor, t)!,
+      interactiveDisabledColor: Color.lerp(
+          interactiveDisabledColor, other.interactiveDisabledColor, t)!,
+      interactiveHoverColor:
+          Color.lerp(interactiveHoverColor, other.interactiveHoverColor, t)!,
+      interactiveInverseColor: Color.lerp(
+          interactiveInverseColor, other.interactiveInverseColor, t)!,
+      paletteBasicsBlack:
+          Color.lerp(paletteBasicsBlack, other.paletteBasicsBlack, t)!,
+      paletteBasicsWhite:
+          Color.lerp(paletteBasicsWhite, other.paletteBasicsWhite, t)!,
+      paletteBasicsWhite64:
+          Color.lerp(paletteBasicsWhite64, other.paletteBasicsWhite64, t)!,
+      paletteBrandCoral100:
+          Color.lerp(paletteBrandCoral100, other.paletteBrandCoral100, t)!,
+      paletteBrandCoral1000:
+          Color.lerp(paletteBrandCoral1000, other.paletteBrandCoral1000, t)!,
+      paletteBrandCoral150:
+          Color.lerp(paletteBrandCoral150, other.paletteBrandCoral150, t)!,
+      paletteBrandCoral200:
+          Color.lerp(paletteBrandCoral200, other.paletteBrandCoral200, t)!,
+      paletteBrandCoral25:
+          Color.lerp(paletteBrandCoral25, other.paletteBrandCoral25, t)!,
+      paletteBrandCoral300:
+          Color.lerp(paletteBrandCoral300, other.paletteBrandCoral300, t)!,
+      paletteBrandCoral400:
+          Color.lerp(paletteBrandCoral400, other.paletteBrandCoral400, t)!,
+      paletteBrandCoral50:
+          Color.lerp(paletteBrandCoral50, other.paletteBrandCoral50, t)!,
+      paletteBrandCoral500:
+          Color.lerp(paletteBrandCoral500, other.paletteBrandCoral500, t)!,
+      paletteBrandCoral600:
+          Color.lerp(paletteBrandCoral600, other.paletteBrandCoral600, t)!,
+      paletteBrandCoral700:
+          Color.lerp(paletteBrandCoral700, other.paletteBrandCoral700, t)!,
+      paletteBrandCoral800:
+          Color.lerp(paletteBrandCoral800, other.paletteBrandCoral800, t)!,
+      paletteBrandCoral900:
+          Color.lerp(paletteBrandCoral900, other.paletteBrandCoral900, t)!,
+      paletteBrandGrey0:
+          Color.lerp(paletteBrandGrey0, other.paletteBrandGrey0, t)!,
+      paletteBrandGrey100:
+          Color.lerp(paletteBrandGrey100, other.paletteBrandGrey100, t)!,
+      paletteBrandGrey1000:
+          Color.lerp(paletteBrandGrey1000, other.paletteBrandGrey1000, t)!,
+      paletteBrandGrey150:
+          Color.lerp(paletteBrandGrey150, other.paletteBrandGrey150, t)!,
+      paletteBrandGrey200:
+          Color.lerp(paletteBrandGrey200, other.paletteBrandGrey200, t)!,
+      paletteBrandGrey25:
+          Color.lerp(paletteBrandGrey25, other.paletteBrandGrey25, t)!,
+      paletteBrandGrey300:
+          Color.lerp(paletteBrandGrey300, other.paletteBrandGrey300, t)!,
+      paletteBrandGrey400:
+          Color.lerp(paletteBrandGrey400, other.paletteBrandGrey400, t)!,
+      paletteBrandGrey50:
+          Color.lerp(paletteBrandGrey50, other.paletteBrandGrey50, t)!,
+      paletteBrandGrey500:
+          Color.lerp(paletteBrandGrey500, other.paletteBrandGrey500, t)!,
+      paletteBrandGrey600:
+          Color.lerp(paletteBrandGrey600, other.paletteBrandGrey600, t)!,
+      paletteBrandGrey700:
+          Color.lerp(paletteBrandGrey700, other.paletteBrandGrey700, t)!,
+      paletteBrandGrey800:
+          Color.lerp(paletteBrandGrey800, other.paletteBrandGrey800, t)!,
+      paletteBrandGrey900:
+          Color.lerp(paletteBrandGrey900, other.paletteBrandGrey900, t)!,
+      paletteBrandIndigo100:
+          Color.lerp(paletteBrandIndigo100, other.paletteBrandIndigo100, t)!,
+      paletteBrandIndigo1000:
+          Color.lerp(paletteBrandIndigo1000, other.paletteBrandIndigo1000, t)!,
+      paletteBrandIndigo150:
+          Color.lerp(paletteBrandIndigo150, other.paletteBrandIndigo150, t)!,
+      paletteBrandIndigo200:
+          Color.lerp(paletteBrandIndigo200, other.paletteBrandIndigo200, t)!,
+      paletteBrandIndigo25:
+          Color.lerp(paletteBrandIndigo25, other.paletteBrandIndigo25, t)!,
+      paletteBrandIndigo300:
+          Color.lerp(paletteBrandIndigo300, other.paletteBrandIndigo300, t)!,
+      paletteBrandIndigo400:
+          Color.lerp(paletteBrandIndigo400, other.paletteBrandIndigo400, t)!,
+      paletteBrandIndigo50:
+          Color.lerp(paletteBrandIndigo50, other.paletteBrandIndigo50, t)!,
+      paletteBrandIndigo500:
+          Color.lerp(paletteBrandIndigo500, other.paletteBrandIndigo500, t)!,
+      paletteBrandIndigo600:
+          Color.lerp(paletteBrandIndigo600, other.paletteBrandIndigo600, t)!,
+      paletteBrandIndigo700:
+          Color.lerp(paletteBrandIndigo700, other.paletteBrandIndigo700, t)!,
+      paletteBrandIndigo800:
+          Color.lerp(paletteBrandIndigo800, other.paletteBrandIndigo800, t)!,
+      paletteBrandIndigo900:
+          Color.lerp(paletteBrandIndigo900, other.paletteBrandIndigo900, t)!,
+      paletteBrandNight0:
+          Color.lerp(paletteBrandNight0, other.paletteBrandNight0, t)!,
+      paletteBrandNight100:
+          Color.lerp(paletteBrandNight100, other.paletteBrandNight100, t)!,
+      paletteBrandNight1000:
+          Color.lerp(paletteBrandNight1000, other.paletteBrandNight1000, t)!,
+      paletteBrandNight100012: Color.lerp(
+          paletteBrandNight100012, other.paletteBrandNight100012, t)!,
+      paletteBrandNight100016: Color.lerp(
+          paletteBrandNight100016, other.paletteBrandNight100016, t)!,
+      paletteBrandNight10008:
+          Color.lerp(paletteBrandNight10008, other.paletteBrandNight10008, t)!,
+      paletteBrandNight150:
+          Color.lerp(paletteBrandNight150, other.paletteBrandNight150, t)!,
+      paletteBrandNight200:
+          Color.lerp(paletteBrandNight200, other.paletteBrandNight200, t)!,
+      paletteBrandNight25:
+          Color.lerp(paletteBrandNight25, other.paletteBrandNight25, t)!,
+      paletteBrandNight300:
+          Color.lerp(paletteBrandNight300, other.paletteBrandNight300, t)!,
+      paletteBrandNight400:
+          Color.lerp(paletteBrandNight400, other.paletteBrandNight400, t)!,
+      paletteBrandNight50:
+          Color.lerp(paletteBrandNight50, other.paletteBrandNight50, t)!,
+      paletteBrandNight500:
+          Color.lerp(paletteBrandNight500, other.paletteBrandNight500, t)!,
+      paletteBrandNight600:
+          Color.lerp(paletteBrandNight600, other.paletteBrandNight600, t)!,
+      paletteBrandNight700:
+          Color.lerp(paletteBrandNight700, other.paletteBrandNight700, t)!,
+      paletteBrandNight800:
+          Color.lerp(paletteBrandNight800, other.paletteBrandNight800, t)!,
+      paletteBrandNight900:
+          Color.lerp(paletteBrandNight900, other.paletteBrandNight900, t)!,
+      paletteDatavizDenim100:
+          Color.lerp(paletteDatavizDenim100, other.paletteDatavizDenim100, t)!,
+      paletteDatavizDenim200:
+          Color.lerp(paletteDatavizDenim200, other.paletteDatavizDenim200, t)!,
+      paletteDatavizDenim300:
+          Color.lerp(paletteDatavizDenim300, other.paletteDatavizDenim300, t)!,
+      paletteDatavizDenim400:
+          Color.lerp(paletteDatavizDenim400, other.paletteDatavizDenim400, t)!,
+      paletteDatavizDenim50:
+          Color.lerp(paletteDatavizDenim50, other.paletteDatavizDenim50, t)!,
+      paletteDatavizDenim500:
+          Color.lerp(paletteDatavizDenim500, other.paletteDatavizDenim500, t)!,
+      paletteDatavizDenim600:
+          Color.lerp(paletteDatavizDenim600, other.paletteDatavizDenim600, t)!,
+      paletteDatavizDenim700:
+          Color.lerp(paletteDatavizDenim700, other.paletteDatavizDenim700, t)!,
+      paletteDatavizDenim800:
+          Color.lerp(paletteDatavizDenim800, other.paletteDatavizDenim800, t)!,
+      paletteDatavizDenim900:
+          Color.lerp(paletteDatavizDenim900, other.paletteDatavizDenim900, t)!,
+      paletteDatavizLavender100: Color.lerp(
+          paletteDatavizLavender100, other.paletteDatavizLavender100, t)!,
+      paletteDatavizLavender200: Color.lerp(
+          paletteDatavizLavender200, other.paletteDatavizLavender200, t)!,
+      paletteDatavizLavender300: Color.lerp(
+          paletteDatavizLavender300, other.paletteDatavizLavender300, t)!,
+      paletteDatavizLavender400: Color.lerp(
+          paletteDatavizLavender400, other.paletteDatavizLavender400, t)!,
+      paletteDatavizLavender50: Color.lerp(
+          paletteDatavizLavender50, other.paletteDatavizLavender50, t)!,
+      paletteDatavizLavender500: Color.lerp(
+          paletteDatavizLavender500, other.paletteDatavizLavender500, t)!,
+      paletteDatavizLavender600: Color.lerp(
+          paletteDatavizLavender600, other.paletteDatavizLavender600, t)!,
+      paletteDatavizLavender700: Color.lerp(
+          paletteDatavizLavender700, other.paletteDatavizLavender700, t)!,
+      paletteDatavizLavender800: Color.lerp(
+          paletteDatavizLavender800, other.paletteDatavizLavender800, t)!,
+      paletteDatavizLavender900: Color.lerp(
+          paletteDatavizLavender900, other.paletteDatavizLavender900, t)!,
+      paletteDatavizLime100:
+          Color.lerp(paletteDatavizLime100, other.paletteDatavizLime100, t)!,
+      paletteDatavizLime200:
+          Color.lerp(paletteDatavizLime200, other.paletteDatavizLime200, t)!,
+      paletteDatavizLime300:
+          Color.lerp(paletteDatavizLime300, other.paletteDatavizLime300, t)!,
+      paletteDatavizLime400:
+          Color.lerp(paletteDatavizLime400, other.paletteDatavizLime400, t)!,
+      paletteDatavizLime50:
+          Color.lerp(paletteDatavizLime50, other.paletteDatavizLime50, t)!,
+      paletteDatavizLime500:
+          Color.lerp(paletteDatavizLime500, other.paletteDatavizLime500, t)!,
+      paletteDatavizLime600:
+          Color.lerp(paletteDatavizLime600, other.paletteDatavizLime600, t)!,
+      paletteDatavizLime700:
+          Color.lerp(paletteDatavizLime700, other.paletteDatavizLime700, t)!,
+      paletteDatavizLime800:
+          Color.lerp(paletteDatavizLime800, other.paletteDatavizLime800, t)!,
+      paletteDatavizLime900:
+          Color.lerp(paletteDatavizLime900, other.paletteDatavizLime900, t)!,
+      paletteDatavizMustard100: Color.lerp(
+          paletteDatavizMustard100, other.paletteDatavizMustard100, t)!,
+      paletteDatavizMustard200: Color.lerp(
+          paletteDatavizMustard200, other.paletteDatavizMustard200, t)!,
+      paletteDatavizMustard300: Color.lerp(
+          paletteDatavizMustard300, other.paletteDatavizMustard300, t)!,
+      paletteDatavizMustard400: Color.lerp(
+          paletteDatavizMustard400, other.paletteDatavizMustard400, t)!,
+      paletteDatavizMustard50: Color.lerp(
+          paletteDatavizMustard50, other.paletteDatavizMustard50, t)!,
+      paletteDatavizMustard500: Color.lerp(
+          paletteDatavizMustard500, other.paletteDatavizMustard500, t)!,
+      paletteDatavizMustard600: Color.lerp(
+          paletteDatavizMustard600, other.paletteDatavizMustard600, t)!,
+      paletteDatavizMustard700: Color.lerp(
+          paletteDatavizMustard700, other.paletteDatavizMustard700, t)!,
+      paletteDatavizMustard800: Color.lerp(
+          paletteDatavizMustard800, other.paletteDatavizMustard800, t)!,
+      paletteDatavizMustard900: Color.lerp(
+          paletteDatavizMustard900, other.paletteDatavizMustard900, t)!,
+      paletteDatavizRuby100:
+          Color.lerp(paletteDatavizRuby100, other.paletteDatavizRuby100, t)!,
+      paletteDatavizRuby200:
+          Color.lerp(paletteDatavizRuby200, other.paletteDatavizRuby200, t)!,
+      paletteDatavizRuby300:
+          Color.lerp(paletteDatavizRuby300, other.paletteDatavizRuby300, t)!,
+      paletteDatavizRuby400:
+          Color.lerp(paletteDatavizRuby400, other.paletteDatavizRuby400, t)!,
+      paletteDatavizRuby50:
+          Color.lerp(paletteDatavizRuby50, other.paletteDatavizRuby50, t)!,
+      paletteDatavizRuby500:
+          Color.lerp(paletteDatavizRuby500, other.paletteDatavizRuby500, t)!,
+      paletteDatavizRuby600:
+          Color.lerp(paletteDatavizRuby600, other.paletteDatavizRuby600, t)!,
+      paletteDatavizRuby700:
+          Color.lerp(paletteDatavizRuby700, other.paletteDatavizRuby700, t)!,
+      paletteDatavizRuby800:
+          Color.lerp(paletteDatavizRuby800, other.paletteDatavizRuby800, t)!,
+      paletteDatavizRuby900:
+          Color.lerp(paletteDatavizRuby900, other.paletteDatavizRuby900, t)!,
+      paletteDatavizTangerine100: Color.lerp(
+          paletteDatavizTangerine100, other.paletteDatavizTangerine100, t)!,
+      paletteDatavizTangerine200: Color.lerp(
+          paletteDatavizTangerine200, other.paletteDatavizTangerine200, t)!,
+      paletteDatavizTangerine300: Color.lerp(
+          paletteDatavizTangerine300, other.paletteDatavizTangerine300, t)!,
+      paletteDatavizTangerine400: Color.lerp(
+          paletteDatavizTangerine400, other.paletteDatavizTangerine400, t)!,
+      paletteDatavizTangerine50: Color.lerp(
+          paletteDatavizTangerine50, other.paletteDatavizTangerine50, t)!,
+      paletteDatavizTangerine500: Color.lerp(
+          paletteDatavizTangerine500, other.paletteDatavizTangerine500, t)!,
+      paletteDatavizTangerine600: Color.lerp(
+          paletteDatavizTangerine600, other.paletteDatavizTangerine600, t)!,
+      paletteDatavizTangerine700: Color.lerp(
+          paletteDatavizTangerine700, other.paletteDatavizTangerine700, t)!,
+      paletteDatavizTangerine800: Color.lerp(
+          paletteDatavizTangerine800, other.paletteDatavizTangerine800, t)!,
+      paletteDatavizTangerine900: Color.lerp(
+          paletteDatavizTangerine900, other.paletteDatavizTangerine900, t)!,
+      paletteSemanticBlue100:
+          Color.lerp(paletteSemanticBlue100, other.paletteSemanticBlue100, t)!,
+      paletteSemanticBlue1000: Color.lerp(
+          paletteSemanticBlue1000, other.paletteSemanticBlue1000, t)!,
+      paletteSemanticBlue150:
+          Color.lerp(paletteSemanticBlue150, other.paletteSemanticBlue150, t)!,
+      paletteSemanticBlue200:
+          Color.lerp(paletteSemanticBlue200, other.paletteSemanticBlue200, t)!,
+      paletteSemanticBlue25:
+          Color.lerp(paletteSemanticBlue25, other.paletteSemanticBlue25, t)!,
+      paletteSemanticBlue300:
+          Color.lerp(paletteSemanticBlue300, other.paletteSemanticBlue300, t)!,
+      paletteSemanticBlue400:
+          Color.lerp(paletteSemanticBlue400, other.paletteSemanticBlue400, t)!,
+      paletteSemanticBlue50:
+          Color.lerp(paletteSemanticBlue50, other.paletteSemanticBlue50, t)!,
+      paletteSemanticBlue500:
+          Color.lerp(paletteSemanticBlue500, other.paletteSemanticBlue500, t)!,
+      paletteSemanticBlue600:
+          Color.lerp(paletteSemanticBlue600, other.paletteSemanticBlue600, t)!,
+      paletteSemanticBlue700:
+          Color.lerp(paletteSemanticBlue700, other.paletteSemanticBlue700, t)!,
+      paletteSemanticBlue800:
+          Color.lerp(paletteSemanticBlue800, other.paletteSemanticBlue800, t)!,
+      paletteSemanticBlue900:
+          Color.lerp(paletteSemanticBlue900, other.paletteSemanticBlue900, t)!,
+      paletteSemanticGreen100: Color.lerp(
+          paletteSemanticGreen100, other.paletteSemanticGreen100, t)!,
+      paletteSemanticGreen1000: Color.lerp(
+          paletteSemanticGreen1000, other.paletteSemanticGreen1000, t)!,
+      paletteSemanticGreen150: Color.lerp(
+          paletteSemanticGreen150, other.paletteSemanticGreen150, t)!,
+      paletteSemanticGreen200: Color.lerp(
+          paletteSemanticGreen200, other.paletteSemanticGreen200, t)!,
+      paletteSemanticGreen25:
+          Color.lerp(paletteSemanticGreen25, other.paletteSemanticGreen25, t)!,
+      paletteSemanticGreen300: Color.lerp(
+          paletteSemanticGreen300, other.paletteSemanticGreen300, t)!,
+      paletteSemanticGreen400: Color.lerp(
+          paletteSemanticGreen400, other.paletteSemanticGreen400, t)!,
+      paletteSemanticGreen50:
+          Color.lerp(paletteSemanticGreen50, other.paletteSemanticGreen50, t)!,
+      paletteSemanticGreen500: Color.lerp(
+          paletteSemanticGreen500, other.paletteSemanticGreen500, t)!,
+      paletteSemanticGreen600: Color.lerp(
+          paletteSemanticGreen600, other.paletteSemanticGreen600, t)!,
+      paletteSemanticGreen700: Color.lerp(
+          paletteSemanticGreen700, other.paletteSemanticGreen700, t)!,
+      paletteSemanticGreen800: Color.lerp(
+          paletteSemanticGreen800, other.paletteSemanticGreen800, t)!,
+      paletteSemanticGreen900: Color.lerp(
+          paletteSemanticGreen900, other.paletteSemanticGreen900, t)!,
+      paletteSemanticOrange100: Color.lerp(
+          paletteSemanticOrange100, other.paletteSemanticOrange100, t)!,
+      paletteSemanticOrange1000: Color.lerp(
+          paletteSemanticOrange1000, other.paletteSemanticOrange1000, t)!,
+      paletteSemanticOrange150: Color.lerp(
+          paletteSemanticOrange150, other.paletteSemanticOrange150, t)!,
+      paletteSemanticOrange200: Color.lerp(
+          paletteSemanticOrange200, other.paletteSemanticOrange200, t)!,
+      paletteSemanticOrange25: Color.lerp(
+          paletteSemanticOrange25, other.paletteSemanticOrange25, t)!,
+      paletteSemanticOrange300: Color.lerp(
+          paletteSemanticOrange300, other.paletteSemanticOrange300, t)!,
+      paletteSemanticOrange400: Color.lerp(
+          paletteSemanticOrange400, other.paletteSemanticOrange400, t)!,
+      paletteSemanticOrange50: Color.lerp(
+          paletteSemanticOrange50, other.paletteSemanticOrange50, t)!,
+      paletteSemanticOrange500: Color.lerp(
+          paletteSemanticOrange500, other.paletteSemanticOrange500, t)!,
+      paletteSemanticOrange600: Color.lerp(
+          paletteSemanticOrange600, other.paletteSemanticOrange600, t)!,
+      paletteSemanticOrange700: Color.lerp(
+          paletteSemanticOrange700, other.paletteSemanticOrange700, t)!,
+      paletteSemanticOrange800: Color.lerp(
+          paletteSemanticOrange800, other.paletteSemanticOrange800, t)!,
+      paletteSemanticOrange900: Color.lerp(
+          paletteSemanticOrange900, other.paletteSemanticOrange900, t)!,
+      paletteSemanticRed100:
+          Color.lerp(paletteSemanticRed100, other.paletteSemanticRed100, t)!,
+      paletteSemanticRed1000:
+          Color.lerp(paletteSemanticRed1000, other.paletteSemanticRed1000, t)!,
+      paletteSemanticRed150:
+          Color.lerp(paletteSemanticRed150, other.paletteSemanticRed150, t)!,
+      paletteSemanticRed200:
+          Color.lerp(paletteSemanticRed200, other.paletteSemanticRed200, t)!,
+      paletteSemanticRed25:
+          Color.lerp(paletteSemanticRed25, other.paletteSemanticRed25, t)!,
+      paletteSemanticRed300:
+          Color.lerp(paletteSemanticRed300, other.paletteSemanticRed300, t)!,
+      paletteSemanticRed400:
+          Color.lerp(paletteSemanticRed400, other.paletteSemanticRed400, t)!,
+      paletteSemanticRed50:
+          Color.lerp(paletteSemanticRed50, other.paletteSemanticRed50, t)!,
+      paletteSemanticRed500:
+          Color.lerp(paletteSemanticRed500, other.paletteSemanticRed500, t)!,
+      paletteSemanticRed600:
+          Color.lerp(paletteSemanticRed600, other.paletteSemanticRed600, t)!,
+      paletteSemanticRed700:
+          Color.lerp(paletteSemanticRed700, other.paletteSemanticRed700, t)!,
+      paletteSemanticRed800:
+          Color.lerp(paletteSemanticRed800, other.paletteSemanticRed800, t)!,
+      paletteSemanticRed900:
+          Color.lerp(paletteSemanticRed900, other.paletteSemanticRed900, t)!,
+      staticContainerColor:
+          Color.lerp(staticContainerColor, other.staticContainerColor, t)!,
+      staticDividerColor:
+          Color.lerp(staticDividerColor, other.staticDividerColor, t)!,
+      textAlertBasic: Color.lerp(textAlertBasic, other.textAlertBasic, t)!,
+      textAlertDanger: Color.lerp(textAlertDanger, other.textAlertDanger, t)!,
+      textAlertInfo: Color.lerp(textAlertInfo, other.textAlertInfo, t)!,
+      textAlertSuccess:
+          Color.lerp(textAlertSuccess, other.textAlertSuccess, t)!,
+      textAlertWarning:
+          Color.lerp(textAlertWarning, other.textAlertWarning, t)!,
+      textDisabled: Color.lerp(textDisabled, other.textDisabled, t)!,
+      textInteractiveActive:
+          Color.lerp(textInteractiveActive, other.textInteractiveActive, t)!,
+      textInteractiveDefault:
+          Color.lerp(textInteractiveDefault, other.textInteractiveDefault, t)!,
+      textInteractiveHover:
+          Color.lerp(textInteractiveHover, other.textInteractiveHover, t)!,
+      textStaticError: Color.lerp(textStaticError, other.textStaticError, t)!,
       textStaticInverse:
           Color.lerp(textStaticInverse, other.textStaticInverse, t)!,
+      textStaticPrimary:
+          Color.lerp(textStaticPrimary, other.textStaticPrimary, t)!,
+      textStaticSecondary:
+          Color.lerp(textStaticSecondary, other.textStaticSecondary, t)!,
+      textStaticTertiary:
+          Color.lerp(textStaticTertiary, other.textStaticTertiary, t)!,
     );
   }
 
@@ -133,14 +2309,374 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
           'backgroundAccentSecondary', backgroundAccentSecondary))
       ..add(DiagnosticsProperty(
           'backgroundAlertBasicPrimary', backgroundAlertBasicPrimary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertBasicSecondary', backgroundAlertBasicSecondary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertDangerPrimary', backgroundAlertDangerPrimary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertDangerSecondary', backgroundAlertDangerSecondary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertInfoPrimary', backgroundAlertInfoPrimary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertInfoSecondary', backgroundAlertInfoSecondary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertSuccessPrimary', backgroundAlertSuccessPrimary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertSuccessSecondary', backgroundAlertSuccessSecondary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertWarningPrimary', backgroundAlertWarningPrimary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertWarningSecondary', backgroundAlertWarningSecondary))
+      ..add(DiagnosticsProperty('backgroundBrand', backgroundBrand))
       ..add(DiagnosticsProperty('backgroundDisabled', backgroundDisabled))
+      ..add(DiagnosticsProperty(
+          'backgroundInteractiveBoldActive', backgroundInteractiveBoldActive))
+      ..add(DiagnosticsProperty(
+          'backgroundInteractiveBoldDefault', backgroundInteractiveBoldDefault))
+      ..add(DiagnosticsProperty(
+          'backgroundInteractiveBoldHover', backgroundInteractiveBoldHover))
+      ..add(DiagnosticsProperty('backgroundInteractiveDangerActive',
+          backgroundInteractiveDangerActive))
+      ..add(DiagnosticsProperty('backgroundInteractiveDangerDefault',
+          backgroundInteractiveDangerDefault))
+      ..add(DiagnosticsProperty(
+          'backgroundInteractiveDangerHover', backgroundInteractiveDangerHover))
       ..add(DiagnosticsProperty('backgroundInteractivePrimaryActive',
           backgroundInteractivePrimaryActive))
       ..add(DiagnosticsProperty('backgroundInteractivePrimaryDefault',
           backgroundInteractivePrimaryDefault))
       ..add(DiagnosticsProperty('backgroundInteractivePrimaryHover',
           backgroundInteractivePrimaryHover))
-      ..add(DiagnosticsProperty('textStaticInverse', textStaticInverse));
+      ..add(DiagnosticsProperty('backgroundInteractiveSecondaryActive',
+          backgroundInteractiveSecondaryActive))
+      ..add(DiagnosticsProperty('backgroundInteractiveSecondaryDefault',
+          backgroundInteractiveSecondaryDefault))
+      ..add(DiagnosticsProperty('backgroundInteractiveSecondaryHover',
+          backgroundInteractiveSecondaryHover))
+      ..add(DiagnosticsProperty('backgroundInteractiveSubtleActive',
+          backgroundInteractiveSubtleActive))
+      ..add(DiagnosticsProperty('backgroundInteractiveSubtleDefault',
+          backgroundInteractiveSubtleDefault))
+      ..add(DiagnosticsProperty(
+          'backgroundInteractiveSubtleHover', backgroundInteractiveSubtleHover))
+      ..add(DiagnosticsProperty('backgroundOverlay', backgroundOverlay))
+      ..add(DiagnosticsProperty('backgroundStaticFlat', backgroundStaticFlat))
+      ..add(DiagnosticsProperty(
+          'backgroundStaticFloating', backgroundStaticFloating))
+      ..add(DiagnosticsProperty(
+          'backgroundStaticInverse', backgroundStaticInverse))
+      ..add(
+          DiagnosticsProperty('backgroundStaticRaised', backgroundStaticRaised))
+      ..add(
+          DiagnosticsProperty('backgroundStaticSunken', backgroundStaticSunken))
+      ..add(DiagnosticsProperty('borderAlertBasic', borderAlertBasic))
+      ..add(DiagnosticsProperty('borderAlertDanger', borderAlertDanger))
+      ..add(DiagnosticsProperty('borderAlertInfo', borderAlertInfo))
+      ..add(DiagnosticsProperty('borderAlertSuccess', borderAlertSuccess))
+      ..add(DiagnosticsProperty('borderAlertWarning', borderAlertWarning))
+      ..add(DiagnosticsProperty('borderDisabled', borderDisabled))
+      ..add(
+          DiagnosticsProperty('borderInteractiveError', borderInteractiveError))
+      ..add(
+          DiagnosticsProperty('borderInteractiveFocus', borderInteractiveFocus))
+      ..add(DiagnosticsProperty(
+          'borderInteractivePrimaryActive', borderInteractivePrimaryActive))
+      ..add(DiagnosticsProperty(
+          'borderInteractivePrimaryDefault', borderInteractivePrimaryDefault))
+      ..add(DiagnosticsProperty(
+          'borderInteractivePrimaryHover', borderInteractivePrimaryHover))
+      ..add(DiagnosticsProperty(
+          'borderInteractiveSecondaryActive', borderInteractiveSecondaryActive))
+      ..add(DiagnosticsProperty(
+          'borderInteractiveSecondaryHover', borderInteractiveSecondaryHover))
+      ..add(DiagnosticsProperty('borderStaticInverse', borderStaticInverse))
+      ..add(DiagnosticsProperty('borderStaticPrimary', borderStaticPrimary))
+      ..add(DiagnosticsProperty('borderStaticSecondary', borderStaticSecondary))
+      ..add(DiagnosticsProperty('inputActiveColor', inputActiveColor))
+      ..add(DiagnosticsProperty('inputDangerColor', inputDangerColor))
+      ..add(DiagnosticsProperty('inputDefaultColor', inputDefaultColor))
+      ..add(DiagnosticsProperty('inputDisabledColor', inputDisabledColor))
+      ..add(DiagnosticsProperty('inputHoverColor', inputHoverColor))
+      ..add(DiagnosticsProperty('inputInverseColor', inputInverseColor))
+      ..add(
+          DiagnosticsProperty('interactiveDangerColor', interactiveDangerColor))
+      ..add(DiagnosticsProperty(
+          'interactiveDefaultColor', interactiveDefaultColor))
+      ..add(DiagnosticsProperty(
+          'interactiveDisabledColor', interactiveDisabledColor))
+      ..add(DiagnosticsProperty('interactiveHoverColor', interactiveHoverColor))
+      ..add(DiagnosticsProperty(
+          'interactiveInverseColor', interactiveInverseColor))
+      ..add(DiagnosticsProperty('paletteBasicsBlack', paletteBasicsBlack))
+      ..add(DiagnosticsProperty('paletteBasicsWhite', paletteBasicsWhite))
+      ..add(DiagnosticsProperty('paletteBasicsWhite64', paletteBasicsWhite64))
+      ..add(DiagnosticsProperty('paletteBrandCoral100', paletteBrandCoral100))
+      ..add(DiagnosticsProperty('paletteBrandCoral1000', paletteBrandCoral1000))
+      ..add(DiagnosticsProperty('paletteBrandCoral150', paletteBrandCoral150))
+      ..add(DiagnosticsProperty('paletteBrandCoral200', paletteBrandCoral200))
+      ..add(DiagnosticsProperty('paletteBrandCoral25', paletteBrandCoral25))
+      ..add(DiagnosticsProperty('paletteBrandCoral300', paletteBrandCoral300))
+      ..add(DiagnosticsProperty('paletteBrandCoral400', paletteBrandCoral400))
+      ..add(DiagnosticsProperty('paletteBrandCoral50', paletteBrandCoral50))
+      ..add(DiagnosticsProperty('paletteBrandCoral500', paletteBrandCoral500))
+      ..add(DiagnosticsProperty('paletteBrandCoral600', paletteBrandCoral600))
+      ..add(DiagnosticsProperty('paletteBrandCoral700', paletteBrandCoral700))
+      ..add(DiagnosticsProperty('paletteBrandCoral800', paletteBrandCoral800))
+      ..add(DiagnosticsProperty('paletteBrandCoral900', paletteBrandCoral900))
+      ..add(DiagnosticsProperty('paletteBrandGrey0', paletteBrandGrey0))
+      ..add(DiagnosticsProperty('paletteBrandGrey100', paletteBrandGrey100))
+      ..add(DiagnosticsProperty('paletteBrandGrey1000', paletteBrandGrey1000))
+      ..add(DiagnosticsProperty('paletteBrandGrey150', paletteBrandGrey150))
+      ..add(DiagnosticsProperty('paletteBrandGrey200', paletteBrandGrey200))
+      ..add(DiagnosticsProperty('paletteBrandGrey25', paletteBrandGrey25))
+      ..add(DiagnosticsProperty('paletteBrandGrey300', paletteBrandGrey300))
+      ..add(DiagnosticsProperty('paletteBrandGrey400', paletteBrandGrey400))
+      ..add(DiagnosticsProperty('paletteBrandGrey50', paletteBrandGrey50))
+      ..add(DiagnosticsProperty('paletteBrandGrey500', paletteBrandGrey500))
+      ..add(DiagnosticsProperty('paletteBrandGrey600', paletteBrandGrey600))
+      ..add(DiagnosticsProperty('paletteBrandGrey700', paletteBrandGrey700))
+      ..add(DiagnosticsProperty('paletteBrandGrey800', paletteBrandGrey800))
+      ..add(DiagnosticsProperty('paletteBrandGrey900', paletteBrandGrey900))
+      ..add(DiagnosticsProperty('paletteBrandIndigo100', paletteBrandIndigo100))
+      ..add(
+          DiagnosticsProperty('paletteBrandIndigo1000', paletteBrandIndigo1000))
+      ..add(DiagnosticsProperty('paletteBrandIndigo150', paletteBrandIndigo150))
+      ..add(DiagnosticsProperty('paletteBrandIndigo200', paletteBrandIndigo200))
+      ..add(DiagnosticsProperty('paletteBrandIndigo25', paletteBrandIndigo25))
+      ..add(DiagnosticsProperty('paletteBrandIndigo300', paletteBrandIndigo300))
+      ..add(DiagnosticsProperty('paletteBrandIndigo400', paletteBrandIndigo400))
+      ..add(DiagnosticsProperty('paletteBrandIndigo50', paletteBrandIndigo50))
+      ..add(DiagnosticsProperty('paletteBrandIndigo500', paletteBrandIndigo500))
+      ..add(DiagnosticsProperty('paletteBrandIndigo600', paletteBrandIndigo600))
+      ..add(DiagnosticsProperty('paletteBrandIndigo700', paletteBrandIndigo700))
+      ..add(DiagnosticsProperty('paletteBrandIndigo800', paletteBrandIndigo800))
+      ..add(DiagnosticsProperty('paletteBrandIndigo900', paletteBrandIndigo900))
+      ..add(DiagnosticsProperty('paletteBrandNight0', paletteBrandNight0))
+      ..add(DiagnosticsProperty('paletteBrandNight100', paletteBrandNight100))
+      ..add(DiagnosticsProperty('paletteBrandNight1000', paletteBrandNight1000))
+      ..add(DiagnosticsProperty(
+          'paletteBrandNight100012', paletteBrandNight100012))
+      ..add(DiagnosticsProperty(
+          'paletteBrandNight100016', paletteBrandNight100016))
+      ..add(
+          DiagnosticsProperty('paletteBrandNight10008', paletteBrandNight10008))
+      ..add(DiagnosticsProperty('paletteBrandNight150', paletteBrandNight150))
+      ..add(DiagnosticsProperty('paletteBrandNight200', paletteBrandNight200))
+      ..add(DiagnosticsProperty('paletteBrandNight25', paletteBrandNight25))
+      ..add(DiagnosticsProperty('paletteBrandNight300', paletteBrandNight300))
+      ..add(DiagnosticsProperty('paletteBrandNight400', paletteBrandNight400))
+      ..add(DiagnosticsProperty('paletteBrandNight50', paletteBrandNight50))
+      ..add(DiagnosticsProperty('paletteBrandNight500', paletteBrandNight500))
+      ..add(DiagnosticsProperty('paletteBrandNight600', paletteBrandNight600))
+      ..add(DiagnosticsProperty('paletteBrandNight700', paletteBrandNight700))
+      ..add(DiagnosticsProperty('paletteBrandNight800', paletteBrandNight800))
+      ..add(DiagnosticsProperty('paletteBrandNight900', paletteBrandNight900))
+      ..add(
+          DiagnosticsProperty('paletteDatavizDenim100', paletteDatavizDenim100))
+      ..add(
+          DiagnosticsProperty('paletteDatavizDenim200', paletteDatavizDenim200))
+      ..add(
+          DiagnosticsProperty('paletteDatavizDenim300', paletteDatavizDenim300))
+      ..add(
+          DiagnosticsProperty('paletteDatavizDenim400', paletteDatavizDenim400))
+      ..add(DiagnosticsProperty('paletteDatavizDenim50', paletteDatavizDenim50))
+      ..add(
+          DiagnosticsProperty('paletteDatavizDenim500', paletteDatavizDenim500))
+      ..add(
+          DiagnosticsProperty('paletteDatavizDenim600', paletteDatavizDenim600))
+      ..add(
+          DiagnosticsProperty('paletteDatavizDenim700', paletteDatavizDenim700))
+      ..add(
+          DiagnosticsProperty('paletteDatavizDenim800', paletteDatavizDenim800))
+      ..add(
+          DiagnosticsProperty('paletteDatavizDenim900', paletteDatavizDenim900))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender100', paletteDatavizLavender100))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender200', paletteDatavizLavender200))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender300', paletteDatavizLavender300))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender400', paletteDatavizLavender400))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender50', paletteDatavizLavender50))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender500', paletteDatavizLavender500))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender600', paletteDatavizLavender600))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender700', paletteDatavizLavender700))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender800', paletteDatavizLavender800))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizLavender900', paletteDatavizLavender900))
+      ..add(DiagnosticsProperty('paletteDatavizLime100', paletteDatavizLime100))
+      ..add(DiagnosticsProperty('paletteDatavizLime200', paletteDatavizLime200))
+      ..add(DiagnosticsProperty('paletteDatavizLime300', paletteDatavizLime300))
+      ..add(DiagnosticsProperty('paletteDatavizLime400', paletteDatavizLime400))
+      ..add(DiagnosticsProperty('paletteDatavizLime50', paletteDatavizLime50))
+      ..add(DiagnosticsProperty('paletteDatavizLime500', paletteDatavizLime500))
+      ..add(DiagnosticsProperty('paletteDatavizLime600', paletteDatavizLime600))
+      ..add(DiagnosticsProperty('paletteDatavizLime700', paletteDatavizLime700))
+      ..add(DiagnosticsProperty('paletteDatavizLime800', paletteDatavizLime800))
+      ..add(DiagnosticsProperty('paletteDatavizLime900', paletteDatavizLime900))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard100', paletteDatavizMustard100))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard200', paletteDatavizMustard200))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard300', paletteDatavizMustard300))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard400', paletteDatavizMustard400))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard50', paletteDatavizMustard50))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard500', paletteDatavizMustard500))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard600', paletteDatavizMustard600))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard700', paletteDatavizMustard700))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard800', paletteDatavizMustard800))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizMustard900', paletteDatavizMustard900))
+      ..add(DiagnosticsProperty('paletteDatavizRuby100', paletteDatavizRuby100))
+      ..add(DiagnosticsProperty('paletteDatavizRuby200', paletteDatavizRuby200))
+      ..add(DiagnosticsProperty('paletteDatavizRuby300', paletteDatavizRuby300))
+      ..add(DiagnosticsProperty('paletteDatavizRuby400', paletteDatavizRuby400))
+      ..add(DiagnosticsProperty('paletteDatavizRuby50', paletteDatavizRuby50))
+      ..add(DiagnosticsProperty('paletteDatavizRuby500', paletteDatavizRuby500))
+      ..add(DiagnosticsProperty('paletteDatavizRuby600', paletteDatavizRuby600))
+      ..add(DiagnosticsProperty('paletteDatavizRuby700', paletteDatavizRuby700))
+      ..add(DiagnosticsProperty('paletteDatavizRuby800', paletteDatavizRuby800))
+      ..add(DiagnosticsProperty('paletteDatavizRuby900', paletteDatavizRuby900))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine100', paletteDatavizTangerine100))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine200', paletteDatavizTangerine200))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine300', paletteDatavizTangerine300))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine400', paletteDatavizTangerine400))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine50', paletteDatavizTangerine50))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine500', paletteDatavizTangerine500))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine600', paletteDatavizTangerine600))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine700', paletteDatavizTangerine700))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine800', paletteDatavizTangerine800))
+      ..add(DiagnosticsProperty(
+          'paletteDatavizTangerine900', paletteDatavizTangerine900))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue100', paletteSemanticBlue100))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticBlue1000', paletteSemanticBlue1000))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue150', paletteSemanticBlue150))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue200', paletteSemanticBlue200))
+      ..add(DiagnosticsProperty('paletteSemanticBlue25', paletteSemanticBlue25))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue300', paletteSemanticBlue300))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue400', paletteSemanticBlue400))
+      ..add(DiagnosticsProperty('paletteSemanticBlue50', paletteSemanticBlue50))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue500', paletteSemanticBlue500))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue600', paletteSemanticBlue600))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue700', paletteSemanticBlue700))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue800', paletteSemanticBlue800))
+      ..add(
+          DiagnosticsProperty('paletteSemanticBlue900', paletteSemanticBlue900))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen100', paletteSemanticGreen100))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen1000', paletteSemanticGreen1000))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen150', paletteSemanticGreen150))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen200', paletteSemanticGreen200))
+      ..add(
+          DiagnosticsProperty('paletteSemanticGreen25', paletteSemanticGreen25))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen300', paletteSemanticGreen300))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen400', paletteSemanticGreen400))
+      ..add(
+          DiagnosticsProperty('paletteSemanticGreen50', paletteSemanticGreen50))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen500', paletteSemanticGreen500))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen600', paletteSemanticGreen600))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen700', paletteSemanticGreen700))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen800', paletteSemanticGreen800))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticGreen900', paletteSemanticGreen900))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange100', paletteSemanticOrange100))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange1000', paletteSemanticOrange1000))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange150', paletteSemanticOrange150))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange200', paletteSemanticOrange200))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange25', paletteSemanticOrange25))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange300', paletteSemanticOrange300))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange400', paletteSemanticOrange400))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange50', paletteSemanticOrange50))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange500', paletteSemanticOrange500))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange600', paletteSemanticOrange600))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange700', paletteSemanticOrange700))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange800', paletteSemanticOrange800))
+      ..add(DiagnosticsProperty(
+          'paletteSemanticOrange900', paletteSemanticOrange900))
+      ..add(DiagnosticsProperty('paletteSemanticRed100', paletteSemanticRed100))
+      ..add(
+          DiagnosticsProperty('paletteSemanticRed1000', paletteSemanticRed1000))
+      ..add(DiagnosticsProperty('paletteSemanticRed150', paletteSemanticRed150))
+      ..add(DiagnosticsProperty('paletteSemanticRed200', paletteSemanticRed200))
+      ..add(DiagnosticsProperty('paletteSemanticRed25', paletteSemanticRed25))
+      ..add(DiagnosticsProperty('paletteSemanticRed300', paletteSemanticRed300))
+      ..add(DiagnosticsProperty('paletteSemanticRed400', paletteSemanticRed400))
+      ..add(DiagnosticsProperty('paletteSemanticRed50', paletteSemanticRed50))
+      ..add(DiagnosticsProperty('paletteSemanticRed500', paletteSemanticRed500))
+      ..add(DiagnosticsProperty('paletteSemanticRed600', paletteSemanticRed600))
+      ..add(DiagnosticsProperty('paletteSemanticRed700', paletteSemanticRed700))
+      ..add(DiagnosticsProperty('paletteSemanticRed800', paletteSemanticRed800))
+      ..add(DiagnosticsProperty('paletteSemanticRed900', paletteSemanticRed900))
+      ..add(DiagnosticsProperty('staticContainerColor', staticContainerColor))
+      ..add(DiagnosticsProperty('staticDividerColor', staticDividerColor))
+      ..add(DiagnosticsProperty('textAlertBasic', textAlertBasic))
+      ..add(DiagnosticsProperty('textAlertDanger', textAlertDanger))
+      ..add(DiagnosticsProperty('textAlertInfo', textAlertInfo))
+      ..add(DiagnosticsProperty('textAlertSuccess', textAlertSuccess))
+      ..add(DiagnosticsProperty('textAlertWarning', textAlertWarning))
+      ..add(DiagnosticsProperty('textDisabled', textDisabled))
+      ..add(DiagnosticsProperty('textInteractiveActive', textInteractiveActive))
+      ..add(
+          DiagnosticsProperty('textInteractiveDefault', textInteractiveDefault))
+      ..add(DiagnosticsProperty('textInteractiveHover', textInteractiveHover))
+      ..add(DiagnosticsProperty('textStaticError', textStaticError))
+      ..add(DiagnosticsProperty('textStaticInverse', textStaticInverse))
+      ..add(DiagnosticsProperty('textStaticPrimary', textStaticPrimary))
+      ..add(DiagnosticsProperty('textStaticSecondary', textStaticSecondary))
+      ..add(DiagnosticsProperty('textStaticTertiary', textStaticTertiary));
   }
 
   @override
@@ -154,33 +2690,532 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
                 backgroundAccentSecondary, other.backgroundAccentSecondary) &&
             const DeepCollectionEquality().equals(backgroundAlertBasicPrimary,
                 other.backgroundAlertBasicPrimary) &&
+            const DeepCollectionEquality().equals(backgroundAlertBasicSecondary,
+                other.backgroundAlertBasicSecondary) &&
+            const DeepCollectionEquality().equals(backgroundAlertDangerPrimary,
+                other.backgroundAlertDangerPrimary) &&
+            const DeepCollectionEquality().equals(
+                backgroundAlertDangerSecondary,
+                other.backgroundAlertDangerSecondary) &&
+            const DeepCollectionEquality().equals(
+                backgroundAlertInfoPrimary, other.backgroundAlertInfoPrimary) &&
+            const DeepCollectionEquality().equals(backgroundAlertInfoSecondary,
+                other.backgroundAlertInfoSecondary) &&
+            const DeepCollectionEquality().equals(backgroundAlertSuccessPrimary,
+                other.backgroundAlertSuccessPrimary) &&
+            const DeepCollectionEquality().equals(
+                backgroundAlertSuccessSecondary,
+                other.backgroundAlertSuccessSecondary) &&
+            const DeepCollectionEquality().equals(backgroundAlertWarningPrimary,
+                other.backgroundAlertWarningPrimary) &&
+            const DeepCollectionEquality().equals(
+                backgroundAlertWarningSecondary,
+                other.backgroundAlertWarningSecondary) &&
+            const DeepCollectionEquality()
+                .equals(backgroundBrand, other.backgroundBrand) &&
             const DeepCollectionEquality()
                 .equals(backgroundDisabled, other.backgroundDisabled) &&
             const DeepCollectionEquality().equals(
-                backgroundInteractivePrimaryActive,
-                other.backgroundInteractivePrimaryActive) &&
+                backgroundInteractiveBoldActive,
+                other.backgroundInteractiveBoldActive) &&
             const DeepCollectionEquality().equals(
-                backgroundInteractivePrimaryDefault,
-                other.backgroundInteractivePrimaryDefault) &&
+                backgroundInteractiveBoldDefault,
+                other.backgroundInteractiveBoldDefault) &&
             const DeepCollectionEquality().equals(
-                backgroundInteractivePrimaryHover,
-                other.backgroundInteractivePrimaryHover) &&
-            const DeepCollectionEquality()
-                .equals(textStaticInverse, other.textStaticInverse));
+                backgroundInteractiveBoldHover,
+                other.backgroundInteractiveBoldHover) &&
+            const DeepCollectionEquality().equals(
+                backgroundInteractiveDangerActive,
+                other.backgroundInteractiveDangerActive) &&
+            const DeepCollectionEquality().equals(backgroundInteractiveDangerDefault, other.backgroundInteractiveDangerDefault) &&
+            const DeepCollectionEquality().equals(backgroundInteractiveDangerHover, other.backgroundInteractiveDangerHover) &&
+            const DeepCollectionEquality().equals(backgroundInteractivePrimaryActive, other.backgroundInteractivePrimaryActive) &&
+            const DeepCollectionEquality().equals(backgroundInteractivePrimaryDefault, other.backgroundInteractivePrimaryDefault) &&
+            const DeepCollectionEquality().equals(backgroundInteractivePrimaryHover, other.backgroundInteractivePrimaryHover) &&
+            const DeepCollectionEquality().equals(backgroundInteractiveSecondaryActive, other.backgroundInteractiveSecondaryActive) &&
+            const DeepCollectionEquality().equals(backgroundInteractiveSecondaryDefault, other.backgroundInteractiveSecondaryDefault) &&
+            const DeepCollectionEquality().equals(backgroundInteractiveSecondaryHover, other.backgroundInteractiveSecondaryHover) &&
+            const DeepCollectionEquality().equals(backgroundInteractiveSubtleActive, other.backgroundInteractiveSubtleActive) &&
+            const DeepCollectionEquality().equals(backgroundInteractiveSubtleDefault, other.backgroundInteractiveSubtleDefault) &&
+            const DeepCollectionEquality().equals(backgroundInteractiveSubtleHover, other.backgroundInteractiveSubtleHover) &&
+            const DeepCollectionEquality().equals(backgroundOverlay, other.backgroundOverlay) &&
+            const DeepCollectionEquality().equals(backgroundStaticFlat, other.backgroundStaticFlat) &&
+            const DeepCollectionEquality().equals(backgroundStaticFloating, other.backgroundStaticFloating) &&
+            const DeepCollectionEquality().equals(backgroundStaticInverse, other.backgroundStaticInverse) &&
+            const DeepCollectionEquality().equals(backgroundStaticRaised, other.backgroundStaticRaised) &&
+            const DeepCollectionEquality().equals(backgroundStaticSunken, other.backgroundStaticSunken) &&
+            const DeepCollectionEquality().equals(borderAlertBasic, other.borderAlertBasic) &&
+            const DeepCollectionEquality().equals(borderAlertDanger, other.borderAlertDanger) &&
+            const DeepCollectionEquality().equals(borderAlertInfo, other.borderAlertInfo) &&
+            const DeepCollectionEquality().equals(borderAlertSuccess, other.borderAlertSuccess) &&
+            const DeepCollectionEquality().equals(borderAlertWarning, other.borderAlertWarning) &&
+            const DeepCollectionEquality().equals(borderDisabled, other.borderDisabled) &&
+            const DeepCollectionEquality().equals(borderInteractiveError, other.borderInteractiveError) &&
+            const DeepCollectionEquality().equals(borderInteractiveFocus, other.borderInteractiveFocus) &&
+            const DeepCollectionEquality().equals(borderInteractivePrimaryActive, other.borderInteractivePrimaryActive) &&
+            const DeepCollectionEquality().equals(borderInteractivePrimaryDefault, other.borderInteractivePrimaryDefault) &&
+            const DeepCollectionEquality().equals(borderInteractivePrimaryHover, other.borderInteractivePrimaryHover) &&
+            const DeepCollectionEquality().equals(borderInteractiveSecondaryActive, other.borderInteractiveSecondaryActive) &&
+            const DeepCollectionEquality().equals(borderInteractiveSecondaryHover, other.borderInteractiveSecondaryHover) &&
+            const DeepCollectionEquality().equals(borderStaticInverse, other.borderStaticInverse) &&
+            const DeepCollectionEquality().equals(borderStaticPrimary, other.borderStaticPrimary) &&
+            const DeepCollectionEquality().equals(borderStaticSecondary, other.borderStaticSecondary) &&
+            const DeepCollectionEquality().equals(inputActiveColor, other.inputActiveColor) &&
+            const DeepCollectionEquality().equals(inputDangerColor, other.inputDangerColor) &&
+            const DeepCollectionEquality().equals(inputDefaultColor, other.inputDefaultColor) &&
+            const DeepCollectionEquality().equals(inputDisabledColor, other.inputDisabledColor) &&
+            const DeepCollectionEquality().equals(inputHoverColor, other.inputHoverColor) &&
+            const DeepCollectionEquality().equals(inputInverseColor, other.inputInverseColor) &&
+            const DeepCollectionEquality().equals(interactiveDangerColor, other.interactiveDangerColor) &&
+            const DeepCollectionEquality().equals(interactiveDefaultColor, other.interactiveDefaultColor) &&
+            const DeepCollectionEquality().equals(interactiveDisabledColor, other.interactiveDisabledColor) &&
+            const DeepCollectionEquality().equals(interactiveHoverColor, other.interactiveHoverColor) &&
+            const DeepCollectionEquality().equals(interactiveInverseColor, other.interactiveInverseColor) &&
+            const DeepCollectionEquality().equals(paletteBasicsBlack, other.paletteBasicsBlack) &&
+            const DeepCollectionEquality().equals(paletteBasicsWhite, other.paletteBasicsWhite) &&
+            const DeepCollectionEquality().equals(paletteBasicsWhite64, other.paletteBasicsWhite64) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral100, other.paletteBrandCoral100) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral1000, other.paletteBrandCoral1000) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral150, other.paletteBrandCoral150) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral200, other.paletteBrandCoral200) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral25, other.paletteBrandCoral25) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral300, other.paletteBrandCoral300) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral400, other.paletteBrandCoral400) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral50, other.paletteBrandCoral50) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral500, other.paletteBrandCoral500) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral600, other.paletteBrandCoral600) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral700, other.paletteBrandCoral700) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral800, other.paletteBrandCoral800) &&
+            const DeepCollectionEquality().equals(paletteBrandCoral900, other.paletteBrandCoral900) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey0, other.paletteBrandGrey0) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey100, other.paletteBrandGrey100) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey1000, other.paletteBrandGrey1000) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey150, other.paletteBrandGrey150) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey200, other.paletteBrandGrey200) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey25, other.paletteBrandGrey25) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey300, other.paletteBrandGrey300) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey400, other.paletteBrandGrey400) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey50, other.paletteBrandGrey50) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey500, other.paletteBrandGrey500) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey600, other.paletteBrandGrey600) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey700, other.paletteBrandGrey700) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey800, other.paletteBrandGrey800) &&
+            const DeepCollectionEquality().equals(paletteBrandGrey900, other.paletteBrandGrey900) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo100, other.paletteBrandIndigo100) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo1000, other.paletteBrandIndigo1000) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo150, other.paletteBrandIndigo150) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo200, other.paletteBrandIndigo200) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo25, other.paletteBrandIndigo25) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo300, other.paletteBrandIndigo300) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo400, other.paletteBrandIndigo400) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo50, other.paletteBrandIndigo50) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo500, other.paletteBrandIndigo500) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo600, other.paletteBrandIndigo600) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo700, other.paletteBrandIndigo700) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo800, other.paletteBrandIndigo800) &&
+            const DeepCollectionEquality().equals(paletteBrandIndigo900, other.paletteBrandIndigo900) &&
+            const DeepCollectionEquality().equals(paletteBrandNight0, other.paletteBrandNight0) &&
+            const DeepCollectionEquality().equals(paletteBrandNight100, other.paletteBrandNight100) &&
+            const DeepCollectionEquality().equals(paletteBrandNight1000, other.paletteBrandNight1000) &&
+            const DeepCollectionEquality().equals(paletteBrandNight100012, other.paletteBrandNight100012) &&
+            const DeepCollectionEquality().equals(paletteBrandNight100016, other.paletteBrandNight100016) &&
+            const DeepCollectionEquality().equals(paletteBrandNight10008, other.paletteBrandNight10008) &&
+            const DeepCollectionEquality().equals(paletteBrandNight150, other.paletteBrandNight150) &&
+            const DeepCollectionEquality().equals(paletteBrandNight200, other.paletteBrandNight200) &&
+            const DeepCollectionEquality().equals(paletteBrandNight25, other.paletteBrandNight25) &&
+            const DeepCollectionEquality().equals(paletteBrandNight300, other.paletteBrandNight300) &&
+            const DeepCollectionEquality().equals(paletteBrandNight400, other.paletteBrandNight400) &&
+            const DeepCollectionEquality().equals(paletteBrandNight50, other.paletteBrandNight50) &&
+            const DeepCollectionEquality().equals(paletteBrandNight500, other.paletteBrandNight500) &&
+            const DeepCollectionEquality().equals(paletteBrandNight600, other.paletteBrandNight600) &&
+            const DeepCollectionEquality().equals(paletteBrandNight700, other.paletteBrandNight700) &&
+            const DeepCollectionEquality().equals(paletteBrandNight800, other.paletteBrandNight800) &&
+            const DeepCollectionEquality().equals(paletteBrandNight900, other.paletteBrandNight900) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim100, other.paletteDatavizDenim100) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim200, other.paletteDatavizDenim200) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim300, other.paletteDatavizDenim300) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim400, other.paletteDatavizDenim400) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim50, other.paletteDatavizDenim50) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim500, other.paletteDatavizDenim500) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim600, other.paletteDatavizDenim600) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim700, other.paletteDatavizDenim700) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim800, other.paletteDatavizDenim800) &&
+            const DeepCollectionEquality().equals(paletteDatavizDenim900, other.paletteDatavizDenim900) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender100, other.paletteDatavizLavender100) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender200, other.paletteDatavizLavender200) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender300, other.paletteDatavizLavender300) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender400, other.paletteDatavizLavender400) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender50, other.paletteDatavizLavender50) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender500, other.paletteDatavizLavender500) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender600, other.paletteDatavizLavender600) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender700, other.paletteDatavizLavender700) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender800, other.paletteDatavizLavender800) &&
+            const DeepCollectionEquality().equals(paletteDatavizLavender900, other.paletteDatavizLavender900) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime100, other.paletteDatavizLime100) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime200, other.paletteDatavizLime200) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime300, other.paletteDatavizLime300) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime400, other.paletteDatavizLime400) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime50, other.paletteDatavizLime50) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime500, other.paletteDatavizLime500) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime600, other.paletteDatavizLime600) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime700, other.paletteDatavizLime700) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime800, other.paletteDatavizLime800) &&
+            const DeepCollectionEquality().equals(paletteDatavizLime900, other.paletteDatavizLime900) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard100, other.paletteDatavizMustard100) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard200, other.paletteDatavizMustard200) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard300, other.paletteDatavizMustard300) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard400, other.paletteDatavizMustard400) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard50, other.paletteDatavizMustard50) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard500, other.paletteDatavizMustard500) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard600, other.paletteDatavizMustard600) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard700, other.paletteDatavizMustard700) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard800, other.paletteDatavizMustard800) &&
+            const DeepCollectionEquality().equals(paletteDatavizMustard900, other.paletteDatavizMustard900) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby100, other.paletteDatavizRuby100) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby200, other.paletteDatavizRuby200) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby300, other.paletteDatavizRuby300) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby400, other.paletteDatavizRuby400) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby50, other.paletteDatavizRuby50) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby500, other.paletteDatavizRuby500) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby600, other.paletteDatavizRuby600) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby700, other.paletteDatavizRuby700) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby800, other.paletteDatavizRuby800) &&
+            const DeepCollectionEquality().equals(paletteDatavizRuby900, other.paletteDatavizRuby900) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine100, other.paletteDatavizTangerine100) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine200, other.paletteDatavizTangerine200) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine300, other.paletteDatavizTangerine300) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine400, other.paletteDatavizTangerine400) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine50, other.paletteDatavizTangerine50) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine500, other.paletteDatavizTangerine500) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine600, other.paletteDatavizTangerine600) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine700, other.paletteDatavizTangerine700) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine800, other.paletteDatavizTangerine800) &&
+            const DeepCollectionEquality().equals(paletteDatavizTangerine900, other.paletteDatavizTangerine900) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue100, other.paletteSemanticBlue100) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue1000, other.paletteSemanticBlue1000) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue150, other.paletteSemanticBlue150) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue200, other.paletteSemanticBlue200) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue25, other.paletteSemanticBlue25) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue300, other.paletteSemanticBlue300) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue400, other.paletteSemanticBlue400) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue50, other.paletteSemanticBlue50) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue500, other.paletteSemanticBlue500) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue600, other.paletteSemanticBlue600) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue700, other.paletteSemanticBlue700) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue800, other.paletteSemanticBlue800) &&
+            const DeepCollectionEquality().equals(paletteSemanticBlue900, other.paletteSemanticBlue900) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen100, other.paletteSemanticGreen100) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen1000, other.paletteSemanticGreen1000) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen150, other.paletteSemanticGreen150) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen200, other.paletteSemanticGreen200) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen25, other.paletteSemanticGreen25) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen300, other.paletteSemanticGreen300) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen400, other.paletteSemanticGreen400) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen50, other.paletteSemanticGreen50) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen500, other.paletteSemanticGreen500) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen600, other.paletteSemanticGreen600) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen700, other.paletteSemanticGreen700) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen800, other.paletteSemanticGreen800) &&
+            const DeepCollectionEquality().equals(paletteSemanticGreen900, other.paletteSemanticGreen900) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange100, other.paletteSemanticOrange100) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange1000, other.paletteSemanticOrange1000) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange150, other.paletteSemanticOrange150) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange200, other.paletteSemanticOrange200) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange25, other.paletteSemanticOrange25) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange300, other.paletteSemanticOrange300) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange400, other.paletteSemanticOrange400) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange50, other.paletteSemanticOrange50) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange500, other.paletteSemanticOrange500) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange600, other.paletteSemanticOrange600) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange700, other.paletteSemanticOrange700) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange800, other.paletteSemanticOrange800) &&
+            const DeepCollectionEquality().equals(paletteSemanticOrange900, other.paletteSemanticOrange900) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed100, other.paletteSemanticRed100) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed1000, other.paletteSemanticRed1000) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed150, other.paletteSemanticRed150) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed200, other.paletteSemanticRed200) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed25, other.paletteSemanticRed25) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed300, other.paletteSemanticRed300) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed400, other.paletteSemanticRed400) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed50, other.paletteSemanticRed50) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed500, other.paletteSemanticRed500) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed600, other.paletteSemanticRed600) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed700, other.paletteSemanticRed700) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed800, other.paletteSemanticRed800) &&
+            const DeepCollectionEquality().equals(paletteSemanticRed900, other.paletteSemanticRed900) &&
+            const DeepCollectionEquality().equals(staticContainerColor, other.staticContainerColor) &&
+            const DeepCollectionEquality().equals(staticDividerColor, other.staticDividerColor) &&
+            const DeepCollectionEquality().equals(textAlertBasic, other.textAlertBasic) &&
+            const DeepCollectionEquality().equals(textAlertDanger, other.textAlertDanger) &&
+            const DeepCollectionEquality().equals(textAlertInfo, other.textAlertInfo) &&
+            const DeepCollectionEquality().equals(textAlertSuccess, other.textAlertSuccess) &&
+            const DeepCollectionEquality().equals(textAlertWarning, other.textAlertWarning) &&
+            const DeepCollectionEquality().equals(textDisabled, other.textDisabled) &&
+            const DeepCollectionEquality().equals(textInteractiveActive, other.textInteractiveActive) &&
+            const DeepCollectionEquality().equals(textInteractiveDefault, other.textInteractiveDefault) &&
+            const DeepCollectionEquality().equals(textInteractiveHover, other.textInteractiveHover) &&
+            const DeepCollectionEquality().equals(textStaticError, other.textStaticError) &&
+            const DeepCollectionEquality().equals(textStaticInverse, other.textStaticInverse) &&
+            const DeepCollectionEquality().equals(textStaticPrimary, other.textStaticPrimary) &&
+            const DeepCollectionEquality().equals(textStaticSecondary, other.textStaticSecondary) &&
+            const DeepCollectionEquality().equals(textStaticTertiary, other.textStaticTertiary));
   }
 
   @override
   int get hashCode {
-    return Object.hash(
+    return Object.hashAll([
       runtimeType.hashCode,
       const DeepCollectionEquality().hash(backgroundAccentPrimary),
       const DeepCollectionEquality().hash(backgroundAccentSecondary),
       const DeepCollectionEquality().hash(backgroundAlertBasicPrimary),
+      const DeepCollectionEquality().hash(backgroundAlertBasicSecondary),
+      const DeepCollectionEquality().hash(backgroundAlertDangerPrimary),
+      const DeepCollectionEquality().hash(backgroundAlertDangerSecondary),
+      const DeepCollectionEquality().hash(backgroundAlertInfoPrimary),
+      const DeepCollectionEquality().hash(backgroundAlertInfoSecondary),
+      const DeepCollectionEquality().hash(backgroundAlertSuccessPrimary),
+      const DeepCollectionEquality().hash(backgroundAlertSuccessSecondary),
+      const DeepCollectionEquality().hash(backgroundAlertWarningPrimary),
+      const DeepCollectionEquality().hash(backgroundAlertWarningSecondary),
+      const DeepCollectionEquality().hash(backgroundBrand),
       const DeepCollectionEquality().hash(backgroundDisabled),
+      const DeepCollectionEquality().hash(backgroundInteractiveBoldActive),
+      const DeepCollectionEquality().hash(backgroundInteractiveBoldDefault),
+      const DeepCollectionEquality().hash(backgroundInteractiveBoldHover),
+      const DeepCollectionEquality().hash(backgroundInteractiveDangerActive),
+      const DeepCollectionEquality().hash(backgroundInteractiveDangerDefault),
+      const DeepCollectionEquality().hash(backgroundInteractiveDangerHover),
       const DeepCollectionEquality().hash(backgroundInteractivePrimaryActive),
       const DeepCollectionEquality().hash(backgroundInteractivePrimaryDefault),
       const DeepCollectionEquality().hash(backgroundInteractivePrimaryHover),
+      const DeepCollectionEquality().hash(backgroundInteractiveSecondaryActive),
+      const DeepCollectionEquality()
+          .hash(backgroundInteractiveSecondaryDefault),
+      const DeepCollectionEquality().hash(backgroundInteractiveSecondaryHover),
+      const DeepCollectionEquality().hash(backgroundInteractiveSubtleActive),
+      const DeepCollectionEquality().hash(backgroundInteractiveSubtleDefault),
+      const DeepCollectionEquality().hash(backgroundInteractiveSubtleHover),
+      const DeepCollectionEquality().hash(backgroundOverlay),
+      const DeepCollectionEquality().hash(backgroundStaticFlat),
+      const DeepCollectionEquality().hash(backgroundStaticFloating),
+      const DeepCollectionEquality().hash(backgroundStaticInverse),
+      const DeepCollectionEquality().hash(backgroundStaticRaised),
+      const DeepCollectionEquality().hash(backgroundStaticSunken),
+      const DeepCollectionEquality().hash(borderAlertBasic),
+      const DeepCollectionEquality().hash(borderAlertDanger),
+      const DeepCollectionEquality().hash(borderAlertInfo),
+      const DeepCollectionEquality().hash(borderAlertSuccess),
+      const DeepCollectionEquality().hash(borderAlertWarning),
+      const DeepCollectionEquality().hash(borderDisabled),
+      const DeepCollectionEquality().hash(borderInteractiveError),
+      const DeepCollectionEquality().hash(borderInteractiveFocus),
+      const DeepCollectionEquality().hash(borderInteractivePrimaryActive),
+      const DeepCollectionEquality().hash(borderInteractivePrimaryDefault),
+      const DeepCollectionEquality().hash(borderInteractivePrimaryHover),
+      const DeepCollectionEquality().hash(borderInteractiveSecondaryActive),
+      const DeepCollectionEquality().hash(borderInteractiveSecondaryHover),
+      const DeepCollectionEquality().hash(borderStaticInverse),
+      const DeepCollectionEquality().hash(borderStaticPrimary),
+      const DeepCollectionEquality().hash(borderStaticSecondary),
+      const DeepCollectionEquality().hash(inputActiveColor),
+      const DeepCollectionEquality().hash(inputDangerColor),
+      const DeepCollectionEquality().hash(inputDefaultColor),
+      const DeepCollectionEquality().hash(inputDisabledColor),
+      const DeepCollectionEquality().hash(inputHoverColor),
+      const DeepCollectionEquality().hash(inputInverseColor),
+      const DeepCollectionEquality().hash(interactiveDangerColor),
+      const DeepCollectionEquality().hash(interactiveDefaultColor),
+      const DeepCollectionEquality().hash(interactiveDisabledColor),
+      const DeepCollectionEquality().hash(interactiveHoverColor),
+      const DeepCollectionEquality().hash(interactiveInverseColor),
+      const DeepCollectionEquality().hash(paletteBasicsBlack),
+      const DeepCollectionEquality().hash(paletteBasicsWhite),
+      const DeepCollectionEquality().hash(paletteBasicsWhite64),
+      const DeepCollectionEquality().hash(paletteBrandCoral100),
+      const DeepCollectionEquality().hash(paletteBrandCoral1000),
+      const DeepCollectionEquality().hash(paletteBrandCoral150),
+      const DeepCollectionEquality().hash(paletteBrandCoral200),
+      const DeepCollectionEquality().hash(paletteBrandCoral25),
+      const DeepCollectionEquality().hash(paletteBrandCoral300),
+      const DeepCollectionEquality().hash(paletteBrandCoral400),
+      const DeepCollectionEquality().hash(paletteBrandCoral50),
+      const DeepCollectionEquality().hash(paletteBrandCoral500),
+      const DeepCollectionEquality().hash(paletteBrandCoral600),
+      const DeepCollectionEquality().hash(paletteBrandCoral700),
+      const DeepCollectionEquality().hash(paletteBrandCoral800),
+      const DeepCollectionEquality().hash(paletteBrandCoral900),
+      const DeepCollectionEquality().hash(paletteBrandGrey0),
+      const DeepCollectionEquality().hash(paletteBrandGrey100),
+      const DeepCollectionEquality().hash(paletteBrandGrey1000),
+      const DeepCollectionEquality().hash(paletteBrandGrey150),
+      const DeepCollectionEquality().hash(paletteBrandGrey200),
+      const DeepCollectionEquality().hash(paletteBrandGrey25),
+      const DeepCollectionEquality().hash(paletteBrandGrey300),
+      const DeepCollectionEquality().hash(paletteBrandGrey400),
+      const DeepCollectionEquality().hash(paletteBrandGrey50),
+      const DeepCollectionEquality().hash(paletteBrandGrey500),
+      const DeepCollectionEquality().hash(paletteBrandGrey600),
+      const DeepCollectionEquality().hash(paletteBrandGrey700),
+      const DeepCollectionEquality().hash(paletteBrandGrey800),
+      const DeepCollectionEquality().hash(paletteBrandGrey900),
+      const DeepCollectionEquality().hash(paletteBrandIndigo100),
+      const DeepCollectionEquality().hash(paletteBrandIndigo1000),
+      const DeepCollectionEquality().hash(paletteBrandIndigo150),
+      const DeepCollectionEquality().hash(paletteBrandIndigo200),
+      const DeepCollectionEquality().hash(paletteBrandIndigo25),
+      const DeepCollectionEquality().hash(paletteBrandIndigo300),
+      const DeepCollectionEquality().hash(paletteBrandIndigo400),
+      const DeepCollectionEquality().hash(paletteBrandIndigo50),
+      const DeepCollectionEquality().hash(paletteBrandIndigo500),
+      const DeepCollectionEquality().hash(paletteBrandIndigo600),
+      const DeepCollectionEquality().hash(paletteBrandIndigo700),
+      const DeepCollectionEquality().hash(paletteBrandIndigo800),
+      const DeepCollectionEquality().hash(paletteBrandIndigo900),
+      const DeepCollectionEquality().hash(paletteBrandNight0),
+      const DeepCollectionEquality().hash(paletteBrandNight100),
+      const DeepCollectionEquality().hash(paletteBrandNight1000),
+      const DeepCollectionEquality().hash(paletteBrandNight100012),
+      const DeepCollectionEquality().hash(paletteBrandNight100016),
+      const DeepCollectionEquality().hash(paletteBrandNight10008),
+      const DeepCollectionEquality().hash(paletteBrandNight150),
+      const DeepCollectionEquality().hash(paletteBrandNight200),
+      const DeepCollectionEquality().hash(paletteBrandNight25),
+      const DeepCollectionEquality().hash(paletteBrandNight300),
+      const DeepCollectionEquality().hash(paletteBrandNight400),
+      const DeepCollectionEquality().hash(paletteBrandNight50),
+      const DeepCollectionEquality().hash(paletteBrandNight500),
+      const DeepCollectionEquality().hash(paletteBrandNight600),
+      const DeepCollectionEquality().hash(paletteBrandNight700),
+      const DeepCollectionEquality().hash(paletteBrandNight800),
+      const DeepCollectionEquality().hash(paletteBrandNight900),
+      const DeepCollectionEquality().hash(paletteDatavizDenim100),
+      const DeepCollectionEquality().hash(paletteDatavizDenim200),
+      const DeepCollectionEquality().hash(paletteDatavizDenim300),
+      const DeepCollectionEquality().hash(paletteDatavizDenim400),
+      const DeepCollectionEquality().hash(paletteDatavizDenim50),
+      const DeepCollectionEquality().hash(paletteDatavizDenim500),
+      const DeepCollectionEquality().hash(paletteDatavizDenim600),
+      const DeepCollectionEquality().hash(paletteDatavizDenim700),
+      const DeepCollectionEquality().hash(paletteDatavizDenim800),
+      const DeepCollectionEquality().hash(paletteDatavizDenim900),
+      const DeepCollectionEquality().hash(paletteDatavizLavender100),
+      const DeepCollectionEquality().hash(paletteDatavizLavender200),
+      const DeepCollectionEquality().hash(paletteDatavizLavender300),
+      const DeepCollectionEquality().hash(paletteDatavizLavender400),
+      const DeepCollectionEquality().hash(paletteDatavizLavender50),
+      const DeepCollectionEquality().hash(paletteDatavizLavender500),
+      const DeepCollectionEquality().hash(paletteDatavizLavender600),
+      const DeepCollectionEquality().hash(paletteDatavizLavender700),
+      const DeepCollectionEquality().hash(paletteDatavizLavender800),
+      const DeepCollectionEquality().hash(paletteDatavizLavender900),
+      const DeepCollectionEquality().hash(paletteDatavizLime100),
+      const DeepCollectionEquality().hash(paletteDatavizLime200),
+      const DeepCollectionEquality().hash(paletteDatavizLime300),
+      const DeepCollectionEquality().hash(paletteDatavizLime400),
+      const DeepCollectionEquality().hash(paletteDatavizLime50),
+      const DeepCollectionEquality().hash(paletteDatavizLime500),
+      const DeepCollectionEquality().hash(paletteDatavizLime600),
+      const DeepCollectionEquality().hash(paletteDatavizLime700),
+      const DeepCollectionEquality().hash(paletteDatavizLime800),
+      const DeepCollectionEquality().hash(paletteDatavizLime900),
+      const DeepCollectionEquality().hash(paletteDatavizMustard100),
+      const DeepCollectionEquality().hash(paletteDatavizMustard200),
+      const DeepCollectionEquality().hash(paletteDatavizMustard300),
+      const DeepCollectionEquality().hash(paletteDatavizMustard400),
+      const DeepCollectionEquality().hash(paletteDatavizMustard50),
+      const DeepCollectionEquality().hash(paletteDatavizMustard500),
+      const DeepCollectionEquality().hash(paletteDatavizMustard600),
+      const DeepCollectionEquality().hash(paletteDatavizMustard700),
+      const DeepCollectionEquality().hash(paletteDatavizMustard800),
+      const DeepCollectionEquality().hash(paletteDatavizMustard900),
+      const DeepCollectionEquality().hash(paletteDatavizRuby100),
+      const DeepCollectionEquality().hash(paletteDatavizRuby200),
+      const DeepCollectionEquality().hash(paletteDatavizRuby300),
+      const DeepCollectionEquality().hash(paletteDatavizRuby400),
+      const DeepCollectionEquality().hash(paletteDatavizRuby50),
+      const DeepCollectionEquality().hash(paletteDatavizRuby500),
+      const DeepCollectionEquality().hash(paletteDatavizRuby600),
+      const DeepCollectionEquality().hash(paletteDatavizRuby700),
+      const DeepCollectionEquality().hash(paletteDatavizRuby800),
+      const DeepCollectionEquality().hash(paletteDatavizRuby900),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine100),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine200),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine300),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine400),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine50),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine500),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine600),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine700),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine800),
+      const DeepCollectionEquality().hash(paletteDatavizTangerine900),
+      const DeepCollectionEquality().hash(paletteSemanticBlue100),
+      const DeepCollectionEquality().hash(paletteSemanticBlue1000),
+      const DeepCollectionEquality().hash(paletteSemanticBlue150),
+      const DeepCollectionEquality().hash(paletteSemanticBlue200),
+      const DeepCollectionEquality().hash(paletteSemanticBlue25),
+      const DeepCollectionEquality().hash(paletteSemanticBlue300),
+      const DeepCollectionEquality().hash(paletteSemanticBlue400),
+      const DeepCollectionEquality().hash(paletteSemanticBlue50),
+      const DeepCollectionEquality().hash(paletteSemanticBlue500),
+      const DeepCollectionEquality().hash(paletteSemanticBlue600),
+      const DeepCollectionEquality().hash(paletteSemanticBlue700),
+      const DeepCollectionEquality().hash(paletteSemanticBlue800),
+      const DeepCollectionEquality().hash(paletteSemanticBlue900),
+      const DeepCollectionEquality().hash(paletteSemanticGreen100),
+      const DeepCollectionEquality().hash(paletteSemanticGreen1000),
+      const DeepCollectionEquality().hash(paletteSemanticGreen150),
+      const DeepCollectionEquality().hash(paletteSemanticGreen200),
+      const DeepCollectionEquality().hash(paletteSemanticGreen25),
+      const DeepCollectionEquality().hash(paletteSemanticGreen300),
+      const DeepCollectionEquality().hash(paletteSemanticGreen400),
+      const DeepCollectionEquality().hash(paletteSemanticGreen50),
+      const DeepCollectionEquality().hash(paletteSemanticGreen500),
+      const DeepCollectionEquality().hash(paletteSemanticGreen600),
+      const DeepCollectionEquality().hash(paletteSemanticGreen700),
+      const DeepCollectionEquality().hash(paletteSemanticGreen800),
+      const DeepCollectionEquality().hash(paletteSemanticGreen900),
+      const DeepCollectionEquality().hash(paletteSemanticOrange100),
+      const DeepCollectionEquality().hash(paletteSemanticOrange1000),
+      const DeepCollectionEquality().hash(paletteSemanticOrange150),
+      const DeepCollectionEquality().hash(paletteSemanticOrange200),
+      const DeepCollectionEquality().hash(paletteSemanticOrange25),
+      const DeepCollectionEquality().hash(paletteSemanticOrange300),
+      const DeepCollectionEquality().hash(paletteSemanticOrange400),
+      const DeepCollectionEquality().hash(paletteSemanticOrange50),
+      const DeepCollectionEquality().hash(paletteSemanticOrange500),
+      const DeepCollectionEquality().hash(paletteSemanticOrange600),
+      const DeepCollectionEquality().hash(paletteSemanticOrange700),
+      const DeepCollectionEquality().hash(paletteSemanticOrange800),
+      const DeepCollectionEquality().hash(paletteSemanticOrange900),
+      const DeepCollectionEquality().hash(paletteSemanticRed100),
+      const DeepCollectionEquality().hash(paletteSemanticRed1000),
+      const DeepCollectionEquality().hash(paletteSemanticRed150),
+      const DeepCollectionEquality().hash(paletteSemanticRed200),
+      const DeepCollectionEquality().hash(paletteSemanticRed25),
+      const DeepCollectionEquality().hash(paletteSemanticRed300),
+      const DeepCollectionEquality().hash(paletteSemanticRed400),
+      const DeepCollectionEquality().hash(paletteSemanticRed50),
+      const DeepCollectionEquality().hash(paletteSemanticRed500),
+      const DeepCollectionEquality().hash(paletteSemanticRed600),
+      const DeepCollectionEquality().hash(paletteSemanticRed700),
+      const DeepCollectionEquality().hash(paletteSemanticRed800),
+      const DeepCollectionEquality().hash(paletteSemanticRed900),
+      const DeepCollectionEquality().hash(staticContainerColor),
+      const DeepCollectionEquality().hash(staticDividerColor),
+      const DeepCollectionEquality().hash(textAlertBasic),
+      const DeepCollectionEquality().hash(textAlertDanger),
+      const DeepCollectionEquality().hash(textAlertInfo),
+      const DeepCollectionEquality().hash(textAlertSuccess),
+      const DeepCollectionEquality().hash(textAlertWarning),
+      const DeepCollectionEquality().hash(textDisabled),
+      const DeepCollectionEquality().hash(textInteractiveActive),
+      const DeepCollectionEquality().hash(textInteractiveDefault),
+      const DeepCollectionEquality().hash(textInteractiveHover),
+      const DeepCollectionEquality().hash(textStaticError),
       const DeepCollectionEquality().hash(textStaticInverse),
-    );
+      const DeepCollectionEquality().hash(textStaticPrimary),
+      const DeepCollectionEquality().hash(textStaticSecondary),
+      const DeepCollectionEquality().hash(textStaticTertiary),
+    ]);
   }
 }

--- a/optimus/lib/src/theme/optimus_tokens.tailor.dart
+++ b/optimus/lib/src/theme/optimus_tokens.tailor.dart
@@ -58,6 +58,7 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
     required this.borderInteractivePrimaryDefault,
     required this.borderInteractivePrimaryHover,
     required this.borderInteractiveSecondaryActive,
+    required this.borderInteractiveSecondaryDefault,
     required this.borderInteractiveSecondaryHover,
     required this.borderStaticInverse,
     required this.borderStaticPrimary,
@@ -310,6 +311,7 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
   final Color borderInteractivePrimaryDefault;
   final Color borderInteractivePrimaryHover;
   final Color borderInteractiveSecondaryActive;
+  final Color borderInteractiveSecondaryDefault;
   final Color borderInteractiveSecondaryHover;
   final Color borderStaticInverse;
   final Color borderStaticPrimary;
@@ -589,6 +591,8 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
         _$OptimusTokens.borderInteractivePrimaryHover[0],
     borderInteractiveSecondaryActive:
         _$OptimusTokens.borderInteractiveSecondaryActive[0],
+    borderInteractiveSecondaryDefault:
+        _$OptimusTokens.borderInteractiveSecondaryDefault[0],
     borderInteractiveSecondaryHover:
         _$OptimusTokens.borderInteractiveSecondaryHover[0],
     borderStaticInverse: _$OptimusTokens.borderStaticInverse[0],
@@ -870,6 +874,8 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
         _$OptimusTokens.borderInteractivePrimaryHover[1],
     borderInteractiveSecondaryActive:
         _$OptimusTokens.borderInteractiveSecondaryActive[1],
+    borderInteractiveSecondaryDefault:
+        _$OptimusTokens.borderInteractiveSecondaryDefault[1],
     borderInteractiveSecondaryHover:
         _$OptimusTokens.borderInteractiveSecondaryHover[1],
     borderStaticInverse: _$OptimusTokens.borderStaticInverse[1],
@@ -1130,6 +1136,7 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
     Color? borderInteractivePrimaryDefault,
     Color? borderInteractivePrimaryHover,
     Color? borderInteractiveSecondaryActive,
+    Color? borderInteractiveSecondaryDefault,
     Color? borderInteractiveSecondaryHover,
     Color? borderStaticInverse,
     Color? borderStaticPrimary,
@@ -1423,6 +1430,8 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
           borderInteractivePrimaryHover ?? this.borderInteractivePrimaryHover,
       borderInteractiveSecondaryActive: borderInteractiveSecondaryActive ??
           this.borderInteractiveSecondaryActive,
+      borderInteractiveSecondaryDefault: borderInteractiveSecondaryDefault ??
+          this.borderInteractiveSecondaryDefault,
       borderInteractiveSecondaryHover: borderInteractiveSecondaryHover ??
           this.borderInteractiveSecondaryHover,
       borderStaticInverse: borderStaticInverse ?? this.borderStaticInverse,
@@ -1892,6 +1901,10 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
       borderInteractiveSecondaryActive: Color.lerp(
           borderInteractiveSecondaryActive,
           other.borderInteractiveSecondaryActive,
+          t)!,
+      borderInteractiveSecondaryDefault: Color.lerp(
+          borderInteractiveSecondaryDefault,
+          other.borderInteractiveSecondaryDefault,
           t)!,
       borderInteractiveSecondaryHover: Color.lerp(
           borderInteractiveSecondaryHover,
@@ -2387,6 +2400,8 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
           'borderInteractivePrimaryHover', borderInteractivePrimaryHover))
       ..add(DiagnosticsProperty(
           'borderInteractiveSecondaryActive', borderInteractiveSecondaryActive))
+      ..add(DiagnosticsProperty('borderInteractiveSecondaryDefault',
+          borderInteractiveSecondaryDefault))
       ..add(DiagnosticsProperty(
           'borderInteractiveSecondaryHover', borderInteractiveSecondaryHover))
       ..add(DiagnosticsProperty('borderStaticInverse', borderStaticInverse))
@@ -2756,6 +2771,7 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
             const DeepCollectionEquality().equals(borderInteractivePrimaryDefault, other.borderInteractivePrimaryDefault) &&
             const DeepCollectionEquality().equals(borderInteractivePrimaryHover, other.borderInteractivePrimaryHover) &&
             const DeepCollectionEquality().equals(borderInteractiveSecondaryActive, other.borderInteractiveSecondaryActive) &&
+            const DeepCollectionEquality().equals(borderInteractiveSecondaryDefault, other.borderInteractiveSecondaryDefault) &&
             const DeepCollectionEquality().equals(borderInteractiveSecondaryHover, other.borderInteractiveSecondaryHover) &&
             const DeepCollectionEquality().equals(borderStaticInverse, other.borderStaticInverse) &&
             const DeepCollectionEquality().equals(borderStaticPrimary, other.borderStaticPrimary) &&
@@ -3013,6 +3029,7 @@ class OptimusTokens extends ThemeExtension<OptimusTokens>
       const DeepCollectionEquality().hash(borderInteractivePrimaryDefault),
       const DeepCollectionEquality().hash(borderInteractivePrimaryHover),
       const DeepCollectionEquality().hash(borderInteractiveSecondaryActive),
+      const DeepCollectionEquality().hash(borderInteractiveSecondaryDefault),
       const DeepCollectionEquality().hash(borderInteractiveSecondaryHover),
       const DeepCollectionEquality().hash(borderStaticInverse),
       const DeepCollectionEquality().hash(borderStaticPrimary),

--- a/optimus/lib/src/theme/optimus_tokens.tailor.dart
+++ b/optimus/lib/src/theme/optimus_tokens.tailor.dart
@@ -1,0 +1,186 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_element, unnecessary_cast
+
+part of 'optimus_tokens.dart';
+
+// **************************************************************************
+// TailorAnnotationsGenerator
+// **************************************************************************
+
+class OptimusTokens extends ThemeExtension<OptimusTokens>
+    with DiagnosticableTreeMixin {
+  const OptimusTokens({
+    required this.backgroundAccentPrimary,
+    required this.backgroundAccentSecondary,
+    required this.backgroundAlertBasicPrimary,
+    required this.backgroundDisabled,
+    required this.backgroundInteractivePrimaryActive,
+    required this.backgroundInteractivePrimaryDefault,
+    required this.backgroundInteractivePrimaryHover,
+    required this.textStaticInverse,
+  });
+
+  final Color backgroundAccentPrimary;
+  final Color backgroundAccentSecondary;
+  final Color backgroundAlertBasicPrimary;
+  final Color backgroundDisabled;
+  final Color backgroundInteractivePrimaryActive;
+  final Color backgroundInteractivePrimaryDefault;
+  final Color backgroundInteractivePrimaryHover;
+  final Color textStaticInverse;
+
+  static final OptimusTokens light = OptimusTokens(
+    backgroundAccentPrimary: _$OptimusTokens.backgroundAccentPrimary[0],
+    backgroundAccentSecondary: _$OptimusTokens.backgroundAccentSecondary[0],
+    backgroundAlertBasicPrimary: _$OptimusTokens.backgroundAlertBasicPrimary[0],
+    backgroundDisabled: _$OptimusTokens.backgroundDisabled[0],
+    backgroundInteractivePrimaryActive:
+        _$OptimusTokens.backgroundInteractivePrimaryActive[0],
+    backgroundInteractivePrimaryDefault:
+        _$OptimusTokens.backgroundInteractivePrimaryDefault[0],
+    backgroundInteractivePrimaryHover:
+        _$OptimusTokens.backgroundInteractivePrimaryHover[0],
+    textStaticInverse: _$OptimusTokens.textStaticInverse[0],
+  );
+
+  static final OptimusTokens dark = OptimusTokens(
+    backgroundAccentPrimary: _$OptimusTokens.backgroundAccentPrimary[1],
+    backgroundAccentSecondary: _$OptimusTokens.backgroundAccentSecondary[1],
+    backgroundAlertBasicPrimary: _$OptimusTokens.backgroundAlertBasicPrimary[1],
+    backgroundDisabled: _$OptimusTokens.backgroundDisabled[1],
+    backgroundInteractivePrimaryActive:
+        _$OptimusTokens.backgroundInteractivePrimaryActive[1],
+    backgroundInteractivePrimaryDefault:
+        _$OptimusTokens.backgroundInteractivePrimaryDefault[1],
+    backgroundInteractivePrimaryHover:
+        _$OptimusTokens.backgroundInteractivePrimaryHover[1],
+    textStaticInverse: _$OptimusTokens.textStaticInverse[1],
+  );
+
+  static final themes = [
+    light,
+    dark,
+  ];
+
+  @override
+  OptimusTokens copyWith({
+    Color? backgroundAccentPrimary,
+    Color? backgroundAccentSecondary,
+    Color? backgroundAlertBasicPrimary,
+    Color? backgroundDisabled,
+    Color? backgroundInteractivePrimaryActive,
+    Color? backgroundInteractivePrimaryDefault,
+    Color? backgroundInteractivePrimaryHover,
+    Color? textStaticInverse,
+  }) {
+    return OptimusTokens(
+      backgroundAccentPrimary:
+          backgroundAccentPrimary ?? this.backgroundAccentPrimary,
+      backgroundAccentSecondary:
+          backgroundAccentSecondary ?? this.backgroundAccentSecondary,
+      backgroundAlertBasicPrimary:
+          backgroundAlertBasicPrimary ?? this.backgroundAlertBasicPrimary,
+      backgroundDisabled: backgroundDisabled ?? this.backgroundDisabled,
+      backgroundInteractivePrimaryActive: backgroundInteractivePrimaryActive ??
+          this.backgroundInteractivePrimaryActive,
+      backgroundInteractivePrimaryDefault:
+          backgroundInteractivePrimaryDefault ??
+              this.backgroundInteractivePrimaryDefault,
+      backgroundInteractivePrimaryHover: backgroundInteractivePrimaryHover ??
+          this.backgroundInteractivePrimaryHover,
+      textStaticInverse: textStaticInverse ?? this.textStaticInverse,
+    );
+  }
+
+  @override
+  OptimusTokens lerp(covariant ThemeExtension<OptimusTokens>? other, double t) {
+    if (other is! OptimusTokens) return this as OptimusTokens;
+    return OptimusTokens(
+      backgroundAccentPrimary: Color.lerp(
+          backgroundAccentPrimary, other.backgroundAccentPrimary, t)!,
+      backgroundAccentSecondary: Color.lerp(
+          backgroundAccentSecondary, other.backgroundAccentSecondary, t)!,
+      backgroundAlertBasicPrimary: Color.lerp(
+          backgroundAlertBasicPrimary, other.backgroundAlertBasicPrimary, t)!,
+      backgroundDisabled:
+          Color.lerp(backgroundDisabled, other.backgroundDisabled, t)!,
+      backgroundInteractivePrimaryActive: Color.lerp(
+          backgroundInteractivePrimaryActive,
+          other.backgroundInteractivePrimaryActive,
+          t)!,
+      backgroundInteractivePrimaryDefault: Color.lerp(
+          backgroundInteractivePrimaryDefault,
+          other.backgroundInteractivePrimaryDefault,
+          t)!,
+      backgroundInteractivePrimaryHover: Color.lerp(
+          backgroundInteractivePrimaryHover,
+          other.backgroundInteractivePrimaryHover,
+          t)!,
+      textStaticInverse:
+          Color.lerp(textStaticInverse, other.textStaticInverse, t)!,
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'OptimusTokens'))
+      ..add(DiagnosticsProperty(
+          'backgroundAccentPrimary', backgroundAccentPrimary))
+      ..add(DiagnosticsProperty(
+          'backgroundAccentSecondary', backgroundAccentSecondary))
+      ..add(DiagnosticsProperty(
+          'backgroundAlertBasicPrimary', backgroundAlertBasicPrimary))
+      ..add(DiagnosticsProperty('backgroundDisabled', backgroundDisabled))
+      ..add(DiagnosticsProperty('backgroundInteractivePrimaryActive',
+          backgroundInteractivePrimaryActive))
+      ..add(DiagnosticsProperty('backgroundInteractivePrimaryDefault',
+          backgroundInteractivePrimaryDefault))
+      ..add(DiagnosticsProperty('backgroundInteractivePrimaryHover',
+          backgroundInteractivePrimaryHover))
+      ..add(DiagnosticsProperty('textStaticInverse', textStaticInverse));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is OptimusTokens &&
+            const DeepCollectionEquality().equals(
+                backgroundAccentPrimary, other.backgroundAccentPrimary) &&
+            const DeepCollectionEquality().equals(
+                backgroundAccentSecondary, other.backgroundAccentSecondary) &&
+            const DeepCollectionEquality().equals(backgroundAlertBasicPrimary,
+                other.backgroundAlertBasicPrimary) &&
+            const DeepCollectionEquality()
+                .equals(backgroundDisabled, other.backgroundDisabled) &&
+            const DeepCollectionEquality().equals(
+                backgroundInteractivePrimaryActive,
+                other.backgroundInteractivePrimaryActive) &&
+            const DeepCollectionEquality().equals(
+                backgroundInteractivePrimaryDefault,
+                other.backgroundInteractivePrimaryDefault) &&
+            const DeepCollectionEquality().equals(
+                backgroundInteractivePrimaryHover,
+                other.backgroundInteractivePrimaryHover) &&
+            const DeepCollectionEquality()
+                .equals(textStaticInverse, other.textStaticInverse));
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      runtimeType.hashCode,
+      const DeepCollectionEquality().hash(backgroundAccentPrimary),
+      const DeepCollectionEquality().hash(backgroundAccentSecondary),
+      const DeepCollectionEquality().hash(backgroundAlertBasicPrimary),
+      const DeepCollectionEquality().hash(backgroundDisabled),
+      const DeepCollectionEquality().hash(backgroundInteractivePrimaryActive),
+      const DeepCollectionEquality().hash(backgroundInteractivePrimaryDefault),
+      const DeepCollectionEquality().hash(backgroundInteractivePrimaryHover),
+      const DeepCollectionEquality().hash(textStaticInverse),
+    );
+  }
+}

--- a/optimus/lib/src/theme/theme.dart
+++ b/optimus/lib/src/theme/theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:optimus/src/colors/colors.dart';
+import 'package:optimus/src/theme/optimus_tokens.dart';
 import 'package:optimus/src/theme/theme_data.dart';
 
 class OptimusTheme extends StatelessWidget {
@@ -60,11 +61,18 @@ final _defaultDarkTheme = _createTheme(Brightness.dark);
 
 OptimusThemeData _createTheme(Brightness brightness) {
   final colors = OptimusColors(brightness);
+  final tokens =
+      brightness == Brightness.dark ? OptimusTokens.dark : OptimusTokens.light;
 
   return OptimusThemeData(
     brightness: brightness,
     colors: colors,
+    tokens: tokens,
   );
+}
+
+extension ThemeTokens on BuildContext {
+  OptimusTokens get tokens => OptimusTheme.of(this).tokens;
 }
 
 mixin ThemeGetter<T extends StatefulWidget> on State<T> {

--- a/optimus/lib/src/theme/theme_data.dart
+++ b/optimus/lib/src/theme/theme_data.dart
@@ -1,7 +1,7 @@
-import 'dart:ui';
-
+import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:optimus/src/colors/colors.dart';
+import 'package:optimus/src/theme/optimus_tokens.dart';
 
 part 'theme_data.freezed.dart';
 
@@ -10,6 +10,7 @@ class OptimusThemeData with _$OptimusThemeData {
   const factory OptimusThemeData({
     required Brightness brightness,
     required OptimusColors colors,
+    required OptimusTokens tokens,
   }) = _OptimusThemeData;
 
   const OptimusThemeData._();

--- a/optimus/lib/src/theme/theme_data.freezed.dart
+++ b/optimus/lib/src/theme/theme_data.freezed.dart
@@ -12,28 +12,13 @@ part of 'theme_data.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
-
-/// @nodoc
-class _$OptimusThemeDataTearOff {
-  const _$OptimusThemeDataTearOff();
-
-  _OptimusThemeData call(
-      {required Brightness brightness, required OptimusColors colors}) {
-    return _OptimusThemeData(
-      brightness: brightness,
-      colors: colors,
-    );
-  }
-}
-
-/// @nodoc
-const $OptimusThemeData = _$OptimusThemeDataTearOff();
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
 mixin _$OptimusThemeData {
   Brightness get brightness => throw _privateConstructorUsedError;
   OptimusColors get colors => throw _privateConstructorUsedError;
+  OptimusTokens get tokens => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $OptimusThemeDataCopyWith<OptimusThemeData> get copyWith =>
@@ -44,72 +29,86 @@ mixin _$OptimusThemeData {
 abstract class $OptimusThemeDataCopyWith<$Res> {
   factory $OptimusThemeDataCopyWith(
           OptimusThemeData value, $Res Function(OptimusThemeData) then) =
-      _$OptimusThemeDataCopyWithImpl<$Res>;
-  $Res call({Brightness brightness, OptimusColors colors});
+      _$OptimusThemeDataCopyWithImpl<$Res, OptimusThemeData>;
+  @useResult
+  $Res call(
+      {Brightness brightness, OptimusColors colors, OptimusTokens tokens});
 }
 
 /// @nodoc
-class _$OptimusThemeDataCopyWithImpl<$Res>
+class _$OptimusThemeDataCopyWithImpl<$Res, $Val extends OptimusThemeData>
     implements $OptimusThemeDataCopyWith<$Res> {
   _$OptimusThemeDataCopyWithImpl(this._value, this._then);
 
-  final OptimusThemeData _value;
   // ignore: unused_field
-  final $Res Function(OptimusThemeData) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? brightness = freezed,
-    Object? colors = freezed,
+    Object? brightness = null,
+    Object? colors = null,
+    Object? tokens = null,
   }) {
     return _then(_value.copyWith(
-      brightness: brightness == freezed
+      brightness: null == brightness
           ? _value.brightness
           : brightness // ignore: cast_nullable_to_non_nullable
               as Brightness,
-      colors: colors == freezed
+      colors: null == colors
           ? _value.colors
           : colors // ignore: cast_nullable_to_non_nullable
               as OptimusColors,
-    ));
+      tokens: null == tokens
+          ? _value.tokens
+          : tokens // ignore: cast_nullable_to_non_nullable
+              as OptimusTokens,
+    ) as $Val);
   }
 }
 
 /// @nodoc
-abstract class _$OptimusThemeDataCopyWith<$Res>
+abstract class _$$_OptimusThemeDataCopyWith<$Res>
     implements $OptimusThemeDataCopyWith<$Res> {
-  factory _$OptimusThemeDataCopyWith(
-          _OptimusThemeData value, $Res Function(_OptimusThemeData) then) =
-      __$OptimusThemeDataCopyWithImpl<$Res>;
+  factory _$$_OptimusThemeDataCopyWith(
+          _$_OptimusThemeData value, $Res Function(_$_OptimusThemeData) then) =
+      __$$_OptimusThemeDataCopyWithImpl<$Res>;
   @override
-  $Res call({Brightness brightness, OptimusColors colors});
+  @useResult
+  $Res call(
+      {Brightness brightness, OptimusColors colors, OptimusTokens tokens});
 }
 
 /// @nodoc
-class __$OptimusThemeDataCopyWithImpl<$Res>
-    extends _$OptimusThemeDataCopyWithImpl<$Res>
-    implements _$OptimusThemeDataCopyWith<$Res> {
-  __$OptimusThemeDataCopyWithImpl(
-      _OptimusThemeData _value, $Res Function(_OptimusThemeData) _then)
-      : super(_value, (v) => _then(v as _OptimusThemeData));
+class __$$_OptimusThemeDataCopyWithImpl<$Res>
+    extends _$OptimusThemeDataCopyWithImpl<$Res, _$_OptimusThemeData>
+    implements _$$_OptimusThemeDataCopyWith<$Res> {
+  __$$_OptimusThemeDataCopyWithImpl(
+      _$_OptimusThemeData _value, $Res Function(_$_OptimusThemeData) _then)
+      : super(_value, _then);
 
-  @override
-  _OptimusThemeData get _value => super._value as _OptimusThemeData;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? brightness = freezed,
-    Object? colors = freezed,
+    Object? brightness = null,
+    Object? colors = null,
+    Object? tokens = null,
   }) {
-    return _then(_OptimusThemeData(
-      brightness: brightness == freezed
+    return _then(_$_OptimusThemeData(
+      brightness: null == brightness
           ? _value.brightness
           : brightness // ignore: cast_nullable_to_non_nullable
               as Brightness,
-      colors: colors == freezed
+      colors: null == colors
           ? _value.colors
           : colors // ignore: cast_nullable_to_non_nullable
               as OptimusColors,
+      tokens: null == tokens
+          ? _value.tokens
+          : tokens // ignore: cast_nullable_to_non_nullable
+              as OptimusTokens,
     ));
   }
 }
@@ -117,45 +116,52 @@ class __$OptimusThemeDataCopyWithImpl<$Res>
 /// @nodoc
 
 class _$_OptimusThemeData extends _OptimusThemeData {
-  const _$_OptimusThemeData({required this.brightness, required this.colors})
+  const _$_OptimusThemeData(
+      {required this.brightness, required this.colors, required this.tokens})
       : super._();
 
   @override
   final Brightness brightness;
   @override
   final OptimusColors colors;
+  @override
+  final OptimusTokens tokens;
 
   @override
   String toString() {
-    return 'OptimusThemeData(brightness: $brightness, colors: $colors)';
+    return 'OptimusThemeData(brightness: $brightness, colors: $colors, tokens: $tokens)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _OptimusThemeData &&
+            other is _$_OptimusThemeData &&
             const DeepCollectionEquality()
                 .equals(other.brightness, brightness) &&
-            const DeepCollectionEquality().equals(other.colors, colors));
+            (identical(other.colors, colors) || other.colors == colors) &&
+            const DeepCollectionEquality().equals(other.tokens, tokens));
   }
 
   @override
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(brightness),
-      const DeepCollectionEquality().hash(colors));
+      colors,
+      const DeepCollectionEquality().hash(tokens));
 
   @JsonKey(ignore: true)
   @override
-  _$OptimusThemeDataCopyWith<_OptimusThemeData> get copyWith =>
-      __$OptimusThemeDataCopyWithImpl<_OptimusThemeData>(this, _$identity);
+  @pragma('vm:prefer-inline')
+  _$$_OptimusThemeDataCopyWith<_$_OptimusThemeData> get copyWith =>
+      __$$_OptimusThemeDataCopyWithImpl<_$_OptimusThemeData>(this, _$identity);
 }
 
 abstract class _OptimusThemeData extends OptimusThemeData {
   const factory _OptimusThemeData(
-      {required Brightness brightness,
-      required OptimusColors colors}) = _$_OptimusThemeData;
+      {required final Brightness brightness,
+      required final OptimusColors colors,
+      required final OptimusTokens tokens}) = _$_OptimusThemeData;
   const _OptimusThemeData._() : super._();
 
   @override
@@ -163,7 +169,9 @@ abstract class _OptimusThemeData extends OptimusThemeData {
   @override
   OptimusColors get colors;
   @override
+  OptimusTokens get tokens;
+  @override
   @JsonKey(ignore: true)
-  _$OptimusThemeDataCopyWith<_OptimusThemeData> get copyWith =>
+  _$$_OptimusThemeDataCopyWith<_$_OptimusThemeData> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/optimus/lib/src/tokens/tokens_color_dark.dart
+++ b/optimus/lib/src/tokens/tokens_color_dark.dart
@@ -7,8 +7,8 @@
 
 import 'dart:ui';
 
-class DesignTokensColor {
-  const DesignTokensColor._();
+class DesignTokensColorDark {
+  const DesignTokensColorDark._();
 
   static const backgroundAccentPrimary = Color(0xFF524FF2);
   static const backgroundAccentSecondary = Color(0xFFF20010);

--- a/optimus/lib/src/tokens/tokens_color_light.dart
+++ b/optimus/lib/src/tokens/tokens_color_light.dart
@@ -7,8 +7,8 @@
 
 import 'dart:ui';
 
-class DesignTokensColor {
-  const DesignTokensColor._();
+class DesignTokensColorLight {
+  const DesignTokensColorLight._();
 
   static const backgroundAccentPrimary = Color(0xFF3B37F2);
   static const backgroundAccentSecondary = Color(0xFFFD424F);

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter_slidable: ">=1.2.0 <4.0.0"
   freezed_annotation: ">=1.0.0 <3.0.0"
   intl: ">=0.17.0 <0.19.0"
+  theme_tailor_annotation: ^2.0.0
 
 dev_dependencies:
   build_runner: ^2.0.4
@@ -20,6 +21,7 @@ dev_dependencies:
     sdk: flutter
   freezed: ">=1.0.0 <3.0.0"
   mews_pedantic: ^0.15.0
+  theme_tailor: ^2.0.0
 flutter:
   fonts:
     - family: Inter

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -35,3 +35,6 @@ flutter:
     - family: OptimusIcons
       fonts:
         - asset: packages/optimus/fonts/OptimusIcons.ttf
+
+dependency_overrides:
+  analyzer: 5.12.0

--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -163,10 +163,11 @@ packages:
   mews_pedantic:
     dependency: "direct dev"
     description:
-      path: "../mews_pedantic"
-      relative: true
-    source: path
-    version: "0.15.0-dev.0"
+      name: mews_pedantic
+      sha256: b1e57633e02789e54bf4db54b1a5ce4d6e2df3c9d7458d9cb48b7a1c731094df
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.0"
   nested:
     dependency: transitive
     description:
@@ -379,6 +380,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.16"
+  theme_tailor_annotation:
+    dependency: transitive
+    description:
+      name: theme_tailor_annotation
+      sha256: e75cf627202816cf4b45910658205959524860b99951bd0d370e760bf3546424
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
#### Summary

- Updated `OptimusTheme` and added an `OptimusTokens tokens` property, which will hold all tokens for light/dark theme.
- `OptimusTokens` is basically a `ThemeExtension` and I'm using `tailor` for the code generation.
- `OptimusTokens` could be overwritten with `copyWith`, this will enable custom theming. You need to wrap your stuff with `OptimusTheme` and provide your custom `OptimusTokens` for light and dark themes.

#### Testing steps

None. A prerequired PR for later tokens integration directly into components.

#### Follow-up issues
- I had to override `analyzer` to `5.12.0`, because they have introduced a new type - `InvalidType` and broke some parts of the code generation. `dynamic` types would resolve to `InvalidType` and the current (latest) `theme_tailor` package is not supporting it yet. `freezed` has some problems with it as well.
- Testing?
- More code generation, from the design-tokens PR, to make this process less error-prone.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
