### PR TITLE
ci: [DX-3562] Change trigger to main branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,8 +1,8 @@
-name: Check PR to master
+name: Check PR to main
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   check:

--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -2,7 +2,7 @@ name: DCM
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   dcm:

--- a/.github/workflows/deploy-widgetbook-azure.yml
+++ b/.github/workflows/deploy-widgetbook-azure.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
     paths:
       - optimus_widgetbook/**
       - optimus/**

--- a/.github/workflows/deploy-widgetbook.yml
+++ b/.github/workflows/deploy-widgetbook.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
     paths:
       - optimus_widgetbook/**
       - optimus/**

--- a/.github/workflows/pr-project.yml
+++ b/.github/workflows/pr-project.yml
@@ -4,7 +4,7 @@ on:
     types:
       - opened
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/pr-size-watcher.yml
+++ b/.github/workflows/pr-size-watcher.yml
@@ -8,7 +8,7 @@ on:
       - labeled
       - unlabeled
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/.github/workflows/tokens-pr.yml
+++ b/.github/workflows/tokens-pr.yml
@@ -53,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr create \
-            --base master \
+            --base main \
             --head ${{ github.ref_name }} \
             --title '${{ env.PR_TYPE }}: Design Tokens Update ${{ env.TOKENS_VERSION }}' \
             --body 'Design Tokens were updated! This PR was created to update the code.'


### PR DESCRIPTION
#### Summary

The default branch is now `main` (because of the Azure access). I've updated all workflows that were watching after changes in `master` to watch `main` now instead.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
