### PR TITLE
ci: Set to ignore local packages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,7 +24,8 @@ updates:
   - package-ecosystem: "pub"
     directory: "/storybook/"
     ignore:
-      # mews_pedantic is a relative dependency that is always up to date
+      # relative dependencies that is always up to date
       - dependency-name: "mews_pedantic"
+      - dependency-name: "optimus"
     schedule:
       interval: "monthly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,7 +24,7 @@ updates:
   - package-ecosystem: "pub"
     directory: "/storybook/"
     ignore:
-      # relative dependencies that is always up to date
+      # Relative dependencies that are always up to date
       - dependency-name: "mews_pedantic"
       - dependency-name: "optimus"
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,5 +23,8 @@ updates:
 
   - package-ecosystem: "pub"
     directory: "/storybook/"
+    ignore:
+      # mews_pedantic is a relative dependency that is always up to date
+      - dependency-name: "mews_pedantic"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
#### Summary

Added `mews_pedantic` to ignore in `storybook`'s `dependabot`. This will ensure `dependabot` will not switch `mews_pedantic` to `pub` version in its PRs.

#### Testing steps

Re-run dependabot and see if `mews_pedantic` dependency was changed.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
