### PR TITLE
fix: [DX-988] Fix text controller styles

### DIFF
--- a/optimus/lib/src/form/date_input_field.dart
+++ b/optimus/lib/src/form/date_input_field.dart
@@ -86,6 +86,11 @@ class _OptimusDateInputFieldState extends State<OptimusDateInputField>
   @override
   void didUpdateWidget(covariant OptimusDateInputField oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    if (widget.isEnabled != oldWidget.isEnabled) {
+      _updateControllerStyle();
+    }
+
     if (oldWidget.value != widget.value) {
       _updateControllerValue(widget.value);
     } else if (oldWidget.format.pattern != widget.format.pattern ||
@@ -93,6 +98,18 @@ class _OptimusDateInputFieldState extends State<OptimusDateInputField>
       final oldDate = _getDateTime(oldWidget.format, _controller.text);
       _updateControllerValue(oldDate);
     }
+  }
+
+  @override
+  void didChangeDependencies() {
+    _updateControllerStyle();
+    super.didChangeDependencies();
+  }
+
+  void _updateControllerStyle() {
+    _controller
+      ..inputStyle = _inputStyle
+      ..placeholderStyle = _placeholderStyle;
   }
 
   void _updateControllerValue(DateTime? newValue) {

--- a/optimus/lib/src/form/styled_input_controller.dart
+++ b/optimus/lib/src/form/styled_input_controller.dart
@@ -5,9 +5,11 @@ import 'package:flutter/widgets.dart';
 class StyledInputController extends TextEditingController {
   StyledInputController({
     required String text,
-    required this.inputStyle,
-    required this.placeholderStyle,
-  }) : super.fromValue(
+    required TextStyle inputStyle,
+    required TextStyle placeholderStyle,
+  })  : _inputStyle = inputStyle,
+        _placeholderStyle = placeholderStyle,
+        super.fromValue(
           // workaround for the issue with the cursor position on Android
           TextEditingValue(
             text: text,
@@ -15,11 +17,22 @@ class StyledInputController extends TextEditingController {
           ),
         );
 
-  /// The style to use for the user entered part.
-  final TextStyle inputStyle;
+  TextStyle _inputStyle;
+  TextStyle _placeholderStyle;
 
-  /// The style to use for the rest.
-  final TextStyle placeholderStyle;
+  set inputStyle(TextStyle value) {
+    if (value == _inputStyle) return;
+
+    _inputStyle = value;
+    notifyListeners();
+  }
+
+  set placeholderStyle(TextStyle value) {
+    if (value == _placeholderStyle) return;
+
+    _placeholderStyle = value;
+    notifyListeners();
+  }
 
   @override
   TextSpan buildTextSpan({
@@ -32,11 +45,12 @@ class StyledInputController extends TextEditingController {
 
     for (int i = textParts.length - 1; i >= 0; i--) {
       if (_allowedDigits.hasMatch(textParts[i])) {
-        children.add(TextSpan(style: inputStyle, text: textParts[i]));
+        children.add(TextSpan(style: _inputStyle, text: textParts[i]));
       } else if (_maskRegExp.hasMatch(textParts[i])) {
-        children.add(TextSpan(style: placeholderStyle, text: textParts[i]));
+        children.add(TextSpan(style: _placeholderStyle, text: textParts[i]));
       } else {
-        final style = children.isEmpty ? placeholderStyle : children.last.style;
+        final style =
+            children.isEmpty ? _placeholderStyle : children.last.style;
         children.add(TextSpan(style: style, text: textParts[i]));
       }
     }


### PR DESCRIPTION
#### Summary

The `StyledInputController` didn't update with the component, which led to `OptimusDateInputField`'s text being displayed using the wrong style.

<details><summary>GIFs</summary>
Before: 

![CleanShot 2024-01-16 at 14 34 16](https://github.com/MewsSystems/mews-flutter/assets/9210422/02aa643d-1bee-45a5-97f1-237969bd23a2)

After:

![CleanShot 2024-01-16 at 14 33 15](https://github.com/MewsSystems/mews-flutter/assets/9210422/8bb75176-4465-4a81-a2ac-f0a058a871cd)

</details>


#### Testing steps

1. Open story with `OptimusDateInputField`
2. Change the theme or disable/enable the component. The text style should be correct now.

#### Follow-up issues

I've noticed that the clean button would not change its color. I will double-check with the design team and will fix it in the follow-up if needed.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
