### PR TITLE
ci: Bump CI Flutter to 3.19.3

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Set up Flutter
       uses: subosito/flutter-action@ea686d7c56499339ad176e9f19c516ff6cf05a31
       with:
-        flutter-version: 3.19.2
+        flutter-version: 3.19.3
         cache: true
 
     - name: Set up environment paths


### PR DESCRIPTION
#### Summary

Bump CI Flutter to 3.19.3.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
