### PR TITLE
feat!: Upgrade to Flutter 3.19.2

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Set up Flutter
       uses: subosito/flutter-action@ea686d7c56499339ad176e9f19c516ff6cf05a31
       with:
-        flutter-version: 3.16.9
+        flutter-version: 3.19.2
         cache: true
 
     - name: Set up environment paths

--- a/optimus/lib/src/tokens/tokens_dark.dart
+++ b/optimus/lib/src/tokens/tokens_dark.dart
@@ -5,7 +5,6 @@
 // Do not edit directly
 // Generated on Wed, 28 Feb 2024 13:44:46 GMT
 
-import 'dart:ui';
 import 'package:flutter/widgets.dart';
 
 class DesignTokensDark {

--- a/optimus/lib/src/tokens/tokens_light.dart
+++ b/optimus/lib/src/tokens/tokens_light.dart
@@ -5,7 +5,6 @@
 // Do not edit directly
 // Generated on Wed, 28 Feb 2024 13:44:46 GMT
 
-import 'dart:ui';
 import 'package:flutter/widgets.dart';
 
 class DesignTokensLight {

--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -5,6 +5,7 @@ repository: https://github.com/MewsSystems/mews-flutter
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   dfunc: ^0.9.0


### PR DESCRIPTION
#### Summary

- **[BREAKING CHANGE]** minimal version is now `3.19.0`
- Changed CI Flutter version to `3.19.2`
- Fixed unused imports that were reported after the migration to `3.19.0`

#### Testing steps

Dev-tested.

#### Follow-up issues

Update the tokens template and remove `dart:ui` import.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
