### PR TITLE
ci: Add tokens PR action

### DIFF
--- a/.github/workflows/tokens-pr.yml
+++ b/.github/workflows/tokens-pr.yml
@@ -1,0 +1,32 @@
+name: Create Design Tokens PR
+on:
+  push:
+    branches:
+      - "design-tokens-**"
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Set up Flutter
+        uses: "./.github/actions/setup"
+
+      - name: Generate tokens files
+        run: melos gen_theme
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Automated commit of generated tailor files
+          file_pattern: "*tailor.dart"
+
+      - name: Create Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          destination_branch: "master"
+          pr_title: "feat: Design Tokens Update"
+          pr_body: "Design Tokens were updated! This PR was created to update the code."
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tokens-pr.yml
+++ b/.github/workflows/tokens-pr.yml
@@ -31,6 +31,11 @@ jobs:
 
       - name: Create Pull Request
         run: |
-          gh pr create -B master -H ${{ github.ref_name }} --title 'feat: Design Tokens Update' --body 'Design Tokens were updated! This PR was created to update the code.'
+          gh pr create \ 
+            --base master \ 
+            --head ${{ github.ref_name }} \
+            --title 'feat: Design Tokens Update' \
+            --body 'Design Tokens were updated! This PR was created to update the code.' \
+            --reviwer MewsSystems/tech.mo.platform.owners
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tokens-pr.yml
+++ b/.github/workflows/tokens-pr.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
 
       - name: Set up Flutter
         uses: "./.github/actions/setup"
@@ -18,10 +20,14 @@ jobs:
         run: melos gen_theme
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Automated commit of generated tailor files
-          file_pattern: "*tailor.dart"
+        run: |
+          git config --local user.email "tech.account@mewssystems.com"
+          git config --local user.name "mews-tech"
+
+          git add .
+          git commit -m "Update generated files"
+
+          git push origin ${{ github.ref_name }}
 
       - name: Create Pull Request
         uses: repo-sync/pull-request@v2

--- a/.github/workflows/tokens-pr.yml
+++ b/.github/workflows/tokens-pr.yml
@@ -30,9 +30,7 @@ jobs:
           git push origin ${{ github.ref_name }}
 
       - name: Create Pull Request
-        uses: repo-sync/pull-request@v2
-        with:
-          destination_branch: "master"
-          pr_title: "feat: Design Tokens Update"
-          pr_body: "Design Tokens were updated! This PR was created to update the code."
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create -B master -H ${{ github.ref_name }} --title 'feat: Design Tokens Update' --body 'Design Tokens were updated! This PR was created to update the code.'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/melos.yaml
+++ b/melos.yaml
@@ -5,7 +5,12 @@ command:
     workspaceChangelog: false
 
 scripts:
-  gen_icons: melos exec --scope="storybook" -- "dart utils/gen_icons.dart $MELOS_ROOT_PATH/optimus/lib/fonts/config/ lib/stories/icon && dart format lib/stories/icon/icons_list.dart"
+  gen_icons: 
+    run: melos exec --scope="storybook" -- "dart utils/gen_icons.dart $MELOS_ROOT_PATH/optimus/lib/fonts/config/ lib/stories/icon && dart format lib/stories/icon/icons_list.dart"
+    description: Generate the list of all icons for the storybook story
+  gen_theme: 
+    run: melos exec --depends-on=build_runner -- "dart run build_runner build -d"
+    description: Build all generated files
 
 packages:
   - "**"


### PR DESCRIPTION
#### Summary

Added an action that would trigger on push in `design-tokens-**` branch. This action will create a PR to `master`.

This action will ensure we have the latest version of tokens from [design-tokens](https://github.com/MewsSystems/design-tokens). Right now we have an action that is committing new files to `design-tokens-${version}` branch. This action will create a PR and generate files that were touched by the tokens update. 


#### Testing steps

We'll need to check whether the trigger is working correctly and the PR is created.

#### Follow-up issues

~~Set up an action that would regenerate `theme_tailor` files in this same PR.~~ done

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
