### PR TITLE
 ci: Add custom base-href to widgetbook

### DIFF
--- a/.github/workflows/deploy-widgetbook-azure.yml
+++ b/.github/workflows/deploy-widgetbook-azure.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build Web
         run: |
-          melos exec --scope="optimus_widgetbook" -- "flutter build web"
+          melos exec --scope="optimus_widgetbook" -- "flutter build web --base-href '/./'"
 
       - name: Modify manifest.json
         run: |

--- a/.github/workflows/deploy-widgetbook-azure.yml
+++ b/.github/workflows/deploy-widgetbook-azure.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   deploy_widgetbook_azure:
+    name: Build and deploy optimus_widgetbook to Azure
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
#### Summary

Due to the current configuration of our blobs, widgetbook is not accessible via `widgetbook.mews.design` directly and we have to add `index.html`. This workaround modifies `base-href` to point to the right folder.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
