### PR TITLE
refactor: Change to named constructor

### DIFF
--- a/optimus/lib/optimus.dart
+++ b/optimus/lib/optimus.dart
@@ -112,12 +112,12 @@ ThemeData createOptimusMaterialTheme(Brightness brightness) => ThemeData(
         labelLarge: baseTextStyle,
         labelSmall: baseTextStyle,
       ),
-      cupertinoOverrideTheme: CupertinoThemeData.raw(
-        brightness,
-        Colors.blue,
-        Colors.blue,
-        const CupertinoTextThemeData(),
-        Colors.white,
-        Colors.white,
+      cupertinoOverrideTheme: CupertinoThemeData(
+        brightness: brightness,
+        primaryColor: Colors.blue,
+        primaryContrastingColor: Colors.blue,
+        textTheme: const CupertinoTextThemeData(),
+        barBackgroundColor: Colors.white,
+        scaffoldBackgroundColor: Colors.white,
       ),
     );


### PR DESCRIPTION
#### Summary

Changes from `CupertinoThemeData.raw` to `CupertinoThemeData`. 
This prevents migrating apps to flutter `3.10.5` since there's a new unnamed argument added.

#### Testing steps

Dev-tested.

#### Follow-up issues

No.

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
