### PR TITLE
ci: Install DCM using github action

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -10,13 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}  
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Install DCM
-        run: >
-          wget -qO- https://dcm.dev/pgp-key.public | sudo gpg --dearmor -o /usr/share/keyrings/dcm.gpg &&
-          echo 'deb [signed-by=/usr/share/keyrings/dcm.gpg arch=amd64] https://dcm.dev/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list &&
-          sudo apt-get update &&
-          sudo apt-get install dcm
+        uses: CQLabs/setup-dcm@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: "1.8.1"
 
       - uses: ./.github/actions/setup
 


### PR DESCRIPTION
#### Summary

Install DCM using official GitHub action and lock DCM version.

#### Testing steps

No.

#### Follow-up issues

No.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
