### PR TITLE
ci: Update .lock files in dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-follow-up.yml
+++ b/.github/workflows/dependabot-follow-up.yml
@@ -1,0 +1,35 @@
+name: Update .lock files on dependabot PR
+on:
+  pull_request:
+    types:
+      - opened
+jobs:
+  run_if:
+    if: startsWith(github.head_ref, 'dependabot/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Set up Flutter
+        uses: ./.github/actions/setup
+
+      - name: Get dependencies
+        run: melos bs
+
+      - name: Check if .lock was changed
+        id: lock_changed
+        run: git status --porcelain | grep -q '.lock'
+        continue-on-error: true
+
+      - name: Commit changes
+        if: steps.lock_changed.outcome == 'success'
+        run: |
+          git config --local user.email "tech.account@mewssystems.com"
+          git config --local user.name "mews-tech"
+
+          git add \*.lock
+          git commit -m "Update .lock files"
+
+          git push origin ${{ github.ref_name }}

--- a/.github/workflows/dependabot-follow-up.yml
+++ b/.github/workflows/dependabot-follow-up.yml
@@ -1,5 +1,7 @@
 name: Update .lock files on dependabot PR
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   run_if:

--- a/.github/workflows/dependabot-follow-up.yml
+++ b/.github/workflows/dependabot-follow-up.yml
@@ -1,8 +1,6 @@
 name: Update .lock files on dependabot PR
-on:
-  pull_request:
-    types:
-      - opened
+on: pull_request
+
 jobs:
   run_if:
     if: startsWith(github.head_ref, 'dependabot/')


### PR DESCRIPTION
#### Summary

Added a follow-up action to commit `.lock` files if PR was created by the `dependabot`.

#### Testing steps

`Dependabot` PR should trigger this action and changes in `.lock` should be committed.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
