### PR TITLE
Dx 3397

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.23.1"
+          version: "1.24.2"
 
       - uses: ./.github/actions/setup
 

--- a/kiosk_mode/example/lib/main.dart
+++ b/kiosk_mode/example/lib/main.dart
@@ -36,11 +36,7 @@ class _HomeState extends State<_Home> {
 
   void _handleStart(bool didStart) {
     if (!didStart && Platform.isIOS) {
-      _showSnackBar(
-        'Single App mode is supported only for devices that are supervised'
-        ' using Mobile Device Management (MDM) and the app itself must'
-        ' be enabled for this mode by MDM.',
-      );
+      _showSnackBar(_unsupportedMessage);
     }
   }
 
@@ -97,3 +93,9 @@ class _HomeState extends State<_Home> {
         },
       );
 }
+
+const _unsupportedMessage = '''
+Single App mode is supported only for devices that are supervised 
+using Mobile Device Management (MDM) and the app itself must 
+be enabled for this mode by MDM.
+''';

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -63,7 +63,6 @@ linter:
     - avoid_init_to_null
     - avoid_js_rounded_ints
     # - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
     # - avoid_private_typedef_functions
     # - avoid_redundant_argument_values
@@ -99,6 +98,7 @@ linter:
     - flutter_style_todos
     - implementation_imports
     - implicit_call_tearoffs
+    - invalid_runtime_check_with_js_interop_types
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_annotations
@@ -186,6 +186,7 @@ linter:
     - unnecessary_lambdas
     - unnecessary_late
     - unnecessary_library_directive
+    - unnecessary_library_name
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_aware_operator_on_extension_on_nullable
@@ -247,6 +248,9 @@ dart_code_metrics:
     # - arguments-ordering
     - avoid-accessing-collections-by-constant-index
     # - avoid-accessing-other-classes-private-members
+    - avoid-adjacent-strings
+    # - avoid-assigning-to-static-field
+    - avoid-assignments-as-conditions
     # - avoid-async-call-in-sync-function
     # - avoid-banned-annotations
     # - avoid-banned-file-names
@@ -297,6 +301,7 @@ dart_code_metrics:
     # - avoid-ignoring-return-values
     - avoid-implicitly-nullable-extension-types
     # - avoid-importing-entrypoint-exports
+    - avoid-incorrect-uri
     # - avoid-inferrable-type-arguments
     - avoid-inverted-boolean-checks
     - avoid-keywords-in-wildcard-pattern
@@ -320,6 +325,7 @@ dart_code_metrics:
     - avoid-multi-assignment
     # - avoid-mutating-parameters
     # - avoid-negated-conditions
+    - avoid-negations-in-equality-checks
     # - avoid-nested-conditional-expressions
     - avoid-nested-extension-types
     - avoid-nested-futures
@@ -407,6 +413,7 @@ dart_code_metrics:
     # - format-comment
     # - format-test-name
     - function-always-returns-null
+    - function-always-returns-same-value
     # - handle-throwing-invocations
     # - map-keys-ordering
     # - match-class-name-pattern
@@ -416,8 +423,7 @@ dart_code_metrics:
     # - member-ordering
     # - missing-test-assertion
     - missing-use-result-annotation:
-        types:
-          - Either
+        type-pattern: ^Either<
     - move-records-to-typedefs
     - move-variable-closer-to-its-usage
     - move-variable-outside-iteration
@@ -437,6 +443,7 @@ dart_code_metrics:
     - no-object-declaration
     # - parameters-ordering
     - prefer-abstract-final-static-class
+    - prefer-add-all
     # - prefer-addition-subtraction-assignments
     - prefer-any-or-every
     # - prefer-async-await
@@ -470,6 +477,7 @@ dart_code_metrics:
     - prefer-explicit-type-arguments
     # - prefer-extracting-function-callbacks
     # - prefer-first
+    - prefer-for-in
     # - prefer-getter-over-method
     - prefer-immediate-return
     - prefer-iterable-of
@@ -516,6 +524,7 @@ dart_code_metrics:
     # - avoid-border-all
     # - avoid-empty-setstate
     - avoid-expanded-as-spacer
+    - avoid-flexible-outside-flex
     # - avoid-incomplete-copy-with
     - avoid-incorrect-image-opacity
     # - avoid-inherited-widget-in-initstate
@@ -527,9 +536,9 @@ dart_code_metrics:
     - avoid-shrink-wrap-in-lists
     - avoid-single-child-column-or-row
     - avoid-state-constructors
+    - avoid-stateless-widget-initialized-fields
     # - avoid-undisposed-instances
     - avoid-unnecessary-gesture-detector
