### PR TITLE
fix: [DX-2051] Fix OptimusTab title overflow

### DIFF
--- a/optimus/lib/src/tabs.dart
+++ b/optimus/lib/src/tabs.dart
@@ -36,7 +36,7 @@ class OptimusTab extends StatelessWidget {
 
     return Container(
       padding: EdgeInsets.symmetric(horizontal: tokens.spacing150),
-      height: 48,
+      height: tokens.sizing600,
       constraints: BoxConstraints(maxWidth: maxWidth ?? double.infinity),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -46,7 +46,7 @@ class OptimusTab extends StatelessWidget {
               padding: EdgeInsets.only(right: tokens.spacing50),
               child: Icon(icon, size: tokens.sizing200),
             ),
-          Text(label, overflow: TextOverflow.ellipsis),
+          Flexible(child: Text(label, overflow: TextOverflow.ellipsis)),
           if (badge case final badge?)
             Padding(
               padding: EdgeInsets.only(left: tokens.spacing50),

--- a/storybook/lib/stories/tab/tabs.dart
+++ b/storybook/lib/stories/tab/tabs.dart
@@ -22,7 +22,7 @@ final Story tabsStory = Story(
         tabs: _items
             .map(
               (i) => OptimusTab(
-                label: 'Tab ${i + 1}',
+                label: i.isEven ? 'Tab with long name' : 'Tab ${i + 1}',
                 icon: i.isOdd ? icon : null,
                 badge: i.isOdd ? badge : null,
                 maxWidth: _tabBarWidth / _items.length,


### PR DESCRIPTION
#### Summary

- fixed the horizontal overflow in tabs with long names

#### Testing steps

1. Open `Tabs` story
2. Check the visuals of the component. The long text should not overflow horizontally.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
