### PR TITLE
ci: Bump Flutter to 3.16.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Set up Flutter
       uses: subosito/flutter-action@ea686d7c56499339ad176e9f19c516ff6cf05a31
       with:
-        flutter-version: 3.13.9
+        flutter-version: 3.16.0
         cache: true
 
     - name: Set up environment paths

--- a/optimus/lib/src/avatar.dart
+++ b/optimus/lib/src/avatar.dart
@@ -43,7 +43,8 @@ class OptimusAvatar extends StatelessWidget {
             ),
             child: Center(
               child: MediaQuery(
-                data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
+                data: MediaQuery.of(context)
+                    .copyWith(textScaler: TextScaler.noScaling),
                 child: imageUrl != null
                     ? FadeInImage.memoryNetwork(
                         width: _diameter,

--- a/optimus/lib/src/dropdown/dropdown_select.dart
+++ b/optimus/lib/src/dropdown/dropdown_select.dart
@@ -150,22 +150,16 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>> {
     });
   }
 
-  bool _handleOnBackPressed() {
+  void _handleOnBackPressed(bool didPop) {
+    if (didPop) return;
     if (_effectiveFocusNode.hasFocus) {
       _effectiveFocusNode.unfocus();
-
-      return false;
-    } else if (widget.embeddedSearch != null) {
-      final overlay = _overlayEntry;
-      if (overlay != null) {
-        _removeOverlay();
-
-        return false;
-      }
     }
-
-    return true;
+    final overlay = _overlayEntry;
+    if (overlay != null) _removeOverlay();
   }
+
+  bool get _canPop => !_effectiveFocusNode.hasFocus && _overlayEntry == null;
 
   void _showOverlay() {
     if (_overlayEntry != null) return;
@@ -173,6 +167,7 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>> {
       Overlay.of(context, rootOverlay: widget.rootOverlay).insert(it);
       widget.onDropdownShow?.call();
     });
+    setState(() {});
   }
 
   void _removeOverlay() {
@@ -291,8 +286,9 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>> {
             isUpdating: widget.isUpdating,
           );
 
-    return WillPopScope(
-      onWillPop: () async => _handleOnBackPressed(),
+    return PopScope(
+      canPop: _canPop,
+      onPopInvoked: _handleOnBackPressed,
       child: widget.multiselect && _hasValues
           ? MultiSelectInputField(
               values: _values ?? [],

--- a/optimus/lib/src/overlay_controller.dart
+++ b/optimus/lib/src/overlay_controller.dart
@@ -101,15 +101,11 @@ class _OverlayControllerState<T> extends State<OverlayController<T>> {
   }
 
   @override
-  Widget build(BuildContext context) => WillPopScope(
-        onWillPop: () async {
-          if (widget.focusNode.hasFocus) {
-            widget.focusNode.unfocus();
-
-            return false;
-          }
-
-          return true;
+  Widget build(BuildContext context) => PopScope(
+        canPop: !widget.focusNode.hasFocus,
+        onPopInvoked: (bool didPop) {
+          if (didPop) return;
+          widget.focusNode.unfocus();
         },
         child: widget.child,
       );

--- a/storybook/lib/stories/icon/icon.dart
+++ b/storybook/lib/stories/icon/icon.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 import 'package:storybook/utils.dart';
@@ -24,7 +23,7 @@ final Story iconStory = Story(
           .map(
             (c) => OptimusListTile(
               title: OptimusSubsectionTitle(
-                child: Text(describeEnum(c).toUpperCase()),
+                child: Text(c.name.toUpperCase()),
               ),
               prefix: OptimusIcon(
                 iconData: icon,
@@ -53,7 +52,7 @@ final Story supplementaryIconStory = Story(
           .map(
             (c) => OptimusListTile(
               title: OptimusSubsectionTitle(
-                child: Text(describeEnum(c).toUpperCase()),
+                child: Text(c.name.toUpperCase()),
               ),
               prefix: OptimusSupplementaryIcon(
                 iconData: icon,

--- a/storybook/lib/stories/tags.dart
+++ b/storybook/lib/stories/tags.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:optimus/optimus.dart';
 import 'package:storybook/utils.dart';
@@ -32,7 +31,7 @@ final Story tagStory = Story(
                 (c) => Padding(
                   padding: const EdgeInsets.all(8),
                   child: OptimusTag(
-                    text: text.isEmpty ? describeEnum(c) : text,
+                    text: text.isEmpty ? c.name : text,
                     leadingIcon: leadingIcon,
                     trailingIcon: trailingIcon,
                     colorOption: c,
@@ -50,7 +49,7 @@ final Story tagStory = Story(
                 (c) => Padding(
                   padding: const EdgeInsets.all(8),
                   child: OptimusCategoricalTag(
-                    text: text.isEmpty ? describeEnum(c) : text,
+                    text: text.isEmpty ? c.name : text,
                     leadingIcon: leadingIcon,
                     trailingIcon: trailingIcon,
                     colorOption: c,


### PR DESCRIPTION
#### Summary

- bumped GH action Flutter version
- fixed migration issues

#### Testing steps

- `WillPopScope` is deprecated and replaced with the `PopScope`. There is an [issue](https://github.com/flutter/flutter/issues/138614) raised asking to preserve `WillPopScope`, but the outcome is not clear. Need to test if the back button press is acting as intended.

#### Follow-up issues

- Material 3 is now enabled by default and we need to test if it is not bleeding through our component and everything is looking like it should. There is a possibility to disable Material 3 for the time, but Material 2 is going to be deprecated so it would just postpone possible issues.
- #474 

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
