### PR TITLE
build: Pin theme_tailor package

### DIFF
--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
     sdk: flutter
   freezed: ">=1.0.0 <3.0.0"
   mews_pedantic: ^0.23.0
-  theme_tailor: ^2.0.0
+  theme_tailor: ">=2.0.0 <2.1.0"
 flutter:
   assets:
     - assets/

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_svg: ^2.0.7
   freezed_annotation: ">=1.0.0 <3.0.0"
   intl: ">=0.17.0 <0.20.0"
-  theme_tailor_annotation: ^2.0.0
+  theme_tailor_annotation: ">=2.0.0 <2.1.0"
 
 dev_dependencies:
   build_runner: ^2.0.4


### PR DESCRIPTION
#### Summary

Pinned `theme_tailor` to `2.0.0` version. I need to do a migration to the `2.1.0` because of the deprecation of the main class that was used for the generation. This step was automated so I need to update the automatisation as well.

#### Testing steps

None

#### Follow-up issues

- Migrate to `theme_tailor: 2.1.0`.
- Update templates and code generation.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
