### PR TITLE
feat!: Upgrade to DCM 1.15.0

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.14.0"
+          version: "1.15.0"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -255,6 +255,7 @@ dart_code_metrics:
     - avoid-bottom-type-in-patterns
     - avoid-bottom-type-in-records
     - avoid-cascade-after-if-null
+    - avoid-casting-to-extension-type
     # - avoid-collapsible-if
     - avoid-collection-methods-with-unrelated-types
     # - avoid-collection-mutating-methods
@@ -272,6 +273,7 @@ dart_code_metrics:
     - avoid-duplicate-switch-case-conditions
     - avoid-duplicate-test-assertions
     # - avoid-dynamic
+    - avoid-empty-spread
     # - avoid-empty-test-groups
     - avoid-equal-expressions
     - avoid-excessive-expressions
@@ -296,6 +298,7 @@ dart_code_metrics:
     # - avoid-long-records
     - avoid-map-keys-contains
     - avoid-missed-calls
+    - avoid-missing-completer-stack-trace
     # - avoid-missing-enum-constant-in-map
     - avoid-missing-interpolation
     # - avoid-missing-test-files
@@ -305,6 +308,7 @@ dart_code_metrics:
     # - avoid-mutating-parameters
     # - avoid-negated-conditions
     # - avoid-nested-conditional-expressions
+    - avoid-nested-extension-types
     - avoid-nested-futures
     - avoid-nested-records
     - avoid-nested-streams-and-futures
@@ -326,11 +330,15 @@ dart_code_metrics:
     - avoid-redundant-else
     - avoid-redundant-positional-field-name
     # - avoid-redundant-pragma-inline
+    # - avoid-referencing-discarded-variables
+    # - avoid-renaming-representation-getters
+    - avoid-returning-void
     - avoid-self-assignment
     - avoid-self-compare
     - avoid-shadowed-extension-methods
     # - avoid-shadowing
     # - avoid-similar-names
+    # - avoid-slow-collection-methods
     # - avoid-substring
     # - avoid-throw-in-catch-block
     # - avoid-throw-objects-without-tostring
@@ -339,7 +347,9 @@ dart_code_metrics:
     - avoid-unassigned-stream-subscriptions
     - avoid-uncaught-future-errors
     - avoid-unconditional-break
+    # - avoid-unknown-pragma
     - avoid-unnecessary-call
+    - avoid-unnecessary-collections
     - avoid-unnecessary-conditionals
     - avoid-unnecessary-futures
     - avoid-unnecessary-getter
@@ -430,8 +440,10 @@ dart_code_metrics:
         ignore-single: true
     # - prefer-named-imports
     - prefer-null-aware-spread
+    - prefer-overriding-parent-equality
     - prefer-parentheses-with-if-null
     # - prefer-prefixed-global-constants
+    # - prefer-private-extension-type-field
     - prefer-public-exception-classes
     - prefer-return-await
     - prefer-returning-conditional-expressions
@@ -461,6 +473,7 @@ dart_code_metrics:
     # - avoid-incomplete-copy-with
     # - avoid-inherited-widget-in-initstate
     - avoid-late-context
+    - avoid-missing-controller
     # - avoid-missing-image-alt
     - avoid-recursive-widget-calls
     # - avoid-returning-widgets
@@ -468,6 +481,7 @@ dart_code_metrics:
     - avoid-single-child-column-or-row
     - avoid-state-constructors
     # - avoid-undisposed-instances
+    - avoid-unnecessary-gesture-detector
     - avoid-stateless-widget-initialized-fields
     - avoid-unnecessary-overrides-in-state
     - avoid-unnecessary-setstate

--- a/storybook/lib/stories/dialog.dart
+++ b/storybook/lib/stories/dialog.dart
@@ -161,21 +161,16 @@ final Story dialogStory = Story(
               padding: EdgeInsets.only(top: 24, bottom: 16),
               child: OptimusTitleMedium(child: Text('Custom content')),
             ),
-            Wrap(
-              spacing: 8,
-              children: [
-                OptimusButton(
-                  variant: OptimusButtonVariant.primary,
-                  onPressed: () => _handleShowCustomContentDialog(
-                    context: context,
-                    isDismissible: isDismissible,
-                    size: OptimusDialogSize.large,
-                    type: type,
-                    title: title,
-                  ),
-                  child: const Text('Custom content'),
-                ),
-              ],
+            OptimusButton(
+              variant: OptimusButtonVariant.primary,
+              onPressed: () => _handleShowCustomContentDialog(
+                context: context,
+                isDismissible: isDismissible,
+                size: OptimusDialogSize.large,
+                type: type,
+                title: title,
+              ),
+              child: const Text('Custom content'),
             ),
           ],
         ),


### PR DESCRIPTION
#### Summary

- Upgrade to DCM 1.15.0

### Enabled rules:

Common:
- [avoid-returning-void](https://dcm.dev/docs/rules/common/avoid-returning-void/)
- [avoid-empty-spread](https://dcm.dev/docs/rules/common/avoid-empty-spread/)
- [avoid-missing-completer-stack-trace](https://dcm.dev/docs/rules/common/avoid-missing-completer-stack-trace/)
- [avoid-casting-to-extension-type](https://dcm.dev/docs/rules/common/avoid-casting-to-extension-type/)
- [avoid-nested-extension-types](https://dcm.dev/docs/rules/common/avoid-nested-extension-types/)
- [prefer-overriding-parent-equality](https://dcm.dev/docs/rules/common/prefer-overriding-parent-equality/)
- [avoid-unnecessary-collections](https://dcm.dev/docs/rules/common/avoid-unnecessary-collections/)

#### Flutter:

- [avoid-unnecessary-gesture-detector](https://dcm.dev/docs/rules/flutter/avoid-unnecessary-gesture-detector/)
- [avoid-missing-controller](https://dcm.dev/docs/rules/flutter/avoid-missing-controller/)

### Left disabled: 
- [avoid-unknown-pragma](https://dcm.dev/docs/rules/common/avoid-unknown-pragma/)
- [avoid-slow-collection-methods](https://dcm.dev/docs/rules/common/avoid-slow-collection-methods/)
- [prefer-private-extension-type-field](https://dcm.dev/docs/rules/common/prefer-private-extension-type-field/)
- [avoid-renaming-representation-getters](https://dcm.dev/docs/rules/common/avoid-renaming-representation-getters/)


#### Testing steps

None.

#### Follow-up issues

Release.
Maybe something to to with slow `sync*` methods like intersperse, is up for debate.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
