### PR TITLE
feat: Update SplitButton style

### DIFF
--- a/optimus/lib/src/button/split.dart
+++ b/optimus/lib/src/button/split.dart
@@ -62,7 +62,8 @@ class OptimusSplitButton<T> extends StatelessWidget {
           size: size,
           child: child,
         ),
-        const SizedBox(width: 1),
+        if (variant == OptimusSplitButtonVariant.primary)
+          const SizedBox(width: 1),
         BaseDropDownButton(
           items: items,
           onItemSelected: onItemSelected,


### PR DESCRIPTION
#### Summary

- updated `OptimusSplitButton` style. Only the primary one should have the gap, according to the design.

<details><summary>Screenshots</summary>
Before:

![CleanShot 2024-03-05 at 17 15 30](https://github.com/MewsSystems/mews-flutter/assets/9210422/950bb882-0b8c-4c9e-8c1a-26110dbad9a4)


After:

![CleanShot 2024-03-05 at 17 14 42](https://github.com/MewsSystems/mews-flutter/assets/9210422/f121cecd-f1ff-49fb-a341-dd375873cbde)




</details>


#### Testing steps

Dev-tested.

#### Follow-up issues

None.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
