### PR TITLE
ci: Update action permissions

### DIFF
--- a/.github/workflows/dependabot-follow-up.yml
+++ b/.github/workflows/dependabot-follow-up.yml
@@ -5,8 +5,10 @@ on:
 
 jobs:
   dependabot_folow_up:
-    if: startsWith(github.head_ref, 'dependabot/')
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
#### Summary

Since: 
> Workflow runs triggered by Dependabot pull requests run as if they are from a forked repository, and therefore use a read-only GITHUB_TOKEN. These workflow runs cannot access any secrets. For information about strategies to keep these workflows secure, see "[Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)."

I've added a `write` permission for the follow-up action for the dependabot PRs.

As an alternative, I can set up an action that would trigger on changes in `storybook/pubscpec.yaml` or `storybook/pubspec.lock` and would run `melos bs` and commit any changed `.lock`files. Then we would need to deal with two PRs instead of one, but then it would only run for those that were `merged`.

Also, I've changed the check to the PR author instead of the branch name.

#### Testing steps

Rebase dependabot PR and see if the follow-up action would end successfully.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
