### PR TITLE
fix: [DX-2181] Fix prefix aspect ratio being wrong

### DIFF
--- a/optimus/lib/src/lists/list_tile.dart
+++ b/optimus/lib/src/lists/list_tile.dart
@@ -159,7 +159,10 @@ class _Prefix extends StatelessWidget {
         child: OptimusTypography(
           color: OptimusTypographyColor.secondary,
           resolveStyle: (_) => tokens.bodyMediumStrong,
-          child: prefix,
+          child: AspectRatio(
+            aspectRatio: 1,
+            child: prefix,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
#### Summary

- fixed aspect ratio of `prefix` being wrong

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
