### PR TITLE
feat: Add inline variant

### DIFF
--- a/optimus/lib/src/common/field_error.dart
+++ b/optimus/lib/src/common/field_error.dart
@@ -30,7 +30,14 @@ class OptimusFieldError extends StatelessWidget {
             color: color,
           ),
         ),
-        OptimusCaption(child: Text(error, style: TextStyle(color: color))),
+        Flexible(
+          child: OptimusCaption(
+            child: Text(
+              error,
+              style: TextStyle(color: color),
+            ),
+          ),
+        ),
       ],
     );
   }

--- a/optimus/lib/src/form/common.dart
+++ b/optimus/lib/src/form/common.dart
@@ -13,6 +13,7 @@ class Suffix extends StatelessWidget {
     this.trailing,
     this.inlineError,
     this.clearAllButton,
+    this.counter,
     this.showLoader = false,
   });
 
@@ -22,6 +23,7 @@ class Suffix extends StatelessWidget {
   final Widget? clearAllButton;
   final Widget? inlineError;
   final bool showLoader;
+  final Widget? counter;
 
   OptimusCircleLoader get _loader => const OptimusCircleLoader(
         size: OptimusCircleLoaderSize.small,
@@ -36,6 +38,7 @@ class Suffix extends StatelessWidget {
         spacing: OptimusStackSpacing.spacing100,
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (counter case final counter?) counter,
           if (suffix case final suffix?) suffix,
           if (showLoader) _loader,
           if (clearAllButton case final clearAllButton?) clearAllButton,

--- a/optimus/lib/src/form/common.dart
+++ b/optimus/lib/src/form/common.dart
@@ -31,9 +31,7 @@ class Suffix extends StatelessWidget {
       );
 
   @override
-  Widget build(BuildContext context) =>
-      inlineError ??
-      OptimusStack(
+  Widget build(BuildContext context) => OptimusStack(
         direction: Axis.horizontal,
         spacing: OptimusStackSpacing.spacing100,
         mainAxisSize: MainAxisSize.min,
@@ -46,6 +44,7 @@ class Suffix extends StatelessWidget {
             passwordButton
           else if (trailing case final trailing?)
             trailing,
+          if (inlineError case final inlineError?) inlineError,
         ],
       );
 }

--- a/optimus/lib/src/form/input_field.dart
+++ b/optimus/lib/src/form/input_field.dart
@@ -51,6 +51,7 @@ class OptimusInputField extends StatefulWidget {
     this.keyboardAppearance,
     this.enableIMEPersonalizedLearning = true,
     this.enableSuggestions = true,
+    this.inline = false,
   });
 
   /// {@macro flutter.widgets.editableText.onChanged}
@@ -154,6 +155,11 @@ class OptimusInputField extends StatefulWidget {
   /// {@macro flutter.services.TextInputConfiguration.enableSuggestions}
   final bool enableSuggestions;
 
+  /// Controls whether the components should be inside the input field or
+  /// outside, wrapping it. The inline variant is more dense and is smaller in
+  /// the vertical direction.
+  final bool inline;
+
   bool get hasError {
     final error = this.error;
 
@@ -207,6 +213,7 @@ class _OptimusInputFieldState extends State<OptimusInputField>
   bool get _shouldShowSuffix =>
       widget.suffix != null ||
       widget.trailing != null ||
+      (widget.inline && widget.maxCharacters != null) ||
       widget.showLoader ||
       widget.isPasswordField ||
       _shouldShowClearAllButton ||
@@ -224,6 +231,12 @@ class _OptimusInputFieldState extends State<OptimusInputField>
   Widget build(BuildContext context) {
     final error = widget.error;
     final maxCharacters = widget.maxCharacters;
+    final counter = maxCharacters != null
+        ? _CharacterCounter(
+            current: _effectiveController.text.length,
+            max: maxCharacters,
+          )
+        : null;
 
     return FieldWrapper(
       focusNode: _effectiveFocusNode,
@@ -237,12 +250,8 @@ class _OptimusInputFieldState extends State<OptimusInputField>
       errorVariant: widget.errorVariant,
       hasBorders: widget.hasBorders,
       isRequired: widget.isRequired,
-      inputLimit: maxCharacters != null
-          ? _CharacterCounter(
-              current: _effectiveController.text.length,
-              max: maxCharacters,
-            )
-          : null,
+      inline: widget.inline,
+      inputCounter: counter,
       prefix: _shouldShowPrefix
           ? Prefix(prefix: widget.prefix, leading: widget.leading)
           : null,
@@ -250,6 +259,7 @@ class _OptimusInputFieldState extends State<OptimusInputField>
           ? Suffix(
               suffix: widget.suffix,
               trailing: widget.trailing,
+              counter: widget.inline ? counter : null,
               passwordButton: widget.isPasswordField
                   ? _PasswordButton(
                       onTap: _handlePasswordTap,

--- a/optimus/lib/src/form/input_field.dart
+++ b/optimus/lib/src/form/input_field.dart
@@ -199,7 +199,8 @@ class _OptimusInputFieldState extends State<OptimusInputField>
   }
 
   bool get _shouldShowInlineError =>
-      widget.errorVariant == OptimusInputErrorVariant.inlineTooltip &&
+      (widget.errorVariant == OptimusInputErrorVariant.inlineTooltip ||
+          widget.inline) &&
       widget.hasError;
 
   void _handleClearAllTap() {
@@ -235,6 +236,7 @@ class _OptimusInputFieldState extends State<OptimusInputField>
         ? _CharacterCounter(
             current: _effectiveController.text.length,
             max: maxCharacters,
+            isEnabled: widget.isEnabled,
           )
         : null;
 
@@ -359,20 +361,26 @@ class _CharacterCounter extends StatelessWidget {
   const _CharacterCounter({
     required this.current,
     required this.max,
+    this.isEnabled = true,
   });
 
   final int current;
   final int max;
+  final bool isEnabled;
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.tokens;
+    final color = isEnabled
+        ? max < current
+            ? tokens.textAlertDanger
+            : tokens.textStaticSecondary
+        : tokens.textDisabled;
 
     final child = Text(
       '$current/$max',
       style: tokens.bodyMedium.copyWith(
-        color:
-            current > max ? tokens.textAlertDanger : tokens.textStaticSecondary,
+        color: color,
       ),
     );
 

--- a/storybook/lib/stories/input.dart
+++ b/storybook/lib/stories/input.dart
@@ -43,11 +43,12 @@ final Story inputStory = Story(
       maxChars =
           k.sliderInt(label: 'Max Characters', max: 100, min: 1, initial: 30);
     }
+    final inline = k.boolean(label: 'Inline', initial: false);
 
     return Align(
       alignment: Alignment.center,
       child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 200),
+        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 300),
         child: OptimusInputField(
           isEnabled: k.boolean(label: 'Enabled', initial: true),
           isRequired: k.boolean(label: 'Required'),
@@ -65,6 +66,7 @@ final Story inputStory = Story(
             initial: OptimusWidgetSize.large,
             options: sizeOptions,
           ),
+          inline: inline,
           label: k.text(label: 'Label', initial: 'Optimus input field'),
           placeholder:
               k.text(label: 'Placeholder', initial: 'Put some hint here...'),


### PR DESCRIPTION
#### Summary

- added inline variant for the input
- refactored the `FieldWrapper`
- updated story
- fixed bug when there is an error but not a helper message, which led to the wrong position of the error widget

<details><summary>Preview</summary>


https://github.com/MewsSystems/mews-flutter/assets/9210422/b7ee390c-d289-4bba-85ca-e25036b99136


</details>


#### Testing steps

1. Open the Storybook Input story
2. Test different knob combinations. 
3. Try the inline variant for that combination

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
