### PR TITLE
feat!: [DX-2187] Upgrade to DCM 1.22.0

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.21.2"
+          version: "1.22.0"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -268,6 +268,7 @@ dart_code_metrics:
     - avoid-double-slash-imports
     - avoid-duplicate-cascades
     - avoid-duplicate-collection-elements
+    - avoid-duplicate-constant-values
     - avoid-duplicate-exports
     - avoid-duplicate-initializers
     - avoid-duplicate-map-keys
@@ -287,9 +288,12 @@ dart_code_metrics:
     - avoid-function-type-in-records
     - avoid-future-tostring
     - avoid-generics-shadowing
+    - avoid-getter-prefix:
+        prefix: '^get'
     - avoid-global-state
     # - avoid-identical-exception-handling-blocks
     # - avoid-ignoring-return-values
+    - avoid-implicitly-nullable-extension-types
     # - avoid-importing-entrypoint-exports
     # - avoid-inferrable-type-arguments
     - avoid-inverted-boolean-checks
@@ -321,6 +325,7 @@ dart_code_metrics:
     # - avoid-nested-switch-expressions
     - avoid-nested-switches
     # - avoid-non-ascii-symbols
+    - avoid-non-final-exception-class-fields
     - avoid-non-null-assertion
     - avoid-not-encodable-in-to-json
     - avoid-nullable-interpolation
@@ -352,6 +357,7 @@ dart_code_metrics:
     # - avoid-throw-in-catch-block
     # - avoid-throw-objects-without-tostring
     # - avoid-top-level-members-in-tests
+    - avoid-type-casts
     - avoid-unassigned-late-fields
     - avoid-unassigned-stream-subscriptions
     - avoid-uncaught-future-errors
@@ -360,12 +366,17 @@ dart_code_metrics:
     - avoid-unnecessary-call
     - avoid-unnecessary-collections
     - avoid-unnecessary-conditionals
+    - avoid-unnecessary-constructor
+    - avoid-unnecessary-enum-arguments
+    - avoid-unnecessary-enum-prefix
+    - avoid-unnecessary-extends
     - avoid-unnecessary-futures
     - avoid-unnecessary-getter
     - avoid-unnecessary-if
     - avoid-unnecessary-local-late
     - avoid-unnecessary-negations
     - avoid-unnecessary-nullable-return-type
+    - avoid-unnecessary-overrides
     - avoid-unnecessary-reassignment
     - avoid-unnecessary-return
     - avoid-unnecessary-super
@@ -376,6 +387,7 @@ dart_code_metrics:
     # - avoid-unsafe-collection-methods
     - avoid-unsafe-reduce
     - avoid-unused-after-null-check
+    - avoid-unused-assignment
     - avoid-unused-generics
     # - avoid-unused-instances
     - avoid-unused-parameters
@@ -424,11 +436,12 @@ dart_code_metrics:
     - prefer-any-or-every
     # - prefer-async-await
     - prefer-boolean-prefixes:
-        prefixes: [is, are, was, were, has, have, had, can, should, will, do, does, did, allow, show, use, hide, only, enable]
+        prefixes: [ is, are, was, were, has, have, had, can, should, will, do, does, did, allow, show, use, hide, only, enable ]
     - prefer-both-inlining-annotations
     # - prefer-bytes-builder
     - prefer-commenting-analyzer-ignores
     # - prefer-conditional-expressions
+    - prefer-contains
     # - prefer-correct-callback-field-name
     - prefer-correct-error-name
     - prefer-correct-for-loop-increment
@@ -440,7 +453,7 @@ dart_code_metrics:
     - prefer-correct-stream-return-type
     # - prefer-correct-switch-length
     - prefer-correct-test-file-name:
-        exclude: ["lib/**", "bin/**"]
+        exclude: [ "lib/**", "bin/**" ]
     # - prefer-correct-throws
     # - prefer-correct-type-name
     - prefer-declaring-const-constructor:
