### PR TITLE
feat!: Upgrade to DCM 1.18.0

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.17.1"
+          version: "1.18.1"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -324,6 +324,7 @@ dart_code_metrics:
     - avoid-nullable-parameters-with-default-values
     - avoid-nullable-tostring
     - avoid-one-field-records
+    - avoid-only-rethrow
     # - avoid-passing-async-when-sync-expected
     # - avoid-passing-default-values
     # - avoid-passing-self-as-argument
@@ -335,6 +336,7 @@ dart_code_metrics:
     # - avoid-redundant-pragma-inline
     # - avoid-referencing-discarded-variables
     # - avoid-renaming-representation-getters
+    - avoid-returning-cascades
     - avoid-returning-void
     - avoid-self-assignment
     - avoid-self-compare
@@ -368,6 +370,7 @@ dart_code_metrics:
     - avoid-unrelated-type-assertions
     - avoid-unrelated-type-casts
     # - avoid-unsafe-collection-methods
+    - avoid-unsafe-reduce
     - avoid-unused-after-null-check
     - avoid-unused-generics
     # - avoid-unused-instances
@@ -409,6 +412,7 @@ dart_code_metrics:
     # - no-magic-string
     - no-object-declaration
     # - parameters-ordering
+    - prefer-abstract-final-static-class
     # - prefer-addition-subtraction-assignments
     - prefer-any-or-every
     # - prefer-async-await
@@ -446,6 +450,8 @@ dart_code_metrics:
     - prefer-named-boolean-parameters:
         ignore-single: true
     # - prefer-named-imports
+    - prefer-named-parameters:
+        max-number: 2
     - prefer-null-aware-spread
     - prefer-overriding-parent-equality
     - prefer-parentheses-with-if-null

--- a/optimus/lib/src/colors/brand_colors.dart
+++ b/optimus/lib/src/colors/brand_colors.dart
@@ -17,7 +17,7 @@ import 'package:flutter/material.dart';
 /// The brand secondary colors are the most versatile and can be used for
 /// brand-specific components, system backgrounds, and other neutral
 /// elements like cards.
-abstract class OptimusBrandColors {
+abstract final class OptimusBrandColors {
   const OptimusBrandColors._();
 
   static const coral500 = Color(0xFFFF5E64);

--- a/optimus/lib/src/colors/colors.dart
+++ b/optimus/lib/src/colors/colors.dart
@@ -39,7 +39,7 @@ import 'package:flutter/material.dart';
 ///
 /// One of the "alert" colors, its purpose is to communicate and convey a
 /// sense of danger, error, or destructive action.
-abstract class OptimusSemanticColors {
+abstract final class OptimusSemanticColors {
   const OptimusSemanticColors._();
 
   static const white = Color(0xFFFFFFFF);
@@ -214,7 +214,7 @@ abstract class OptimusSemanticColors {
   static const red600t48 = Color(0x7AD62F29);
 }
 
-abstract class OptimusLightColors {
+abstract final class OptimusLightColors {
   const OptimusLightColors._();
 
   static const neutral0 = OptimusSemanticColors.white;
@@ -335,7 +335,7 @@ abstract class OptimusLightColors {
   static const danger = danger500;
 }
 
-abstract class OptimusDarkColors {
+abstract final class OptimusDarkColors {
   const OptimusDarkColors._();
 
   static const neutral0 = OptimusSemanticColors.white;

--- a/optimus/lib/src/colors/data_colors.dart
+++ b/optimus/lib/src/colors/data_colors.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-abstract class OptimusDataColors {
+abstract final class OptimusDataColors {
   const OptimusDataColors._();
 
   static const denim50 = Color(0xFFE6EFF6);

--- a/optimus/lib/src/constants.dart
+++ b/optimus/lib/src/constants.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/rendering.dart';
 
-abstract class OpacityValue {
+abstract final class OpacityValue {
   static const double enabled = 1;
   static const double disabled = .32;
 }

--- a/optimus/lib/src/tokens/tokens_dark.dart
+++ b/optimus/lib/src/tokens/tokens_dark.dart
@@ -7,7 +7,7 @@
 
 import 'package:flutter/widgets.dart';
 
-class DesignTokensDark {
+abstract final class DesignTokensDark {
   const DesignTokensDark._();
 
   static const Color backgroundAccentBrand = Color(0xFFAEACFA);

--- a/optimus/lib/src/tokens/tokens_light.dart
+++ b/optimus/lib/src/tokens/tokens_light.dart
@@ -7,7 +7,7 @@
 
 import 'package:flutter/widgets.dart';
 
-class DesignTokensLight {
+abstract final class DesignTokensLight {
   const DesignTokensLight._();
 
   static const Color backgroundAccentBrand = Color(0xFF7876FB);

--- a/optimus/lib/src/typography/fonts.dart
+++ b/optimus/lib/src/typography/fonts.dart
@@ -1,4 +1,4 @@
-class OptimusFonts {
+abstract final class OptimusFonts {
   const OptimusFonts._();
 
   static const inter = 'packages/optimus/Inter';

--- a/optimus_icons/lib/src/optimus_icons.dart
+++ b/optimus_icons/lib/src/optimus_icons.dart
@@ -17,7 +17,7 @@
 
 import 'package:flutter/widgets.dart';
 
-class OptimusIcons {
+abstract final class OptimusIcons {
   const OptimusIcons._();
 
   static const _kFontFam = 'OptimusIcons';


### PR DESCRIPTION
#### Summary

- upgraded `mews_pedantic` to the latest DCM version - [`1.18.0`](https://dcm.dev/blog/2024/06/07/whats-new-in-dcm-1-18-0/)
- fixed linter issues

##### Enabled rules:
- [avoid-only-rethrow](https://dcm.dev/docs/rules/common/avoid-only-rethrow/)
- [avoid-returning-cascades](https://dcm.dev/docs/rules/common/avoid-returning-cascades/)
- [avoid-unsafe-reduce](https://dcm.dev/docs/rules/common/avoid-unsafe-reduce/)
- [prefer-abstract-final-static-class](https://dcm.dev/docs/rules/common/prefer-abstract-final-static-class/)
- [prefer-named-parameters](https://dcm.dev/docs/rules/common/prefer-named-parameters/) - set the limit to 2 as most of the time it is something like `(error, result)` or `(context, child)`. We can debate about the limit.

#### Testing steps

None

#### Follow-up issues

Update token code generation templates and make classes `abstract final`

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
