### PR TITLE
fix: [DX-1926] Fix placeholder alignment in the multiline input

### DIFF
--- a/optimus/lib/src/common/field_wrapper.dart
+++ b/optimus/lib/src/common/field_wrapper.dart
@@ -26,6 +26,7 @@ class FieldWrapper extends StatefulWidget {
     this.inline = false,
     this.multiline = false,
     this.statusBarState,
+    this.placeholder,
   });
 
   final bool isEnabled;
@@ -48,6 +49,7 @@ class FieldWrapper extends StatefulWidget {
   final bool inline;
   final bool multiline;
   final OptimusStatusBarState? statusBarState;
+  final Widget? placeholder;
 
   bool get hasError {
     final error = this.error;
@@ -165,25 +167,37 @@ class _FieldWrapper extends State<FieldWrapper> with ThemeGetter {
                     horizontal: widget.size.getContentPadding(tokens),
                     vertical: _verticalPadding,
                   ),
-                  child: Row(
+                  child: Stack(
                     children: [
-                      if (widget.prefix case final prefix?)
-                        Padding(
-                          padding: EdgeInsets.only(right: tokens.spacing100),
-                          child: _Styled(
-                            isEnabled: widget.isEnabled,
-                            child: prefix,
-                          ),
+                      if (widget.placeholder case final placeholder?)
+                        Align(
+                          alignment: widget.multiline
+                              ? Alignment.topLeft
+                              : Alignment.centerLeft,
+                          child: placeholder,
                         ),
-                      ...widget.children,
-                      if (widget.suffix case final suffix?)
-                        Padding(
-                          padding: EdgeInsets.only(left: tokens.spacing50),
-                          child: _Styled(
-                            isEnabled: widget.isEnabled,
-                            child: suffix,
-                          ),
-                        ),
+                      Row(
+                        children: [
+                          if (widget.prefix case final prefix?)
+                            Padding(
+                              padding:
+                                  EdgeInsets.only(right: tokens.spacing100),
+                              child: _Styled(
+                                isEnabled: widget.isEnabled,
+                                child: prefix,
+                              ),
+                            ),
+                          ...widget.children,
+                          if (widget.suffix case final suffix?)
+                            Padding(
+                              padding: EdgeInsets.only(left: tokens.spacing50),
+                              child: _Styled(
+                                isEnabled: widget.isEnabled,
+                                child: suffix,
+                              ),
+                            ),
+                        ],
+                      ),
                     ],
                   ),
                 ),

--- a/optimus/lib/src/form/input_field.dart
+++ b/optimus/lib/src/form/input_field.dart
@@ -275,10 +275,13 @@ class _OptimusInputFieldState extends State<OptimusInputField>
 
   Widget? get _placeholder {
     final placeholder = widget.placeholder;
-    if (placeholder != null && _effectiveController.text.isEmpty) {
+    if (placeholder != null &&
+        _effectiveController.text.isEmpty &&
+        !_effectiveFocusNode.hasFocus) {
       return Text(
         placeholder,
-        style: widget.placeholderStyle ?? theme.getTextInputStyle(),
+        style: widget.placeholderStyle ??
+            theme.getTextInputStyle(isEnabled: widget.isEnabled),
       );
     }
   }

--- a/optimus/lib/src/form/input_field.dart
+++ b/optimus/lib/src/form/input_field.dart
@@ -115,7 +115,10 @@ class OptimusInputField extends StatefulWidget {
   /// An optional text to display before the input.
   final Widget? prefix;
 
+  /// The [Key] for the input field.
   final Key? inputKey;
+
+  /// The [Key] for the field box.
   final Key? fieldBoxKey;
 
   /// An optional text to display after the text.
@@ -128,8 +131,10 @@ class OptimusInputField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.readOnly}
   final bool readOnly;
 
+  /// The callback to be called when the field is tapped.
   final VoidCallback? onTap;
 
+  /// The horizontal alignment of the text.
   final TextAlign textAlign;
 
   /// {@macro flutter.widgets.editableText.textCapitalization}
@@ -268,6 +273,16 @@ class _OptimusInputFieldState extends State<OptimusInputField>
         () => _isShowPasswordEnabled = !_isShowPasswordEnabled,
       );
 
+  Widget? get _placeholder {
+    final placeholder = widget.placeholder;
+    if (placeholder != null && _effectiveController.text.isEmpty) {
+      return Text(
+        placeholder,
+        style: widget.placeholderStyle ?? theme.getTextInputStyle(),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final error = widget.error;
@@ -324,6 +339,8 @@ class _OptimusInputFieldState extends State<OptimusInputField>
           : null,
       fieldBoxKey: widget.fieldBoxKey,
       size: widget.size,
+      placeholder:
+          _placeholder, // TODO(witwash): rework when https://github.com/flutter/flutter/issues/138794 is fixed
       children: [
         Expanded(
           child: CupertinoTextField(
@@ -341,9 +358,6 @@ class _OptimusInputFieldState extends State<OptimusInputField>
             minLines: _minLines,
             onSubmitted: widget.onSubmitted,
             textInputAction: widget.textInputAction,
-            placeholder: widget.placeholder,
-            placeholderStyle: widget.placeholderStyle ??
-                theme.getPlaceholderStyle(isEnabled: widget.isEnabled),
             focusNode: _effectiveFocusNode,
             enabled: widget.isEnabled,
             padding: EdgeInsets.zero,


### PR DESCRIPTION
#### Summary
- fixed vertical alignment of the `placeholder` inside the `OptimusInputField`. 
- due to the https://github.com/flutter/flutter/issues/138794 I had to move it and create a separate `placeholder` with stack
 
#### Testing steps

1. Open any input story.
2. Check the input and placeholder style when empty, not empty, disabled, enabled and both in light and dark themes.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
