### PR TITLE
feat: Update background color

### DIFF
--- a/storybook/lib/main.dart
+++ b/storybook/lib/main.dart
@@ -96,6 +96,13 @@ class _MyAppState extends State<MyApp> {
                 ),
                 DeviceFramePlugin(),
               ],
+              wrapperBuilder: (BuildContext _, Widget? child) => MaterialApp(
+                theme: ThemeData.light()
+                    .copyWith(scaffoldBackgroundColor: Colors.white),
+                darkTheme: ThemeData.dark(),
+                debugShowCheckedModeBanner: false,
+                home: Scaffold(body: Center(child: child)),
+              ),
               initialStory: 'Welcome',
               stories: [
                 welcomeStory,


### PR DESCRIPTION
#### Summary

Changed the Storybook background for the light theme to white. 
Material3 is enabled by default since the latest Flutter release and its beige color looks off when embedded into [mews.design](http://mews.design) 

#### Testing steps

Dev tested.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
