### PR TITLE
ci: [DX-1806] Automate package publish on tag

### DIFF
--- a/.github/workflows/optimus-publish.yml
+++ b/.github/workflows/optimus-publish.yml
@@ -12,3 +12,4 @@ jobs:
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       working-directory: optimus/
+      environment: pub.dev

--- a/.github/workflows/optimus-publish.yml
+++ b/.github/workflows/optimus-publish.yml
@@ -1,0 +1,14 @@
+name: Publish optimus to pub.dev
+
+on:
+  push:
+    tags:
+      - 'optimus-v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: optimus/


### PR DESCRIPTION
#### Summary

- added a workflow to publish `optimus` on tag pushed.

We need to set it up on the other [end](https://dart.dev/tools/pub/automated-publishing#configuring-automated-publishing-from-github-actions-on-pub-dev) to allow this automation.

#### Testing steps

- Create a release and try if it works, after all is set up.

#### Follow-up issues

Tune this workflow and do the same for other packages that need to be published on `pub.dev`

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
