### PR TITLE
ci: Update trigger condition

### DIFF
--- a/.github/workflows/tokens-pr.yml
+++ b/.github/workflows/tokens-pr.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   pull-request:
+    if: github.event.head_commit.author.name == 'mews-tech'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
@@ -38,7 +39,6 @@ jobs:
           git push origin ${{ github.ref_name }}
 
       - name: Create Pull Request
-        # assigning team as a reviewer is not possible due to the bug: https://github.com/cli/cli/issues/6395
         run: |
           gh pr create \
             --base master \


### PR DESCRIPTION
#### Summary

Make so that action would trigger on push from `mews-tech` only.

#### Testing steps

Chech if follow-up changes in the `design-tokens` branch would trigger this action.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
