### PR TITLE
fix: Fix Badge overflowing

### DIFF
--- a/optimus/lib/src/badge/badge.dart
+++ b/optimus/lib/src/badge/badge.dart
@@ -9,6 +9,7 @@ class OptimusBadge extends StatelessWidget {
     super.key,
     this.text = '',
     this.outline = true,
+    this.overflow = TextOverflow.ellipsis,
   });
 
   /// Text of the badge. If empty, badge will be represented as a simple dot.
@@ -18,6 +19,11 @@ class OptimusBadge extends StatelessWidget {
   /// for example on top of the [OptimusButtonVariant.ghost]. Outlined version
   /// could be more accessible, depending on the underlying component.
   final bool outline;
+
+  /// Define how to display the overflowing text. Defaults to
+  /// [TextOverflow.ellipsis]. Due to small height of the badge, the
+  /// [TextOverflow.fade] is not recommended, as it makes the badge unreadable.
+  final TextOverflow overflow;
 
   @override
   Widget build(BuildContext context) => BaseBadge(text: text, outline: outline);

--- a/optimus/lib/src/badge/base_badge.dart
+++ b/optimus/lib/src/badge/base_badge.dart
@@ -8,6 +8,7 @@ class BaseBadge extends StatelessWidget {
     super.key,
     required this.text,
     required this.outline,
+    this.overflow = TextOverflow.ellipsis,
     this.backgroundColor,
     this.textColor,
     this.outlineColor,
@@ -15,6 +16,7 @@ class BaseBadge extends StatelessWidget {
 
   final String text;
   final bool outline;
+  final TextOverflow overflow;
   final Color? backgroundColor;
   final Color? textColor;
   final Color? outlineColor;
@@ -44,6 +46,8 @@ class BaseBadge extends StatelessWidget {
             children: [
               Text(
                 text,
+                maxLines: 1,
+                overflow: overflow,
                 textAlign: TextAlign.center,
                 style: baseTextStyle.copyWith(
                   fontSize: 11,


### PR DESCRIPTION
#### Summary

While working on the `OptimusTab` update I've noticed that `OptimusBadge`'s line count is not limited, which would lead to overflowing. Now the line count is limited to `1` and the `TextOverflow` behaviour could be defined when declaring the badge.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
