### PR TITLE
feat: Add support for breaking releases

### DIFF
--- a/.github/workflows/tokens-pr.yml
+++ b/.github/workflows/tokens-pr.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "optimus/lib/src/theme/optimus_tokens.dart"
 
+env:
+  PR_TYPE: "feat"
+
 jobs:
   pull-request:
     if: github.event.head_commit.author.name == 'mews-tech'
@@ -38,12 +41,16 @@ jobs:
 
           git push origin ${{ github.ref_name }}
 
+      - name: Mark breaking release
+        if: endsWith(github.ref_name, '.0.0')
+        run: echo "PR_TYPE=feat!" >> $GITHUB_ENV
+
       - name: Create Pull Request
         run: |
           gh pr create \
             --base master \
             --head ${{ github.ref_name }} \
-            --title 'feat: Design Tokens Update' \
+            --title '$PR_TYPE: Design Tokens Update' \
             --body 'Design Tokens were updated! This PR was created to update the code.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Summary

- PRs created from the design tokens branch ending with `0.0` would be marked as `breaking`.

#### Testing steps

- New design tokens version should create a proper PR and depending on its version it should be marked as breaking.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
