### PR TITLE
feat: [DX-1033] Hide helper message in disabled input

### DIFF
--- a/optimus/lib/src/common/field_wrapper.dart
+++ b/optimus/lib/src/common/field_wrapper.dart
@@ -188,7 +188,7 @@ class _FieldWrapper extends State<FieldWrapper> with ThemeGetter {
             ),
           ),
         ),
-        if (helperMessage != null)
+        if (widget.isEnabled && helperMessage != null)
           Padding(
             padding: widget.size.getHelperPadding(tokens),
             child: OptimusCaption(
@@ -198,7 +198,9 @@ class _FieldWrapper extends State<FieldWrapper> with ThemeGetter {
               ),
             ),
           ),
-        if (_isUsingBottomHint && _normalizedError.isNotEmpty)
+        if (widget.isEnabled &&
+            _isUsingBottomHint &&
+            _normalizedError.isNotEmpty)
           Padding(
             padding: widget.size.getErrorPadding(tokens),
             child: OptimusFieldError(


### PR DESCRIPTION
#### Summary

Updated the design of the input field wrapper. Disabled input should not have either the error or helper message underneath it.

#### Testing steps

1. Open the `Input Field` story
2. Add helper message/error
3. Disable/Enable the component and check if the component is following the design decision.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
