### PR TITLE
ci: Change widgetbook base-href

### DIFF
--- a/.github/workflows/deploy-widgetbook-azure.yml
+++ b/.github/workflows/deploy-widgetbook-azure.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build Web
         run: |
-          melos exec --scope="optimus_widgetbook" -- "flutter build web"
+          melos exec --scope="optimus_widgetbook" -- "flutter build web --base-href '/release/"
 
       - name: Modify manifest.json
         run: |

--- a/.github/workflows/deploy-widgetbook-azure.yml
+++ b/.github/workflows/deploy-widgetbook-azure.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build Web
         run: |
-          melos exec --scope="optimus_widgetbook" -- "flutter build web --base-href '/./'"
+          melos exec --scope="optimus_widgetbook" -- "flutter build web"
 
       - name: Modify manifest.json
         run: |

--- a/optimus_widgetbook/web/index.html
+++ b/optimus_widgetbook/web/index.html
@@ -14,7 +14,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+  <base href="./">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">

--- a/optimus_widgetbook/web/index.html
+++ b/optimus_widgetbook/web/index.html
@@ -14,8 +14,8 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="./">
-
+  <base href="$FLUTTER_BASE_HREF">
+  
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Mews Widgetbook">

--- a/optimus_widgetbook/web/index.html
+++ b/optimus_widgetbook/web/index.html
@@ -18,7 +18,7 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Mews Widgetbook">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
#### Summary

Another attempt to fix `base-href`. The build is deployed to the `release` folder so the `base-href` should be the same as the path on the blob. Per [documentation](https://docs.flutter.dev/ui/navigation/url-strategies#hosting-a-flutter-app-at-a-non-root-location).

- changed `base-href` to `/release/`


#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
