### PR TITLE
fix: [DX-3581] Fix dropdown not closing on scroll

### DIFF
--- a/optimus/lib/src/common/gesture_detector.dart
+++ b/optimus/lib/src/common/gesture_detector.dart
@@ -5,16 +5,20 @@ class AllowMultipleRawGestureDetector extends RawGestureDetector {
   AllowMultipleRawGestureDetector({
     super.key,
     GestureTapCallback? onTap,
+    GestureTapDownCallback? onTapDown,
+    super.behavior = HitTestBehavior.opaque,
     super.child,
   }) : super(
-          behavior: HitTestBehavior.opaque,
           gestures: <Type, GestureRecognizerFactory>{
             AllowMultipleGestureRecognizer:
                 GestureRecognizerFactoryWithHandlers<
                     AllowMultipleGestureRecognizer>(
               AllowMultipleGestureRecognizer.new,
-              (AllowMultipleGestureRecognizer instance) =>
-                  instance.onTap = onTap,
+              (AllowMultipleGestureRecognizer instance) {
+                instance
+                  ..onTap = onTap
+                  ..onTapDown = onTapDown;
+              },
             ),
           },
         );

--- a/optimus/lib/src/dropdown/dropdown_select.dart
+++ b/optimus/lib/src/dropdown/dropdown_select.dart
@@ -112,6 +112,7 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>>
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _effectiveFocusNode.addListener(_onFocusChanged);
   }
 
@@ -124,11 +125,19 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
-    _removeOverlay();
+    switch (state) {
+      case AppLifecycleState.paused:
+      case AppLifecycleState.detached:
+        _removeOverlay();
+      case AppLifecycleState.resumed:
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.hidden:
+    }
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _effectiveFocusNode.removeListener(_onFocusChanged);
     _focusNode?.dispose();
     _controller?.dispose();

--- a/optimus/lib/src/dropdown/dropdown_select.dart
+++ b/optimus/lib/src/dropdown/dropdown_select.dart
@@ -269,7 +269,7 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>>
             }
           }
 
-          return GestureDetector(
+          return AllowMultipleRawGestureDetector(
             key: const Key('OptimusDropdownOverlay'),
             behavior: HitTestBehavior.translucent,
             onTapDown: handleTapDown,

--- a/optimus/lib/src/dropdown/dropdown_select.dart
+++ b/optimus/lib/src/dropdown/dropdown_select.dart
@@ -94,7 +94,8 @@ class DropdownSelect<T> extends StatefulWidget {
   State<DropdownSelect<T>> createState() => _DropdownSelectState<T>();
 }
 
-class _DropdownSelectState<T> extends State<DropdownSelect<T>> {
+class _DropdownSelectState<T> extends State<DropdownSelect<T>>
+    with WidgetsBindingObserver {
   final _fieldBoxKey = GlobalKey();
 
   FocusNode? _focusNode;
@@ -118,6 +119,12 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>> {
     if (widget.embeddedSearch == null && _effectiveFocusNode.hasFocus) {
       _showOverlay();
     }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    _removeOverlay();
   }
 
   @override


### PR DESCRIPTION
#### Summary

`OptimusSelectInput` `HitTest` wasn't triggered on scroll in `SingleChildScrollView` because the latter consumed the gesture. `AllowMultipleRawGestureDetector` fixes this case and now the dropdown closes when the screen is scrolled. I've added a dropdown close on the app state change.

<details><summary>Preview</summary>


https://github.com/user-attachments/assets/28862dde-8588-430b-9096-0fcf33017ba6



</details>


#### Testing steps

Dev-tested.


#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
