### PR TITLE
fix: [DX-911] Fix disabled label style

### DIFF
--- a/optimus/lib/src/checkbox/checkbox.dart
+++ b/optimus/lib/src/checkbox/checkbox.dart
@@ -121,6 +121,7 @@ class OptimusCheckbox extends StatelessWidget {
         ignoring: !isEnabled,
         child: GroupWrapper(
           error: error,
+          isEnabled: isEnabled,
           child: GestureDetector(
             onTap: _handleTap,
             child: Row(

--- a/optimus/lib/src/checkbox/checkbox_group.dart
+++ b/optimus/lib/src/checkbox/checkbox_group.dart
@@ -58,6 +58,7 @@ class OptimusCheckboxGroup<T> extends StatelessWidget {
   Widget build(BuildContext context) => GroupWrapper(
         label: label,
         error: error,
+        isEnabled: isEnabled,
         child: IgnorePointer(
           ignoring: !isEnabled,
           child: Column(

--- a/optimus/lib/src/checkbox/nested_checkbox.dart
+++ b/optimus/lib/src/checkbox/nested_checkbox.dart
@@ -48,6 +48,7 @@ class OptimusNestedCheckboxGroup extends StatelessWidget {
   Widget build(BuildContext context) => GroupWrapper(
         label: label,
         error: error,
+        isEnabled: isEnabled,
         child: IgnorePointer(
           ignoring: !isEnabled,
           child: NestedCheckboxData(

--- a/optimus/lib/src/common/group_wrapper.dart
+++ b/optimus/lib/src/common/group_wrapper.dart
@@ -9,12 +9,14 @@ class GroupWrapper extends StatelessWidget {
     this.label,
     this.error,
     this.isRequired = false,
+    this.isEnabled = true,
   });
 
   final Widget child;
   final String? label;
   final String? error;
   final bool isRequired;
+  final bool isEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +28,11 @@ class GroupWrapper extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         if (label != null && label.isNotEmpty)
-          OptimusFieldLabel(label: label, isRequired: isRequired),
+          OptimusFieldLabel(
+            label: label,
+            isRequired: isRequired,
+            isEnabled: isEnabled,
+          ),
         child,
         if (error != null && error.isNotEmpty) OptimusFieldError(error: error),
       ],

--- a/optimus/lib/src/radio/radio.dart
+++ b/optimus/lib/src/radio/radio.dart
@@ -119,6 +119,7 @@ class _OptimusRadioState<T> extends State<OptimusRadio<T>> with ThemeGetter {
   @override
   Widget build(BuildContext context) => GroupWrapper(
         error: widget.error,
+        isEnabled: widget.isEnabled,
         child: IgnorePointer(
           ignoring: !widget.isEnabled,
           child: GestureWrapper(

--- a/optimus/lib/src/radio/radio_group.dart
+++ b/optimus/lib/src/radio/radio_group.dart
@@ -62,6 +62,7 @@ class OptimusRadioGroup<T> extends StatelessWidget {
   Widget build(BuildContext context) => GroupWrapper(
         label: label,
         error: error,
+        isEnabled: isEnabled,
         child: OptimusEnabled(
           isEnabled: isEnabled,
           child: Column(

--- a/optimus/lib/src/segmented_control/segmented_control.dart
+++ b/optimus/lib/src/segmented_control/segmented_control.dart
@@ -71,6 +71,7 @@ class OptimusSegmentedControl<T> extends StatelessWidget {
         label: label,
         error: error,
         isRequired: isRequired,
+        isEnabled: isEnabled,
         child: OptimusEnabled(
           isEnabled: isEnabled,
           child: DecoratedBox(


### PR DESCRIPTION
#### Summary

- `GroupWrapper` now correctly supports disabled label style.

<details><summary>Preview</summary>
Before:

![CleanShot 2024-01-05 at 14 41 42](https://github.com/MewsSystems/mews-flutter/assets/9210422/186f1f6e-d409-4b61-83af-f78c28c96da7)


After:

![CleanShot 2024-01-05 at 14 40 07](https://github.com/MewsSystems/mews-flutter/assets/9210422/80462d59-a14d-4f1e-8681-47984c4711b8)


</details>


#### Testing steps

- Open Checkbox/Radio group story. 
- Disabled group label should use `textDisabled` color and change its color depending on the style of the component.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
