### PR TITLE
ci: Add storybook to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,3 +20,8 @@ updates:
     directory: "/remote_logger/"
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "pub"
+    directory: "/storybook/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
#### Summary

Added `storybook` to the `dependabot`.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
