### PR TITLE
fix: [UX-283] Fix banner close icon overlapping

### DIFF
--- a/optimus/lib/src/banner.dart
+++ b/optimus/lib/src/banner.dart
@@ -66,101 +66,106 @@ class OptimusBanner extends StatelessWidget {
   /// Called when close button is pressed (if [isDismissible] == true).
   final VoidCallback? onDismiss;
 
+  Color _getDescriptionColor(OptimusThemeData theme) =>
+      theme.isDark ? theme.colors.neutral0 : theme.colors.neutral1000t64;
+
   @override
   Widget build(BuildContext context) {
     final theme = OptimusTheme.of(context);
-    final description = this.description;
 
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: _backgroundColor(theme),
+        color: variant.backgroundColor(theme),
         borderRadius: const BorderRadius.all(borderRadius100),
       ),
-      child: Padding(
-        padding: const EdgeInsets.only(left: 18),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            if (hasIcon)
-              Padding(
-                padding: const EdgeInsets.only(right: 18),
-                child: OptimusIcon(
-                  iconData: _icon,
-                  colorOption: _iconColor,
-                ),
-              ),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
+      child: Stack(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(spacing200),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (hasIcon)
+                  Padding(
+                    padding: const EdgeInsets.only(right: spacing200),
+                    child: OptimusIcon(
+                      iconData: variant.icon,
+                      colorOption: variant.iconColor,
+                    ),
+                  ),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Expanded(
-                        child: Padding(
-                          padding: EdgeInsets.only(
-                            bottom: description != null ? spacing50 : 10,
-                            top: 9,
-                          ),
-                          child: DefaultTextStyle.merge(
-                            child: title,
-                            style: preset300s,
-                          ),
+                      Padding(
+                        padding: EdgeInsets.only(
+                          right: isDismissible ? spacing200 : 0,
+                        ),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: DefaultTextStyle.merge(
+                                child: title,
+                                style: preset300s,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
-                      if (isDismissible)
-                        OptimusIconButton(
-                          onPressed: () => onDismiss,
-                          icon: const Icon(OptimusIcons.cross_close, size: 12),
-                          size: OptimusWidgetSize.small,
-                          variant: OptimusButtonVariant.ghost,
+                      if (description case final description?)
+                        Padding(
+                          padding: const EdgeInsets.only(top: spacing50),
+                          child: DefaultTextStyle.merge(
+                            child: description,
+                            style: preset200r.copyWith(
+                              color: _getDescriptionColor(theme),
+                            ),
+                          ),
                         ),
                     ],
                   ),
-                  if (description != null)
-                    Padding(
-                      padding: const EdgeInsets.only(
-                        top: spacing50,
-                        bottom: 10,
-                      ),
-                      child: DefaultTextStyle.merge(
-                        child: description,
-                        style: preset200r.copyWith(
-                          color: _getDescriptionColor(theme),
-                        ),
-                      ),
-                    ),
-                ],
+                ),
+              ],
+            ),
+          ),
+          if (isDismissible)
+            Positioned(
+              top: spacing100,
+              right: spacing100,
+              child: OptimusIconButton(
+                onPressed: () => onDismiss,
+                icon: const Icon(OptimusIcons.cross_close),
+                size: OptimusWidgetSize.small,
+                variant: OptimusButtonVariant.ghost,
               ),
             ),
-          ],
-        ),
+        ],
       ),
     );
   }
+}
 
-  IconData get _icon => switch (variant) {
+extension on OptimusBannerVariant {
+  IconData get icon => switch (this) {
         OptimusBannerVariant.primary => OptimusIcons.info,
         OptimusBannerVariant.success => OptimusIcons.done_circle,
         OptimusBannerVariant.warning => OptimusIcons.problematic,
         OptimusBannerVariant.error => OptimusIcons.blacklist,
       };
 
-  OptimusIconColorOption get _iconColor => switch (variant) {
+  OptimusIconColorOption get iconColor => switch (this) {
         OptimusBannerVariant.primary => OptimusIconColorOption.primary,
         OptimusBannerVariant.success => OptimusIconColorOption.success,
         OptimusBannerVariant.warning => OptimusIconColorOption.warning,
         OptimusBannerVariant.error => OptimusIconColorOption.danger,
       };
 
-  Color _backgroundColor(OptimusThemeData theme) => switch (variant) {
+  Color backgroundColor(OptimusThemeData theme) => switch (this) {
         OptimusBannerVariant.primary => theme.colors.primary500t8,
         OptimusBannerVariant.success => theme.colors.success500t8,
         OptimusBannerVariant.warning => theme.colors.warning500t8,
         OptimusBannerVariant.error => theme.colors.danger500t8,
       };
-
-  Color _getDescriptionColor(OptimusThemeData theme) =>
-      theme.isDark ? theme.colors.neutral0 : theme.colors.neutral1000t64;
 }
 
 enum OptimusWideBannerVariant {

--- a/storybook/lib/stories/banner.dart
+++ b/storybook/lib/stories/banner.dart
@@ -9,24 +9,30 @@ final Story bannerStory = Story(
     final k = context.knobs;
     final title = k.text(label: 'Title', initial: 'Title');
     final description = k.text(label: 'Additional description', initial: '');
+    final width = k.slider(label: 'Width', initial: 400, max: 800, min: 200);
 
-    return SingleChildScrollView(
-      child: Column(
-        children: OptimusBannerVariant.values
-            .map(
-              (v) => Padding(
-                padding: const EdgeInsets.all(8),
-                child: OptimusBanner(
-                  title: Text(title),
-                  description:
-                      description.isNotEmpty ? Text(description) : null,
-                  hasIcon: k.boolean(label: 'Show icon'),
-                  isDismissible: k.boolean(label: 'Dismissible'),
-                  variant: v,
-                ),
-              ),
-            )
-            .toList(),
+    return Center(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: width),
+        child: SingleChildScrollView(
+          child: Column(
+            children: OptimusBannerVariant.values
+                .map(
+                  (v) => Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: OptimusBanner(
+                      title: Text(title),
+                      description:
+                          description.isNotEmpty ? Text(description) : null,
+                      hasIcon: k.boolean(label: 'Show icon'),
+                      isDismissible: k.boolean(label: 'Dismissible'),
+                      variant: v,
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ),
       ),
     );
   },


### PR DESCRIPTION
#### Summary

- Fixed the new close button overlapping with the banner edge
- Refactor
- Updated banner story

#### Testing steps

1. Open Banner story
2. Check whether the dismissible variant is displayed correctly with all options.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
