### PR TITLE
fix: Add namespace field to build.gradle

### DIFF
--- a/kiosk_mode/android/build.gradle
+++ b/kiosk_mode/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
+    namespace 'com.mews.kiosk_mode'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
#### Summary

On Flutter 3.16, kiosk_mode package fails to build with the error message below:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':kiosk_mode'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
 ```

That's why I added `namespace` field to build.gradle file.

#### Testing steps

Built.

#### Follow-up issues

Other packages on the repository may be updated as well.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
