### PR TITLE
feat!: [DX-1695] Limit button badge to numbers only

### DIFF
--- a/optimus/lib/src/button/button.dart
+++ b/optimus/lib/src/button/button.dart
@@ -21,7 +21,10 @@ class OptimusButton extends StatelessWidget {
     this.isLoading = false,
     this.size = OptimusWidgetSize.large,
     this.variant = OptimusButtonVariant.primary,
-  });
+  }) : assert(
+          counter == null || counter >= 0,
+          'Counter must be null or a non-negative integer',
+        );
 
   /// Called when the button is tapped or otherwise activated.
   ///
@@ -42,8 +45,9 @@ class OptimusButton extends StatelessWidget {
 
   /// Badge counter.
   ///
-  /// If more than 99 will be displayed as 99+.
-  final num? counter;
+  /// If more than 99 will be displayed as 99+. If null or 0, the badge will not
+  /// be displayed. Must be a non-negative integer.
+  final int? counter;
 
   /// Size of the button widget.
   final OptimusWidgetSize size;
@@ -82,7 +86,11 @@ class OptimusButton extends StatelessWidget {
         leadingIcon: leadingIcon,
         trailingIcon: trailingIcon,
         badgeLabel: counter?.let(
-          (v) => v.abs() > 99 ? '${v < 0 ? '-' : ''}99+' : v.toString(),
+          (v) => switch (v) {
+            0 => null,
+            > 99 => '99+',
+            _ => v.toString(),
+          },
         ),
         size: size,
         isLoading: isLoading,

--- a/optimus/lib/src/button/button.dart
+++ b/optimus/lib/src/button/button.dart
@@ -1,3 +1,4 @@
+import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
@@ -14,7 +15,7 @@ class OptimusButton extends StatelessWidget {
     this.onPressed,
     required this.child,
     this.minWidth,
-    this.badgeLabel,
+    this.counter,
     this.leadingIcon,
     this.trailingIcon,
     this.isLoading = false,
@@ -39,8 +40,10 @@ class OptimusButton extends StatelessWidget {
   /// The icon to the right of the [child].
   final IconData? trailingIcon;
 
-  /// Badge text. Typically used for the counter.
-  final String? badgeLabel;
+  /// Badge counter.
+  ///
+  /// If more than 99 will be displayed as 99+.
+  final num? counter;
 
   /// Size of the button widget.
   final OptimusWidgetSize size;
@@ -78,7 +81,9 @@ class OptimusButton extends StatelessWidget {
         minWidth: minWidth,
         leadingIcon: leadingIcon,
         trailingIcon: trailingIcon,
-        badgeLabel: badgeLabel,
+        badgeLabel: counter?.let(
+          (v) => v.abs() > 99 ? '${v < 0 ? '-' : ''}99+' : v.toString(),
+        ),
         size: size,
         isLoading: isLoading,
         variant: variant.toBaseVariant(),

--- a/storybook/lib/stories/button/button.dart
+++ b/storybook/lib/stories/button/button.dart
@@ -19,6 +19,10 @@ final Story button = Story(
       options: exampleIcons,
     );
 
+    final showBadge = k.boolean(label: 'Show Badge', initial: false);
+    final counter =
+        k.sliderInt(label: 'Badge Count', initial: 0, max: 110, min: -110);
+
     return SingleChildScrollView(
       child: Column(
         children: OptimusButtonVariant.values
@@ -37,7 +41,7 @@ final Story button = Story(
                   variant: v,
                   leadingIcon: leadingIcon,
                   trailingIcon: trailingIcon,
-                  badgeLabel: k.text(label: 'Badge', initial: ''),
+                  counter: showBadge ? counter : null,
                   child: Text(k.text(label: 'Text', initial: 'Button')),
                 ),
               ),

--- a/storybook/lib/stories/button/button.dart
+++ b/storybook/lib/stories/button/button.dart
@@ -21,7 +21,7 @@ final Story button = Story(
 
     final showBadge = k.boolean(label: 'Show Badge', initial: false);
     final counter =
-        k.sliderInt(label: 'Badge Count', initial: 0, max: 110, min: -110);
+        k.sliderInt(label: 'Badge Count', initial: 0, max: 110, min: 0);
 
     return SingleChildScrollView(
       child: Column(


### PR DESCRIPTION
#### Summary

- **[BREAKING CHANGE]** badge now accepts positive numbers only. The `badgeLabel` is renamed to `counter` to match the MDS component naming.
- updated story

<details><summary>Preview</summary>


https://github.com/MewsSystems/mews-flutter/assets/9210422/e100032b-0b12-4644-b271-b4c94661444a



</details>


#### Testing steps

1. Open Button story
2. Test button counter with different variables and themes. Test exposed knobs to determine whether the look is consistent.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
