### PR TITLE
feat!: Upgrade to DCM 1.14.0

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.13.4"
+          version: "1.14.0"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -258,6 +258,7 @@ dart_code_metrics:
     # - avoid-collapsible-if
     - avoid-collection-methods-with-unrelated-types
     # - avoid-collection-mutating-methods
+    - avoid-contradictory-expressions
     # - avoid-declaring-call-method
     - avoid-double-slash-imports
     - avoid-duplicate-cascades
@@ -271,7 +272,9 @@ dart_code_metrics:
     - avoid-duplicate-switch-case-conditions
     - avoid-duplicate-test-assertions
     # - avoid-dynamic
+    # - avoid-empty-test-groups
     - avoid-equal-expressions
+    - avoid-excessive-expressions
     - avoid-explicit-pattern-field-name
     # - avoid-explicit-type-declaration
     # - avoid-extensions-on-records
@@ -309,6 +312,7 @@ dart_code_metrics:
     - avoid-nested-switches
     # - avoid-non-ascii-symbols
     - avoid-non-null-assertion
+    - avoid-not-encodable-in-to-json
     - avoid-nullable-interpolation
     - avoid-nullable-parameters-with-default-values
     - avoid-nullable-tostring
@@ -381,7 +385,7 @@ dart_code_metrics:
     # - no-empty-block
     # - no-equal-arguments
     - no-equal-conditions
-    # - no-equal-nested-conditions
+    - no-equal-nested-conditions
     - no-equal-switch-case
     - no-equal-switch-expression-cases
     - no-equal-then-else
@@ -423,7 +427,7 @@ dart_code_metrics:
     # - prefer-match-file-name
     # - prefer-moving-to-variable
     - prefer-named-boolean-parameters:
-      ignore-single: true
+        ignore-single: true
     # - prefer-named-imports
     - prefer-null-aware-spread
     - prefer-parentheses-with-if-null


### PR DESCRIPTION
#### Summary

- Upgrade to DCM 1.14.0

##### Enabled rules

- [avoid-contradictory-expressions](https://dcm.dev/docs/rules/common/avoid-contradictory-expressions/)
- [avoid-excessive-expressions](https://dcm.dev/docs/rules/common/avoid-excessive-expressions/)
- [avoid-not-encodable-in-to-json](avoid-not-encodable-in-to-json)
- [no-equal-nested-conditions](https://dcm.dev/docs/rules/common/no-equal-nested-conditions/) - was disabled before, but I think this should be enabled.

##### Rules left disabled
- [avoid-empty-test-groups](https://dcm.dev/docs/rules/common/avoid-empty-test-groups/) - waiting for the `@isTest` annotation support

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