-    - avoid-stateless-widget-initialized-fields
     - avoid-unnecessary-overrides-in-state
     - avoid-unnecessary-setstate
     - avoid-unnecessary-stateful-widgets
@@ -538,20 +547,21 @@ dart_code_metrics:
     - consistent-update-render-object
     - dispose-fields
     # - prefer-action-button-tooltip
+    - prefer-center-over-align
     - prefer-const-border-radius
     - prefer-correct-edge-insets-constructor
     - prefer-dedicated-media-query-methods
     - prefer-define-hero-tag
     # - prefer-extracting-callbacks
     # - prefer-for-loop-in-children
+    - prefer-padding-over-container
     # - prefer-single-widget-per-file
+    - prefer-sized-box-square
     - prefer-sliver-prefix
     - prefer-text-rich
     # - prefer-using-list-view
     - prefer-widget-private-members:
         ignore-static: true
-    #    - avoid-assigning-to-static-field
-    - avoid-assignments-as-conditions
     - proper-super-calls
     - use-setstate-synchronously
 
@@ -562,16 +572,23 @@ dart_code_metrics:
     # - avoid-watch-outside-build
     - dispose-providers
     - prefer-multi-provider
+    - prefer-provider-extensions
 
     # Bloc
 
     - avoid-bloc-public-methods
     - avoid-cubits
+    # - avoid-duplicate-bloc-event-handlers
     # - avoid-empty-build-when
     - avoid-passing-bloc-to-bloc
+    - avoid-passing-build-context-to-blocs
     # - check-is-not-closed-after-async-gap
+    - handle-bloc-event-subclasses
+    - prefer-bloc-extensions
     - prefer-correct-bloc-provider
     - prefer-multi-bloc-provider
+    - prefer-sealed-bloc-events
+    - prefer-sealed-bloc-state
 
   pubspec-rules:
   #    - avoid-any-version

--- a/optimus/lib/src/chat/bubble.dart
+++ b/optimus/lib/src/chat/bubble.dart
@@ -72,8 +72,10 @@ class _Date extends StatelessWidget {
       direction: Axis.horizontal,
       spacing: OptimusStackSpacing.spacing100,
       children: [
+        // ignore: avoid-flexible-outside-flex, it is wrapped in Flex latter
         Expanded(child: horizontalLine),
         Text(date, style: tokens.bodySmallStrong),
+        // ignore: avoid-flexible-outside-flex, it is wrapped in Flex latter
         Expanded(child: horizontalLine),
       ],
     );

