### PR TITLE
fix: [DX-2199] Fix alignment addon

### DIFF
--- a/optimus_widgetbook/lib/main.dart
+++ b/optimus_widgetbook/lib/main.dart
@@ -23,7 +23,6 @@ class WidgetbookApp extends StatelessWidget {
             ],
           ),
           InspectorAddon(),
-          AlignmentAddon(),
           ThemeAddon<OptimusThemeData>(
             themes: [
               const WidgetbookTheme(
@@ -54,9 +53,10 @@ class WidgetbookApp extends StatelessWidget {
             name: 'Background builder',
             builder: (BuildContext context, Widget widget) => ColoredBox(
               color: context.tokens.backgroundStaticFlat,
-              child: Center(child: widget),
+              child: SafeArea(child: widget),
             ),
           ),
+          AlignmentAddon(),
         ],
         directories: directories,
       );


### PR DESCRIPTION
#### Summary

- Fixed `AlignmentAddon` not working properly because of the wrong order in nesting.

#### Testing steps

- `AlignmentAddon` should work now and change align should visually change the position of the showcased component.

#### Follow-up issues

- Rework some use cases that wrap components in `Center` as they would intervene with this addon.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
