### PR TITLE
build!: Downgrade java version to java 8

### DIFF
--- a/kiosk_mode/android/build.gradle
+++ b/kiosk_mode/android/build.gradle
@@ -32,12 +32,12 @@ android {
     compileSdk = 34
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 
     sourceSets {


### PR DESCRIPTION
Fixed the following issue:
```
flutterEngine.getPlugins().add(new com.mews.kiosk_mode.KioskModePlugin());
                                                            ^
  bad class file: /Users/${path-to-project}/build/kiosk_mode/intermediates/compile_library_classes_jar/debug/bundleLibCompileToJarDebug/classes.jar(/com/mews/kiosk_mode/KioskModePlugin.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
1 error

```