### PR TITLE
feat!: [RND-177099] Update checkbox to use shared colors

### DIFF
--- a/optimus/lib/src/checkbox/checkbox.dart
+++ b/optimus/lib/src/checkbox/checkbox.dart
@@ -104,6 +104,7 @@ class _OptimusCheckboxState extends State<OptimusCheckbox> with ThemeGetter {
     if (!widget.isEnabled) return _InteractionState.disabled;
     if (_isTappedDown) return _InteractionState.active;
     if (_isHovering) return _InteractionState.hover;
+
     return _InteractionState.basic;
   }
 
@@ -118,6 +119,7 @@ class _OptimusCheckboxState extends State<OptimusCheckbox> with ThemeGetter {
 
   bool get _isError {
     final error = widget.error;
+
     return error != null && error.isNotEmpty;
   }
 

--- a/optimus/lib/src/checkbox/checkbox_group.dart
+++ b/optimus/lib/src/checkbox/checkbox_group.dart
@@ -58,8 +58,8 @@ class OptimusCheckboxGroup<T> extends StatelessWidget {
   Widget build(BuildContext context) => GroupWrapper(
         label: label,
         error: error,
-        child: OptimusEnabled(
-          isEnabled: isEnabled,
+        child: IgnorePointer(
+          ignoring: !isEnabled,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: _items
@@ -68,6 +68,7 @@ class OptimusCheckboxGroup<T> extends StatelessWidget {
                     isChecked: _values.contains(v.value),
                     size: size,
                     label: v.label,
+                    isEnabled: isEnabled,
                     onChanged: (checked) => _onChanged(v, checked),
                   ),
                 )

--- a/optimus/lib/src/checkbox/nested_checkbox.dart
+++ b/optimus/lib/src/checkbox/nested_checkbox.dart
@@ -17,7 +17,7 @@ class OptimusNestedCheckboxGroup extends StatelessWidget {
   });
 
   /// Children of this nested checkbox group.
-  final List<OptimusCheckbox> children;
+  final List<OptimusNestedCheckbox> children;
 
   /// Label displayed next to the parent checkbox. Typically a [Text] widget.
   final Widget parent;
@@ -48,32 +48,97 @@ class OptimusNestedCheckboxGroup extends StatelessWidget {
   Widget build(BuildContext context) => GroupWrapper(
         label: label,
         error: error,
-        child: OptimusEnabled(
-          isEnabled: isEnabled,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              OptimusCheckbox(
-                tristate: true,
-                isChecked: _isParentChecked,
-                label: parent,
-                onChanged: (bool value) {
-                  for (final child in children) {
-                    child.onChanged(value);
-                  }
-                },
-              ),
-              Padding(
-                padding: const EdgeInsets.only(left: spacing200),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: children,
+        child: IgnorePointer(
+          ignoring: !isEnabled,
+          child: NestedCheckboxData(
+            isEnabled: isEnabled,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                OptimusCheckbox(
+                  tristate: true,
+                  isEnabled: isEnabled,
+                  isChecked: _isParentChecked,
+                  label: parent,
+                  onChanged: (bool value) {
+                    for (final child in children) {
+                      child.onChanged(value);
+                    }
+                  },
                 ),
-              ),
-            ],
+                Padding(
+                  padding: const EdgeInsets.only(left: spacing200),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: children,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       );
+}
+
+/// A checkbox that is a part of a [OptimusNestedCheckboxGroup]. It is a wrapper
+/// around [OptimusCheckbox] that overrides it's [isEnabled] property with the
+/// value from the parent checkbox group.
+class OptimusNestedCheckbox extends StatelessWidget {
+  const OptimusNestedCheckbox({
+    super.key,
+    required this.label,
+    this.isChecked,
+    this.size = OptimusCheckboxSize.large,
+    this.isEnabled = true,
+    required this.onChanged,
+  });
+
+  /// {@macro optimus.checkbox.label}
+  final Widget label;
+
+  /// {@macro optimus.checkbox.isChecked}
+  final bool? isChecked;
+
+  /// {@macro optimus.checkbox.size}
+  final OptimusCheckboxSize size;
+
+  /// {@macro optimus.checkbox.onChanged}
+  final ValueChanged<bool> onChanged;
+
+  /// {@macro optimus.checkbox.isEnabled}
+  /// The value will be overridden by the parent of the checkbox group.
+  final bool isEnabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final isEnabled =
+        NestedCheckboxData.of(context)?.isEnabled ?? this.isEnabled;
+
+    return OptimusCheckbox(
+      label: label,
+      size: size,
+      tristate: false,
+      isEnabled: isEnabled,
+      isChecked: isChecked,
+      onChanged: onChanged,
+    );
+  }
+}
+
+class NestedCheckboxData extends InheritedWidget {
+  const NestedCheckboxData({
+    super.key,
+    required this.isEnabled,
+    required super.child,
+  });
+
+  final bool isEnabled;
+
+  static NestedCheckboxData? of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<NestedCheckboxData>();
+
+  @override
+  bool updateShouldNotify(NestedCheckboxData oldWidget) => true;
 }

--- a/optimus/lib/src/spacing.dart
+++ b/optimus/lib/src/spacing.dart
@@ -2,6 +2,7 @@ const double spacing0 = 0;
 const double spacing25 = 2;
 const double spacing50 = 4;
 const double spacing100 = 8;
+const double spacing150 = 12;
 const double spacing200 = 16;
 const double spacing300 = 24;
 const double spacing400 = 32;

--- a/storybook/lib/stories/checkbox.dart
+++ b/storybook/lib/stories/checkbox.dart
@@ -24,19 +24,24 @@ class _CheckboxStoryState extends State<_CheckboxStory> {
   Widget build(BuildContext context) {
     final k = widget.knobs;
 
-    return OptimusCheckbox(
-      label: Text(k.text(label: 'Label', initial: 'Checkbox Label')),
-      error: k.text(label: 'Error'),
-      isEnabled: k.boolean(label: 'Enabled', initial: true),
-      size: k.options(
-        label: 'Size',
-        options: OptimusCheckboxSize.values.toOptions(),
-        initial: OptimusCheckboxSize.large,
+    return Center(
+      child: SizedBox(
+        width: 400,
+        child: OptimusCheckbox(
+          label: Text(k.text(label: 'Label', initial: 'Checkbox Label')),
+          error: k.text(label: 'Error'),
+          isEnabled: k.boolean(label: 'Enabled', initial: true),
+          size: k.options(
+            label: 'Size',
+            options: OptimusCheckboxSize.values.toOptions(),
+            initial: OptimusCheckboxSize.large,
+          ),
+          isChecked: _checked,
+          onChanged: (b) => setState(() {
+            _checked = b;
+          }),
+        ),
       ),
-      isChecked: _checked,
-      onChanged: (b) => setState(() {
-        _checked = b;
-      }),
     );
   }
 }

--- a/storybook/lib/stories/checkbox_nested.dart
+++ b/storybook/lib/stories/checkbox_nested.dart
@@ -27,6 +27,8 @@ class _CheckboxGroupStoryState extends State<_CheckboxGroupStory> {
   Widget build(BuildContext context) {
     final k = widget.knobs;
 
+    final enabled = k.boolean(label: 'Enabled', initial: true);
+
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -34,6 +36,7 @@ class _CheckboxGroupStoryState extends State<_CheckboxGroupStory> {
           OptimusCheckbox(
             label: const Text('Outside Checkbox'),
             isChecked: _outsideCheckbox,
+            isEnabled: enabled,
             onChanged: (bool value) {
               setState(() {
                 _outsideCheckbox = value;
@@ -44,52 +47,33 @@ class _CheckboxGroupStoryState extends State<_CheckboxGroupStory> {
             parent: const Text('Parent'),
             label: k.text(label: 'Label:'),
             error: k.text(label: 'Error'),
-            isEnabled: k.boolean(label: 'Enabled', initial: true),
+            isEnabled: enabled,
             children: [
-              OptimusCheckbox(
+              OptimusNestedCheckbox(
                 label: const Text('Checkbox 1'),
                 isChecked: _values.first,
-                onChanged: (bool value) {
-                  setState(() {
-                    _values.first = value;
-                  });
-                },
+                onChanged: (bool value) =>
+                    setState(() => _values.first = value),
               ),
-              OptimusCheckbox(
+              OptimusNestedCheckbox(
                 label: const Text('Checkbox 2'),
                 isChecked: _values[1],
-                onChanged: (bool value) {
-                  setState(() {
-                    _values[1] = value;
-                  });
-                },
+                onChanged: (bool value) => setState(() => _values[1] = value),
               ),
-              OptimusCheckbox(
+              OptimusNestedCheckbox(
                 isChecked: _values[2],
                 label: const Text('Checkbox 3'),
-                onChanged: (bool value) {
-                  setState(() {
-                    _values[2] = value;
-                  });
-                },
+                onChanged: (bool value) => setState(() => _values[2] = value),
               ),
-              OptimusCheckbox(
+              OptimusNestedCheckbox(
                 isChecked: _values[3],
                 label: const Text('Checkbox 4'),
-                onChanged: (bool value) {
-                  setState(() {
-                    _values[3] = value;
-                  });
-                },
+                onChanged: (bool value) => setState(() => _values[3] = value),
               ),
-              OptimusCheckbox(
+              OptimusNestedCheckbox(
                 isChecked: _values.last,
                 label: const Text('Checkbox 5'),
-                onChanged: (bool value) {
-                  setState(() {
-                    _values.last = value;
-                  });
-                },
+                onChanged: (bool value) => setState(() => _values.last = value),
               ),
             ],
           ),


### PR DESCRIPTION
RND-177099
#### Summary

- updated checkbox to use shared colors
- the disabled state now has a dedicated color and is not using opacity, so I've replaced the `OptimusEnabled` and I've updated the `OptimusNestedCheckboxGroup` to follow this new style.
- added animation
- updated story
- **[BREAKING CHANGE]** `OptimusNestedCheckboxGroup` now uses `OptimusNestedCheckbox` which would override the `isEnabled` based on the parent status.

<details><summary>Video</summary>


https://github.com/MewsSystems/mews-flutter/assets/9210422/4cdbfd73-510f-4f47-842c-5c04c33186cc


</details>


#### Testing steps

- Open Storybook with checkbox story
- Check the checkbox in all states in light and dark theme

#### Follow-up issues

None


#### Check during review

- Verify against YouTrack issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
