### PR TITLE
build: Update Storybook dependencies

### DIFF
--- a/storybook/pubspec.lock
+++ b/storybook/pubspec.lock
@@ -166,7 +166,7 @@ packages:
       path: "../mews_pedantic"
       relative: true
     source: path
-    version: "0.15.0"
+    version: "0.16.0"
   nested:
     dependency: transitive
     description:
@@ -181,7 +181,7 @@ packages:
       path: "../optimus"
       relative: true
     source: path
-    version: "0.26.0+1"
+    version: "0.27.0"
   path:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
#### Summary

- bump Storybook deps to latest `optimus` and `mews_pedantic`

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
