### PR TITLE
ci: Bump publish action Flutter version

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: 3.22.3
+        flutter-version: 3.24.2
 
     - name: Get ID Token
       uses: actions/github-script@v6


### PR DESCRIPTION
#### Summary

- fixed outdated Flutter version in publish action

#### Testing steps

Not needed

#### Follow-up issues

- create a variable or something that would ensure all versions are in sync and this won't happen again

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
