### PR TITLE
fix: [DX-1036] Fix CompactStepBar dark style

### DIFF
--- a/optimus/lib/src/step_bar/step_bar_compact.dart
+++ b/optimus/lib/src/step_bar/step_bar_compact.dart
@@ -142,7 +142,7 @@ class _CollapsedCompactStepBar extends StatelessWidget {
             height: _itemHeight,
             constraints: const BoxConstraints(minHeight: _itemHeight),
             decoration: BoxDecoration(
-              color: OptimusTheme.of(context).colors.neutral0,
+              color: context.tokens.borderStaticInverse,
               boxShadow: _getShadow(context.tokens),
               borderRadius:
                   BorderRadius.circular(context.tokens.borderRadius50),
@@ -429,7 +429,7 @@ class _AnimatedStepBarState extends State<_AnimatedStepBar> {
             child: Container(
               width: widget.width,
               decoration: BoxDecoration(
-                color: OptimusTheme.of(context).colors.neutral0,
+                color: tokens.backgroundStaticFlat,
                 boxShadow: context.tokens.shadow100,
                 borderRadius:
                     BorderRadius.circular(context.tokens.borderRadius50),

--- a/optimus/lib/src/step_bar/step_bar_item.dart
+++ b/optimus/lib/src/step_bar/step_bar_item.dart
@@ -62,7 +62,6 @@ class StepBarItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = OptimusTheme.of(context);
     final tokens = context.tokens;
     final description = item.description;
 
@@ -91,10 +90,8 @@ class StepBarItem extends StatelessWidget {
                     OptimusTypography(
                       resolveStyle: (_) => preset200s.copyWith(
                         overflow: TextOverflow.ellipsis,
-                        color: theme.isDark
-                            ? theme.colors.neutral0t64
-                            : theme.colors.neutral1000t64,
                       ),
+                      color: OptimusTypographyColor.secondary,
                       maxLines: 1,
                       child: description,
                     ),


### PR DESCRIPTION
#### Summary

Fixed dark style for the `OptimusCompactStepBar`.

<details><summary>Preview</summary>
Before: 

![image](https://github.com/MewsSystems/mews-flutter/assets/9210422/580728c7-6260-42ec-ab7b-ced402afc0a0)


After:
![CleanShot 2024-01-23 at 14 42 00](https://github.com/MewsSystems/mews-flutter/assets/9210422/f34c576a-31ea-4bb5-92db-e9714ef80b17)


</details>


#### Testing steps

1. Open `OptimusCompactStepBar` story.
2. Change the theme to dark.
3. Check whether the component is displayed correctly.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
