### PR TITLE
ci: Update Storybook deploy action trigger

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - master
     paths:
-      - storybook/
-      - optimus/
+      - storybook/**
+      - optimus/**
 
 jobs:
   deploy_storybook:


### PR DESCRIPTION
#### Summary

Trigger paths were not defined correctly and GH `Storybook Deploy` action would not start.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