--- a/optimus/lib/src/chat/chat.dart
+++ b/optimus/lib/src/chat/chat.dart
@@ -125,6 +125,7 @@ class OptimusChat extends StatelessWidget {
       child: OptimusStack(
         spacing: OptimusStackSpacing.spacing200,
         children: [
+          // ignore: avoid-flexible-outside-flex, it is wrapped in Flex later
           Expanded(
             child: ListView.builder(
               itemCount: _messages.length,

--- a/optimus/lib/src/dialogs/dialog_content.dart
+++ b/optimus/lib/src/dialogs/dialog_content.dart
@@ -41,8 +41,8 @@ class DialogContent extends StatelessWidget {
     final title = this.title;
     final content = this.content;
 
-    return Container(
-      margin: margin,
+    return Padding(
+      padding: margin ?? EdgeInsets.zero,
       child: Padding(
         padding: EdgeInsets.all(spacing ?? tokens.spacing0),
         child: ConstrainedBox(

--- a/optimus/lib/src/dropdown/dropdown.dart
+++ b/optimus/lib/src/dropdown/dropdown.dart
@@ -163,7 +163,7 @@ class _DropdownContentState<T> extends State<_DropdownContent<T>>
                 child: _buildList(isOnTop, listMaxHeight),
               ),
             )
-          : widget.emptyResultPlaceholder ?? const SizedBox.shrink();
+          : (widget.emptyResultPlaceholder ?? const SizedBox.shrink());
       final children = [
         Material(color: Colors.transparent, child: content),
         if (widget.embeddedSearch case final embeddedSearch?)

--- a/optimus/lib/src/expansion/expansion_tile.dart
+++ b/optimus/lib/src/expansion/expansion_tile.dart
@@ -173,7 +173,7 @@ class _OptimusExpansionTileState extends State<OptimusExpansionTile>
                 child: listTile,
               ),
             ClipRect(
-              child: Align(heightFactor: _heightFactor.value, child: child),
+              child: Center(heightFactor: _heightFactor.value, child: child),
             ),
           ],
         );

--- a/optimus/lib/src/form/input_field.dart
+++ b/optimus/lib/src/form/input_field.dart
@@ -348,6 +348,7 @@ class _OptimusInputFieldState extends State<OptimusInputField>
       placeholder:
           _placeholder, // TODO(witwash): rework when https://github.com/flutter/flutter/issues/138794 is fixed
       children: [
+        // ignore: avoid-flexible-outside-flex, it is wrapped in Row later
         Expanded(
           child: CupertinoTextField(
             key: widget.inputKey,

--- a/optimus/lib/src/form/multiselect_field.dart
+++ b/optimus/lib/src/form/multiselect_field.dart
@@ -123,6 +123,7 @@ class _OptimusMultiSelectInputFieldState extends State<MultiSelectInputField>
           fieldBoxKey: widget.fieldBoxKey,
           size: widget.size,
           children: [
+            // ignore: avoid-flexible-outside-flex, it is wrapped in Row later
             Flexible(
               child: Focus(
                 focusNode: _effectiveFocusNode,

--- a/optimus/lib/src/loader/spinner.dart
+++ b/optimus/lib/src/loader/spinner.dart
@@ -99,9 +99,8 @@ class _OptimusSpinnerState extends State<OptimusSpinner>
   }
 
   @override
-  Widget build(BuildContext context) => SizedBox(
-        width: widget.size.getSize(tokens),
-        height: widget.size.getSize(tokens),
+  Widget build(BuildContext context) => SizedBox.square(
+        dimension: widget.size.getSize(tokens),
         child: AnimatedBuilder(
           animation: _controller,
           builder: (context, child) => Stack(

--- a/optimus/lib/src/logo.dart
+++ b/optimus/lib/src/logo.dart
@@ -92,8 +92,8 @@ class OptimusMewsLogo extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.tokens;
 
-    return Container(
-      margin: _getMargin(tokens),
+    return Padding(
+      padding: _getMargin(tokens),
       child: switch (logoVariant) {
         OptimusMewsLogoVariant.logomark => _NonSquaredIcon(
             OptimusIcons.mews_logo,

--- a/optimus/lib/src/pictogram/pictogram.dart
+++ b/optimus/lib/src/pictogram/pictogram.dart
@@ -20,9 +20,8 @@ class OptimusPictogram extends StatelessWidget {
   final OptimusPictogramSize size;
 
   @override
-  Widget build(BuildContext context) => SizedBox(
-        width: size.getSize(context.tokens),
-        height: size.getSize(context.tokens),
+  Widget build(BuildContext context) => SizedBox.square(
+        dimension: size.getSize(context.tokens),
         child: SvgPicture.asset(
           variant.path(context.theme.brightness),
           package: 'optimus',

--- a/optimus/lib/src/progress_indicator/progress_indicator_item.dart
+++ b/optimus/lib/src/progress_indicator/progress_indicator_item.dart
@@ -263,9 +263,8 @@ class _DisabledIndicatorItem extends StatelessWidget {
     final tokens = context.tokens;
     final size = tokens.sizing300;
 
-    return SizedBox(
-      height: size,
-      width: size,
+    return SizedBox.square(
+      dimension: size,
       child: Center(
         child: Container(
           constraints: BoxConstraints(

--- a/optimus/lib/src/selection_card.dart
+++ b/optimus/lib/src/selection_card.dart
@@ -283,7 +283,7 @@ class _VerticalCard extends StatelessWidget {
               top: context.tokens.spacing100,
               child: selector,
             ),
-          Container(
+          Padding(
             padding: EdgeInsets.symmetric(
               horizontal: context.tokens.spacing200,
               vertical: context.tokens.spacing400,

--- a/optimus/lib/src/theme/theme.dart
+++ b/optimus/lib/src/theme/theme.dart
@@ -32,8 +32,8 @@ class OptimusTheme extends StatelessWidget {
     final bool isDark = themeMode == ThemeMode.dark ||
         (themeMode == ThemeMode.system && brightness == Brightness.dark);
     final theme = isDark
-        ? darkTheme ?? _defaultDarkTheme
-        : lightTheme ?? _defaultLightTheme;
+        ? (darkTheme ?? _defaultDarkTheme)
+        : (lightTheme ?? _defaultLightTheme);
 
     return _OptimusTheme(
       theme: theme,

--- a/optimus/lib/src/toggle.dart
+++ b/optimus/lib/src/toggle.dart
@@ -126,9 +126,8 @@ class _Knob extends StatelessWidget {
     final tokens = context.tokens;
     final knobSize = tokens.sizing200;
 
-    return SizedBox(
-      width: knobSize,
-      height: knobSize,
+    return SizedBox.square(
+      dimension: knobSize,
       child: DecoratedBox(
         decoration: ShapeDecoration(
           color: tokens.backgroundStaticFlat,

--- a/optimus/lib/src/tooltip/tooltip_wrapper.dart
+++ b/optimus/lib/src/tooltip/tooltip_wrapper.dart
@@ -54,6 +54,9 @@ class _OptimusTooltipWrapperState extends State<OptimusTooltipWrapper> {
           tooltipPosition: widget.tooltipPosition,
           content: widget.text,
         ),
-        child: Container(key: _anchorKey, child: widget.child),
+        child: KeyedSubtree(
+          key: _anchorKey,
+          child: widget.child,
+        ),
       );
 }

--- a/optimus_icons/utils/gen_icons.dart
+++ b/optimus_icons/utils/gen_icons.dart
@@ -66,8 +66,8 @@ void main(List<String> arguments) {
         )
         ..writeln('const optimusIcons = <IconDetails>[');
 
-      for (int i = 0; i < icons.length; i++) {
-        final Map<String, dynamic> glyphs = icons[i] as Map<String, dynamic>;
+      for (final icon in icons) {
+        final Map<String, dynamic> glyphs = icon as Map<String, dynamic>;
         final glyphName = convertGlyphName(glyphs['css'].toString());
         buffer.writeln(
           "    IconDetails($fontFamilyName.$glyphName, '$glyphName'),",

--- a/optimus_widgetbook/lib/components/layout/spacing.dart
+++ b/optimus_widgetbook/lib/components/layout/spacing.dart
@@ -36,9 +36,8 @@ Widget _buildSpacing(OptimusTokens tokens, double spacing, String label) =>
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
       child: Row(
         children: [
-          SizedBox(
-            width: spacing,
-            height: spacing,
+          SizedBox.square(
+            dimension: spacing,
             child: Container(color: Colors.black),
           ),
           Padding(


### PR DESCRIPTION
#### Summary

#### Enabled rules: 
##### Common:
-   [avoid-negations-in-equality-checks](https://dcm.dev/docs/rules/common/avoid-negations-in-equality-checks/) 
-   [avoid-incorrect-uri](https://dcm.dev/docs/rules/common/avoid-incorrect-uri/)
-   [function-always-returns-same-value](https://dcm.dev/docs/rules/common/function-always-returns-same-value/)
-   [prefer-add-all](https://dcm.dev/docs/rules/common/prefer-add-all/)
-   [prefer-for-in](https://dcm.dev/docs/rules/common/prefer-for-in/)
-   [avoid-adjacent-strings](https://dcm.dev/docs/rules/common/avoid-adjacent-strings/)

##### Flutter:

-   [prefer-sized-box-square](https://dcm.dev/docs/rules/flutter/prefer-sized-box-square/)
-   [avoid-flexible-outside-flex](https://dcm.dev/docs/rules/flutter/avoid-flexible-outside-flex/) - We might need to give feedback to the author to add exceptions. We have `OptimusStack` and other widgets that get `children` as input and wrap it in `Flex` later. I had to just ignore those cases for now.
-   [prefer-center-over-align](https://dcm.dev/docs/rules/flutter/prefer-center-over-align/) 
-   [prefer-padding-over-container](https://dcm.dev/docs/rules/flutter/prefer-padding-over-container/) - we have one like this from the core linter, but DCM one is working for more cases.

##### Bloc:

-   [prefer-bloc-extensions](https://dcm.dev/docs/rules/bloc/prefer-bloc-extensions/)
-   [avoid-duplicate-bloc-event-handlers](https://dcm.dev/docs/rules/bloc/avoid-duplicate-bloc-event-handlers/)
-   [handle-bloc-event-subclasses](https://dcm.dev/docs/rules/bloc/handle-bloc-event-subclasses/)
-   [avoid-passing-build-context-to-blocs](https://dcm.dev/docs/rules/bloc/avoid-passing-build-context-to-blocs/)
-   [prefer-sealed-bloc-events](https://dcm.dev/docs/rules/bloc/prefer-sealed-bloc-events/) 
-   [prefer-sealed-bloc-state](https://dcm.dev/docs/rules/bloc/prefer-sealed-bloc-state/) 

##### Provider:

-   [prefer-provider-extensions](https://dcm.dev/docs/rules/provider/prefer-provider-extensions/)

Added new rules from the `flutter_lints`: 
- [invalid_runtime_check_with_js_interop_types](https://dart.dev/tools/linter-rules/invalid_runtime_check_with_js_interop_types)
- [unnecessary_library_name](https://dart.dev/tools/linter-rules/unnecessary_library_name)

Plus small refactoring: removing old rules (that were deleted from the `flutter_lint`) and rearranging rules in list, to match the list on `dcm.dev`.

#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
