### PR TITLE
feat!: Upgrade to DCM 1.19.1

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.18.1"
+          version: "1.19.1"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -385,6 +385,7 @@ dart_code_metrics:
     # - format-comment
     # - format-test-name
     - function-always-returns-null
+    # - handle-throwing-invocations
     # - map-keys-ordering
     # - match-class-name-pattern
     - match-getter-setter-field-names
@@ -432,6 +433,7 @@ dart_code_metrics:
     # - prefer-correct-switch-length
     - prefer-correct-test-file-name:
         exclude: ["lib/**", "bin/**"]
+    # - prefer-correct-throws
     # - prefer-correct-type-name
     - prefer-declaring-const-constructor:
         ignore-abstract: false
@@ -440,6 +442,7 @@ dart_code_metrics:
     - prefer-explicit-function-type
     - prefer-explicit-parameter-names
     - prefer-explicit-type-arguments
+    # - prefer-extracting-function-callbacks
     # - prefer-first
     # - prefer-getter-over-method
     - prefer-immediate-return
@@ -486,6 +489,7 @@ dart_code_metrics:
     # - avoid-empty-setstate
     - avoid-expanded-as-spacer
     # - avoid-incomplete-copy-with
+    - avoid-incorrect-image-opacity
     # - avoid-inherited-widget-in-initstate
     - avoid-late-context
     - avoid-missing-controller


### PR DESCRIPTION
#### Summary

- upgraded to DCM 1.19.1
##### New rules: 
- [avoid-incorrect-image-opacity](https://dcm.dev/docs/rules/flutter/avoid-incorrect-image-opacity/)


##### Rules left disabled:
- [handle-throwing-invocations](https://dcm.dev/docs/rules/common/handle-throwing-invocations/) - is focused around `dart-code-metrics-annotations` package which we don't use
- [prefer-correct-throws](https://dcm.dev/docs/rules/common/prefer-correct-throws/) - again, focused around the `dart-code-metrics-annotations` package
- [prefer-extracting-function-callbacks](https://dcm.dev/docs/rules/common/prefer-extracting-function-callbacks/) - is a good idea, we could enable it (with a limit of something like 5 lines) but it is flagging a bunch of tests.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
