### PR TITLE
build!: Downgrade Java to Java 8

### DIFF
--- a/kiosk_mode/android/build.gradle
+++ b/kiosk_mode/android/build.gradle
@@ -32,12 +32,12 @@ android {
     compileSdk = 34
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 
     sourceSets {


### PR DESCRIPTION
#### Summary

fixes #697 
It was fixed in #710, but that PR went to `master`, but we've been on `main` brunch for some while, hence this PR.

#### Testing steps

None. I've tested `kiosk`. The success path is working.

#### Follow-up issues

Release new `kiosk_mode` version.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
