### PR TITLE
feat: [DX-1919] Add padding to multiline input

### DIFF
--- a/optimus/lib/src/common/field_wrapper.dart
+++ b/optimus/lib/src/common/field_wrapper.dart
@@ -24,6 +24,7 @@ class FieldWrapper extends StatefulWidget {
     this.size = OptimusWidgetSize.large,
     this.inputCounter,
     this.inline = false,
+    this.multiline = false,
     this.statusBarState,
   });
 
@@ -45,6 +46,7 @@ class FieldWrapper extends StatefulWidget {
   final OptimusWidgetSize size;
   final Widget? inputCounter;
   final bool inline;
+  final bool multiline;
   final OptimusStatusBarState? statusBarState;
 
   bool get hasError {
@@ -104,20 +106,22 @@ class _FieldWrapper extends State<FieldWrapper> with ThemeGetter {
 
   bool get _hasFooterError => _normalizedError.isNotEmpty && _isUsingBottomHint;
 
+  double get _verticalPadding => widget.multiline
+      ? widget.size.getVerticalPadding(tokens)
+      : tokens.spacing0;
+
   Color get _borderColor {
     if (!widget.isEnabled) return tokens.borderDisabled;
     if (widget.hasError) return tokens.borderAlertDanger;
     if (_isFocused) return tokens.borderInteractiveFocus;
     if (_isHovered) return tokens.borderInteractiveSecondaryHover;
 
-    return theme.tokens.borderInteractiveSecondaryDefault;
+    return tokens.borderInteractiveSecondaryDefault;
   }
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.tokens;
-    final prefix = widget.prefix;
-    final suffix = widget.suffix;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -159,10 +163,11 @@ class _FieldWrapper extends State<FieldWrapper> with ThemeGetter {
                 child: Padding(
                   padding: EdgeInsets.symmetric(
                     horizontal: widget.size.getContentPadding(tokens),
+                    vertical: _verticalPadding,
                   ),
                   child: Row(
                     children: [
-                      if (prefix != null)
+                      if (widget.prefix case final prefix?)
                         Padding(
                           padding: EdgeInsets.only(right: tokens.spacing100),
                           child: _Styled(
@@ -171,7 +176,7 @@ class _FieldWrapper extends State<FieldWrapper> with ThemeGetter {
                           ),
                         ),
                       ...widget.children,
-                      if (suffix != null)
+                      if (widget.suffix case final suffix?)
                         Padding(
                           padding: EdgeInsets.only(left: tokens.spacing50),
                           child: _Styled(
@@ -498,6 +503,15 @@ extension on OptimusWidgetSize {
       };
   EdgeInsets getErrorPadding(OptimusTokens tokens) =>
       EdgeInsets.only(top: tokens.spacing50);
+
+  double getVerticalPadding(OptimusTokens tokens) => switch (this) {
+        OptimusWidgetSize.small ||
+        OptimusWidgetSize.medium =>
+          tokens.spacing100,
+        OptimusWidgetSize.large ||
+        OptimusWidgetSize.extraLarge =>
+          tokens.spacing150,
+      };
 
   double getContentPadding(OptimusTokens tokens) => switch (this) {
         OptimusWidgetSize.small => tokens.spacing150,

--- a/optimus/lib/src/form/input_field.dart
+++ b/optimus/lib/src/form/input_field.dart
@@ -259,7 +259,8 @@ class _OptimusInputFieldState extends State<OptimusInputField>
       hasBorders: widget.hasBorders,
       isRequired: widget.isRequired,
       inline: widget.inline,
-      inputCounter: counter,
+      multiline: (widget.minLines ?? 1) > 1,
+      inputCounter: widget.inline ? null : counter,
       statusBarState: widget.statusBarState,
       prefix: _shouldShowPrefix
           ? Prefix(prefix: widget.prefix, leading: widget.leading)

--- a/storybook/lib/stories/input.dart
+++ b/storybook/lib/stories/input.dart
@@ -43,6 +43,8 @@ final Story inputStory = Story(
       maxChars =
           k.sliderInt(label: 'Max Characters', max: 100, min: 1, initial: 30);
     }
+    final minLines =
+        k.sliderInt(label: 'Min lines', initial: 1, min: 1, max: 10);
     final inline = k.boolean(label: 'Inline', initial: false);
 
     final statusBar = k.options(
@@ -60,6 +62,8 @@ final Story inputStory = Story(
           isRequired: k.boolean(label: 'Required'),
           isPasswordField: k.boolean(label: 'Password'),
           maxCharacters: maxChars,
+          minLines: minLines,
+          maxLines: minLines,
           prefix: prefix.isNotEmpty ? Text(prefix) : null,
           suffix: suffix.isNotEmpty ? Text(suffix) : null,
           leading: leadingIcon == null ? null : Icon(leadingIcon),


### PR DESCRIPTION
#### Summary

- added vertical padding to the input when the input is multi-lined
- updated story
- minor clean-up

<details><summary>Screenshots</summary>
Before:

![CleanShot 2024-06-26 at 11 45 43](https://github.com/MewsSystems/mews-flutter/assets/9210422/8c6aa6d1-29aa-4bbd-9d0b-949df943fb37)



After:

![CleanShot 2024-06-26 at 11 41 14](https://github.com/MewsSystems/mews-flutter/assets/9210422/dd08620e-c467-4881-a1f7-18119c4601b7)


</details>


#### Testing steps

1. Open `Input` story
2. Test input with various `Minimal lines` knob

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
