### PR TITLE
feat!: Update rules configuration

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: '1.10.2'
+          version: "1.10.3"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -382,7 +382,8 @@ dart_code_metrics:
     - prefer-correct-test-file-name:
         exclude: ["lib/**", "bin/**"]
     # - prefer-correct-type-name
-    - prefer-declaring-const-constructor
+    - prefer-declaring-const-constructor:
+        ignore-abstract: false
     - prefer-early-return
     # - prefer-enums-by-name
     - prefer-explicit-parameter-names


### PR DESCRIPTION
#### Summary

- Updated DCM in CI to 1.10.3.
- Disabled `ignore-abstract` for `prefer-declaring-const-constructor`.

#### Testing steps

No, static analyzer config updated.

#### Follow-up issues

No.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
