### PR TITLE
ci: Add missing publish workflows

### DIFF
--- a/.github/workflows/kiosk_mode-publish.yml
+++ b/.github/workflows/kiosk_mode-publish.yml
@@ -1,0 +1,21 @@
+name: Publish kiosk_mode to pub.dev
+
+on:
+  push:
+    tags:
+      - "kiosk_mode-v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  publish:
+    name: Publish to pub.dev
+    runs-on: ubuntu-latest
+    environment: pub.dev
+    permissions:
+      id-token: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/publish
+        with:
+          working-directory: kiosk_mode

--- a/.github/workflows/remote_logger-publish.yml
+++ b/.github/workflows/remote_logger-publish.yml
@@ -1,0 +1,21 @@
+name: Publish remote_logger to pub.dev
+
+on:
+  push:
+    tags:
+      - "remote_logger-v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  publish:
+    name: Publish to pub.dev
+    runs-on: ubuntu-latest
+    environment: pub.dev
+    permissions:
+      id-token: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/publish
+        with:
+          working-directory: remote_logger


### PR DESCRIPTION
#### Summary

- Added publish workflows for `kiosk_mode` and `remote_logger`

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
