### PR TITLE
feat!: [DX-3716] Upgrade to DCM 1.26.1

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.25.0"
+          version: "1.26.1"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -266,8 +266,11 @@ dart_code_metrics:
     - avoid-collection-equality-checks
     - avoid-collection-methods-with-unrelated-types
     # - avoid-collection-mutating-methods
+    - avoid-commented-out-code
+    # - avoid-complex-arithmetic-expressions
     - avoid-complex-loop-conditions
     - avoid-conditions-with-boolean-literals
+    # - avoid-continue
     - avoid-contradictory-expressions
     # - avoid-declaring-call-method
     - avoid-double-slash-imports
@@ -291,6 +294,7 @@ dart_code_metrics:
     # - avoid-explicit-type-declaration
     # - avoid-extensions-on-records
     - avoid-function-type-in-records
+    - avoid-future-ignore
     - avoid-future-tostring
     - avoid-generics-shadowing
     - avoid-getter-prefix:
@@ -298,6 +302,7 @@ dart_code_metrics:
     - avoid-global-state
     # - avoid-high-cyclomatic-complexity
     # - avoid-identical-exception-handling-blocks
+    # - avoid-if-with-many-branches
     # - avoid-ignoring-return-values
     - avoid-implicitly-nullable-extension-types
     # - avoid-importing-entrypoint-exports
@@ -379,6 +384,7 @@ dart_code_metrics:
     - avoid-unnecessary-collections
     - avoid-unnecessary-conditionals
     - avoid-unnecessary-constructor
+    - avoid-unnecessary-continue
     - avoid-unnecessary-enum-arguments
     - avoid-unnecessary-enum-prefix
     - avoid-unnecessary-extends
@@ -434,6 +440,7 @@ dart_code_metrics:
     - newline-before-return
     - no-boolean-literal-compare
     # - no-empty-block
+    # - no-empty-string
     # - no-equal-arguments
     - no-equal-conditions
     - no-equal-nested-conditions
@@ -444,6 +451,7 @@ dart_code_metrics:
     # - no-magic-string
     - no-object-declaration
     # - parameters-ordering
+    # - pattern-fields-ordering
     - prefer-abstract-final-static-class
     - prefer-add-all
     # - prefer-addition-subtraction-assignments
@@ -454,7 +462,9 @@ dart_code_metrics:
         prefixes: [ is, are, was, were, has, have, had, can, should, will, do, does, did, allow, show, use, hide, only, enable ]
     - prefer-both-inlining-annotations
     # - prefer-bytes-builder
+    # - prefer-class-destructuring
     - prefer-commenting-analyzer-ignores
+    # - prefer-commenting-future-delayed
     # - prefer-conditional-expressions
     - prefer-contains
     # - prefer-correct-callback-field-name
@@ -505,6 +515,8 @@ dart_code_metrics:
     # - prefer-single-declaration-per-file
     - prefer-specific-cases-first
     # - prefer-static-class
+    # - prefer-static-method
+    - prefer-switch-expression
     - prefer-switch-with-enums
     - prefer-switch-with-sealed-classes
     # - prefer-test-matchers
@@ -519,6 +531,7 @@ dart_code_metrics:
     # - record-fields-ordering
     # - tag-name
     # - unnecessary-trailing-comma
+    - use-existing-destructuring
     - use-existing-variable
 
     # Flutter
@@ -551,6 +564,7 @@ dart_code_metrics:
     - consistent-update-render-object
     - dispose-fields
     # - prefer-action-button-tooltip
+    - prefer-align-over-container
     - prefer-center-over-align
     - prefer-const-border-radius
     - prefer-container
@@ -563,11 +577,14 @@ dart_code_metrics:
     # - prefer-single-widget-per-file
     - prefer-sized-box-square
     - prefer-sliver-prefix
+    # - prefer-spacing
     - prefer-text-rich
+    - prefer-transform-over-container
     # - prefer-using-list-view
     - prefer-widget-private-members:
         ignore-static: true
     - proper-super-calls
+    - use-closest-build-context
     - use-setstate-synchronously
 
     # Provider
@@ -598,8 +615,8 @@ dart_code_metrics:
     - prefer-bloc-extensions
     - prefer-bloc-state-suffix
     - prefer-correct-bloc-provider
-    # - prefer-immutable-bloc-events
-    # - prefer-immutable-bloc-state
+    - prefer-immutable-bloc-events
+    - prefer-immutable-bloc-state
     - prefer-multi-bloc-provider
     - prefer-sealed-bloc-events
     - prefer-sealed-bloc-state