@@ -530,6 +543,8 @@ dart_code_metrics:
     # - prefer-using-list-view
     - prefer-widget-private-members:
         ignore-static: true
+    #    - avoid-assigning-to-static-field
+    - avoid-assignments-as-conditions
     - proper-super-calls
     - use-setstate-synchronously
 
@@ -549,6 +564,17 @@ dart_code_metrics:
     # - check-is-not-closed-after-async-gap
     - prefer-correct-bloc-provider
     - prefer-multi-bloc-provider
+
+  pubspec-rules:
+  #    - avoid-any-version
+  #    - avoid-dependency-overrides
+  #    - banned-dependencies
+  #    - prefer-caret-version-syntax
+  #    - prefer-correct-package-name
+  #    - prefer-correct-screenshots
+  #    - prefer-pinned-version-syntax
+  #    - prefer-publish-to-none
+  #    - prefer-semver-version
 
   metrics-exclude:
     - lib/**

--- a/optimus/lib/src/common/anchored_overlay.dart
+++ b/optimus/lib/src/common/anchored_overlay.dart
@@ -7,8 +7,11 @@ abstract class AnchoredOverlayController {
   const AnchoredOverlayController();
 
   double get maxHeight;
+
   double get width;
+
   double get top;
+
   double get bottom;
 }
 
@@ -128,10 +131,12 @@ class AnchoredOverlayState extends State<AnchoredOverlay>
         size;
   }
 
-  RenderBox? _getOverlay() =>
-      Overlay.of(context, rootOverlay: widget.useRootOverlay)
-          .context
-          .findRenderObject() as RenderBox?;
+  RenderBox? _getOverlay() {
+    final renderBox = Overlay.of(context, rootOverlay: widget.useRootOverlay)
+        .context
+        .findRenderObject();
+    if (renderBox is RenderBox) return renderBox;
+  }
 
   Size? _getOverlaySize() => _getOverlay()?.size;
 

--- a/optimus/lib/src/dropdown/dropdown.dart
+++ b/optimus/lib/src/dropdown/dropdown.dart
@@ -287,8 +287,8 @@ class _GroupedDropdownListViewState<T>
 
         int? result = widget.groupBy(value1).compareTo(widget.groupBy(value2));
         if (result == 0) {
-          if (value1 is Comparable) {
-            result = value1.compareTo(value2 as Comparable);
+          if (value1 is Comparable && value2 is Comparable) {
+            result = value1.compareTo(value2);
           }
         } else {
           groupsCount++;

--- a/optimus/lib/src/dropdown/dropdown_tile.dart
+++ b/optimus/lib/src/dropdown/dropdown_tile.dart
@@ -5,9 +5,6 @@ abstract class OptimusDropdownTile<T> extends StatelessWidget {
   const OptimusDropdownTile({super.key, required this.value});
 
   final T value;
-
-  @override
-  Widget build(BuildContext context);
 }
 
 class ListDropdownTile<T> extends OptimusDropdownTile<T> {

--- a/optimus/lib/src/expansion/expansion_tile.dart
+++ b/optimus/lib/src/expansion/expansion_tile.dart
@@ -103,8 +103,8 @@ class _OptimusExpansionTileState extends State<OptimusExpansionTile>
     _heightFactor = _controller.drive(_easeInTween);
     _iconTurns = _controller.drive(_halfTween.chain(_easeInTween));
 
-    _isExpanded = (PageStorage.of(context).readState(context) ??
-        widget.isInitiallyExpanded) as bool;
+    final stateValue = PageStorage.of(context).readState(context);
+    _isExpanded = stateValue is bool ? stateValue : widget.isInitiallyExpanded;
     if (_isExpanded) _controller.value = 1.0;
   }
 

--- a/optimus/lib/src/feedback/alert_overlay.dart
+++ b/optimus/lib/src/feedback/alert_overlay.dart
@@ -203,6 +203,7 @@ class _NoClipSizeTransition extends AnimatedWidget {
 
   final Widget? child;
 
+  // ignore: avoid-type-casts, no need to check, can't be anything else
   Animation<double> get sizeFactor => listenable as Animation<double>;
 
   @override

--- a/optimus/lib/src/form/date_formatter.dart
+++ b/optimus/lib/src/form/date_formatter.dart
@@ -158,6 +158,11 @@ class DateFormatter extends TextInputFormatter {
           newText[oldSelectionStart],
         );
         resultSelection = _getNextInputIndex(newSelectionStart);
+
+        return TextEditingValue(
+          text: resultText,
+          selection: TextSelection.collapsed(offset: resultSelection),
+        );
       }
     } else if (newText.length < oldText.length) {
       if (_isValidDigit(oldText[newSelectionStart])) {
@@ -180,9 +185,10 @@ class DateFormatter extends TextInputFormatter {
           placeholder.substring(start, end),
         );
 
-        if (_inputLength(resultText) == 0) resultText = '';
-
-        resultSelection = selectionPosition;
+        return TextEditingValue(
+          text: _inputLength(resultText) == 0 ? '' : resultText,
+          selection: TextSelection.collapsed(offset: selectionPosition),
+        );
       } else if (_isDesignatedSpace(newSelectionStart)) {
         final prevInputSpace = _getPreviousInputIndex(newSelectionStart);
         if (_isValidDigit(oldText[prevInputSpace])) {

--- a/optimus/lib/src/form/date_input_form_field.dart
+++ b/optimus/lib/src/form/date_input_form_field.dart
@@ -45,5 +45,6 @@ class OptimusDateInputFormField extends FormField<DateTime?> {
 class _DateInputFormFieldState extends FormFieldState<DateTime?> {
   @override
   OptimusDateInputFormField get widget =>
+      // ignore: avoid-type-casts, no need to check, can't be anything else
       super.widget as OptimusDateInputFormField;
 }

--- a/optimus/lib/src/form/input_form_field.dart
+++ b/optimus/lib/src/form/input_form_field.dart
@@ -54,6 +54,7 @@ class OptimusInputFormField extends FormField<String> {
               controller != null ? controller.text : (initialValue ?? ''),
           enabled: isEnabled,
           builder: (FormFieldState<String> field) {
+            // ignore: avoid-type-casts, can't be anything else. No need to check
             final _InputFormFieldState state = field as _InputFormFieldState;
 
             return OptimusInputField(
@@ -114,6 +115,7 @@ class _InputFormFieldState extends FormFieldState<String> {
   // initialized at this point
 
   @override
+  // ignore: avoid-type-casts, can't be anything else. No need to check.
   OptimusInputFormField get widget => super.widget as OptimusInputFormField;
 
   @override

--- a/optimus/lib/src/tokens/tokens_dark.dart
+++ b/optimus/lib/src/tokens/tokens_dark.dart
@@ -2,6 +2,8 @@
 // tokens_dark.dart
 //
 
+// ignore_for_file: avoid-duplicate-constant-values
+
 // Do not edit directly
 // Generated on Mon, 02 Sep 2024 13:49:23 GMT
 

--- a/optimus/lib/src/tokens/tokens_light.dart
+++ b/optimus/lib/src/tokens/tokens_light.dart
@@ -2,6 +2,8 @@
 // tokens_light.dart
 //
 
+// ignore_for_file: avoid-duplicate-constant-values
+
 // Do not edit directly
 // Generated on Mon, 02 Sep 2024 13:49:22 GMT
 

--- a/optimus/lib/src/tooltip/tooltip_overlay.dart
+++ b/optimus/lib/src/tooltip/tooltip_overlay.dart
@@ -62,7 +62,7 @@ class TooltipOverlayState extends State<TooltipOverlay>
   late Rect _savedRect = _calculateRect(widget.anchorKey);
   late Rect _tooltipRect = _calculateRect(widget.tooltipKey);
   late Size? _overlaySize = _getOverlaySize();
-  late OptimusTooltipPosition _position = _getPreferredPosition;
+  late OptimusTooltipPosition _position = _preferredPosition;
 
   double _opacity = 0.0;
 
@@ -112,7 +112,7 @@ class TooltipOverlayState extends State<TooltipOverlay>
   double get _verticalCenterBottom =>
       _savedRect.top - _savedRect.height / 2 + _tooltipRect.height / 2;
 
-  OptimusTooltipPosition get _getPreferredPosition =>
+  OptimusTooltipPosition get _preferredPosition =>
       widget.position ?? _fallbackPosition;
 
   OptimusTooltipPosition get _fallbackPosition =>
@@ -280,10 +280,12 @@ class TooltipOverlayState extends State<TooltipOverlay>
         size;
   }
 
-  RenderBox? _getOverlay() =>
-      Overlay.of(context, rootOverlay: widget.useRootOverlay)
-          .context
-          .findRenderObject() as RenderBox?;
+  RenderBox? _getOverlay() {
+    final renderObject = Overlay.of(context, rootOverlay: widget.useRootOverlay)
+        .context
+        .findRenderObject();
+    if (renderObject is RenderBox) return renderObject;
+  }
 
   Size? _getOverlaySize() => _getOverlay()?.size;
 

--- a/optimus_icons/utils/gen_icons.dart
+++ b/optimus_icons/utils/gen_icons.dart
@@ -1,6 +1,8 @@
 /// Copyright (c) 2020, Mike Hoolehan, StarHeight Media
 /// All rights reserved.
 
+// ignore_for_file: avoid-type-casts, utility script
+
 /// Redistribution and use in source and binary forms, with or without
 /// modification, are permitted provided that the following conditions are met:
 ///     * Redistributions of source code must retain the above copyright


### PR DESCRIPTION
#### Summary

New rules:
- [avoid-unnecessary-extends](https://dcm.dev/docs/rules/common/avoid-unnecessary-extends/) 🛠
- [avoid-assignments-as-conditions](https://dcm.dev/docs/rules/common/avoid-assignments-as-conditions/)
- [avoid-type-casts](https://dcm.dev/docs/rules/common/avoid-type-casts/) ⚙️
- [avoid-unused-assignment](https://dcm.dev/docs/rules/common/avoid-unused-assignment/)
- [avoid-unnecessary-overrides](https://dcm.dev/docs/rules/common/avoid-unnecessary-overrides/) 🛠
- [avoid-duplicate-constant-values](https://dcm.dev/docs/rules/common/avoid-duplicate-constant-values/)
- [avoid-unnecessary-enum-arguments](https://dcm.dev/docs/rules/common/avoid-unnecessary-enum-arguments/) 🛠
- [prefer-contains](https://dcm.dev/docs/rules/common/prefer-contains/) 🛠
- [avoid-unnecessary-constructor](https://dcm.dev/docs/rules/common/avoid-unnecessary-constructor/) 🛠
- [avoid-implicitly-nullable-extension-types](https://dcm.dev/docs/rules/common/avoid-implicitly-nullable-extension-types/) 🛠
- [avoid-getter-prefix](https://dcm.dev/docs/rules/common/avoid-getter-prefix/) ⚙️
- [avoid-unnecessary-enum-prefix](https://dcm.dev/docs/rules/common/avoid-unnecessary-enum-prefix/) 🛠
- [avoid-non-final-exception-class-fields](https://dcm.dev/docs/rules/common/avoid-non-final-exception-class-fields/)
-

New rules left disabled:
- [avoid-assigning-to-static-field](https://dcm.dev/docs/rules/common/avoid-assigning-to-static-field/)

Minor formatting and linter fixes

#### Testing steps

None

#### Follow-up issues

Release `optimus_pedantic`

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
