### PR TITLE
ci: [DX-1992] Fix publish workflow

### DIFF
--- a/.github/workflows/optimus-publish.yml
+++ b/.github/workflows/optimus-publish.yml
@@ -3,13 +3,29 @@ name: Publish optimus to pub.dev
 on:
   push:
     tags:
-      - 'optimus-v[0-9]+.[0-9]+.[0-9]+*'
+      - "optimus-v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   publish:
+    name: Publish to pub.dev
+    runs-on: ubuntu-latest
+
     permissions:
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      working-directory: optimus/
-      environment: pub.dev
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+
+      - name: Publish to pub.dev
+        run: flutter pub publish --directory=optimus --force


### PR DESCRIPTION
#### Summary

- added `flutter` to the workflow. 

Because of the https://github.com/dart-lang/setup-dart/issues/68 you either have to skip all validations or add `flutter`  and run publish via `flutter` not `dart`. 

#### Testing steps

I will create a new release and see if it will solve the problem.

#### Follow-up issues

None.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