--- a/optimus/lib/src/selection_card.dart
+++ b/optimus/lib/src/selection_card.dart
@@ -308,12 +308,8 @@ class _VerticalCard extends StatelessWidget {
 }
 
 extension on OptimusSelectionCardBorderRadius {
-  Radius getBorderRadius(OptimusTokens tokens) {
-    switch (this) {
-      case OptimusSelectionCardBorderRadius.small:
-        return tokens.borderRadius100;
-      case OptimusSelectionCardBorderRadius.medium:
-        return tokens.borderRadius200;
-    }
-  }
+  Radius getBorderRadius(OptimusTokens tokens) => switch (this) {
+        OptimusSelectionCardBorderRadius.small => tokens.borderRadius100,
+        OptimusSelectionCardBorderRadius.medium => tokens.borderRadius200
+      };
 }

--- a/optimus_widgetbook/lib/components/common/nesting.dart
+++ b/optimus_widgetbook/lib/components/common/nesting.dart
@@ -7,12 +7,11 @@ class NestedWrapper extends StatelessWidget {
 
   Route<dynamic> _handleGenerateRoute(RouteSettings settings) {
     late WidgetBuilder builder;
-    switch (settings.name) {
-      case 'initialRoute':
-        builder = (context) => ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 400),
-              child: contentBuilder(context),
-            );
+    if (settings.name case 'initialRoute') {
+      builder = (context) => ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400),
+            child: contentBuilder(context),
+          );
     }
 
     return MaterialPageRoute<dynamic>(


### PR DESCRIPTION
#### Summary

- Upgrade to DCM [1.26.0](https://dcm.dev/changelog/#1.26.0)

Enabled rules: 

- [avoid-commented-out-code](https://dcm.dev/docs/rules/common/avoid-commented-out-code/)
- [avoid-future-ignore](https://dcm.dev/docs/rules/common/avoid-future-ignore/)
- [prefer-switch-expression](https://dcm.dev/docs/rules/common/prefer-switch-expression/) 
- [avoid-continue](https://dcm.dev/docs/rules/common/avoid-continue/)
- [use-existing-destructuring](https://dcm.dev/docs/rules/common/use-existing-destructuring/)
- [use-closest-build-context](https://dcm.dev/docs/rules/flutter/use-closest-build-context/)
- [prefer-transform-over-container](https://dcm.dev/docs/rules/flutter/prefer-transform-over-container/) 
- [prefer-align-over-container](https://dcm.dev/docs/rules/flutter/prefer-align-over-container/)
- [prefer-immutable-bloc-events](https://dcm.dev/docs/rules/bloc/prefer-immutable-bloc-events) - seems to be working with `freezed` after `1.26.0`
- [prefer-immutable-bloc-state](https://dcm.dev/docs/rules/bloc/prefer-immutable-bloc-state) - seems to be working with `freezed` after `1.26.0`

Rules left disabled:
- [avoid-unnecessary-continue](https://dcm.dev/docs/rules/common/avoid-unnecessary-continue/) - used `avoid-continue` instead
- [pattern-fields-ordering](https://dcm.dev/docs/rules/common/pattern-fields-ordering/) 
- [prefer-class-destructuring](https://dcm.dev/docs/rules/common/prefer-class-destructuring/) - `use-existing-destructuring` felt more suitable, for cases when you don't want to destructure everything at once. For example, I would have to declare all tokens used for button styling and then use only those applicable to the state. Instead of just calling `tokens.textDisabled`.
- [avoid-if-with-many-branches](https://dcm.dev/docs/rules/common/avoid-if-with-many-branches/) 
- [prefer-static-method](https://dcm.dev/docs/rules/common/prefer-static-method/)
- [avoid-complex-arithmetic-expressions](https://dcm.dev/docs/rules/common/avoid-complex-arithmetic-expressions/)
- [prefer-spacing](https://dcm.dev/docs/rules/flutter/prefer-spacing/) - thinking about that one. It is useful, but sometimes spacing between widgets is not consistent.
- [prefer-commenting-future-delayed](https://dcm.dev/docs/rules/common/prefer-commenting-future-delayed/) - in most cases code is self-describing. If it is not, future delayed or not it has to be commented
- [no-empty-string](https://dcm.dev/docs/rules/common/no-empty-string/)



#### Testing steps

None

#### Follow-up issues

Release the new version

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
