### PR TITLE
feat: [DX-1513] Hide password toggle while loading

### DIFF
--- a/optimus/lib/src/form/common.dart
+++ b/optimus/lib/src/form/common.dart
@@ -40,10 +40,8 @@ class Suffix extends StatelessWidget {
           if (suffix case final suffix?) suffix,
           if (showLoader) _loader,
           if (clearAllButton case final clearAllButton?) clearAllButton,
-          if (passwordButton case final passwordButton?)
-            passwordButton
-          else if (trailing case final trailing?)
-            trailing,
+          if (passwordButton case final passwordButton?) passwordButton,
+          if (trailing case final trailing?) trailing,
           if (inlineError case final inlineError?) inlineError,
         ],
       );

--- a/optimus/lib/src/form/common.dart
+++ b/optimus/lib/src/form/common.dart
@@ -38,8 +38,8 @@ class Suffix extends StatelessWidget {
         children: [
           if (counter case final counter?) counter,
           if (suffix case final suffix?) suffix,
-          if (showLoader) _loader,
           if (clearAllButton case final clearAllButton?) clearAllButton,
+          if (showLoader) _loader,
           if (passwordButton case final passwordButton?) passwordButton,
           if (trailing case final trailing?) trailing,
           if (inlineError case final inlineError?) inlineError,

--- a/optimus/lib/src/form/input_field.dart
+++ b/optimus/lib/src/form/input_field.dart
@@ -222,6 +222,9 @@ class _OptimusInputFieldState extends State<OptimusInputField>
 
   bool get _shouldShowPrefix => widget.leading != null || widget.prefix != null;
 
+  bool get _isPasswordToggleVisible =>
+      widget.isPasswordField && !widget.showLoader;
+
   void _handleStateUpdate() => setState(() {});
 
   void _handlePasswordTap() => setState(
@@ -262,7 +265,7 @@ class _OptimusInputFieldState extends State<OptimusInputField>
               suffix: widget.suffix,
               trailing: widget.trailing,
               counter: widget.inline ? counter : null,
-              passwordButton: widget.isPasswordField
+              passwordButton: _isPasswordToggleVisible
                   ? _PasswordButton(
                       onTap: _handlePasswordTap,
                       isEnabled: _isShowPasswordEnabled,


### PR DESCRIPTION
#### Summary

- The password toggle is now hidden when input is loading.

#### Testing steps

1. Set input to the password field
2. Enabled loading
3. Visibility toggle should be hidden

#### Follow-up issues

None.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
