### PR TITLE
build: Remove analyzer version override

### DIFF
--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -35,6 +35,4 @@ flutter:
     - family: OptimusIcons
       fonts:
         - asset: packages/optimus/fonts/OptimusIcons.ttf
-
-dependency_overrides:
-  analyzer: 5.12.0
+        


### PR DESCRIPTION
#### Summary

- Not ready for the major bump, but the `version_override` is not needed anymore.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
