### PR TITLE
ci: [DX-3555] Add Azure cleanup workflow

### DIFF
--- a/.github/workflows/clean-azure-blob.yml
+++ b/.github/workflows/clean-azure-blob.yml
@@ -1,0 +1,28 @@
+name: clean-azure-blob
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  deploy_widgetbook_azure:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID}}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Clean widgetbook blob folder
+        uses: azure/CLI@v2
+        with:
+          inlineScript: |
+            az storage blob delete-batch --source mews-ui-widgetbook --account-name ${{ secrets.AZURE_ACCOUNT_NAME }} --auth-mode login --dryrun


### PR DESCRIPTION
#### Summary

We've uploaded everything into the root blob folder (the root of `mews-ui-widgetbook`), but it had to be in the `release` folder, so the Web app can work correctly. 
Doing anything without credentials requires a bunch of requests etc, `product-engineering` recommended me to clean it up using the workflow and credentials they've provided.

To be safe, it is a dry run, I'll create a new one if deleting with the dry run is successful.

#### Testing steps

We merge, and I run. Maybe will need to change the trigger, because there are some limitations about what branch Azure is accessible to us.

#### Follow-up issues

Remove `-dryrun` and do the cleanup.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
