### PR TITLE
feat: [DX-3474] Update OptimusTabBar

### DIFF
--- a/optimus/lib/src/tabs.dart
+++ b/optimus/lib/src/tabs.dart
@@ -35,7 +35,6 @@ class OptimusTab extends StatelessWidget {
     final tokens = context.tokens;
 
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: tokens.spacing150),
       height: tokens.sizing600,
       constraints: BoxConstraints(maxWidth: maxWidth ?? double.infinity),
       child: Row(
@@ -72,11 +71,24 @@ class OptimusTabBar extends StatelessWidget {
     required this.tabs,
     required this.pages,
     this.tabController,
+    this.isScrollable = false,
+    this.tabPadding,
   });
 
+  /// The list of child tabs.
   final List<Widget> tabs;
+
+  /// The list of child pages.
   final List<Widget> pages;
+
+  /// The optional tab controller, for adding listeners and control the tab flow.
   final TabController? tabController;
+
+  /// Defines if the [OptimusTabBar] is scrollable. The scroll is enabled in the horizontal axis only.
+  final bool isScrollable;
+
+  /// A padding between tabs. Defaults to the horizontal padding with [tokens.spacing150].
+  final EdgeInsets? tabPadding;
 
   Decoration _buildIndicator(OptimusTokens tokens) => UnderlineTabIndicator(
         borderSide: BorderSide(
@@ -86,6 +98,11 @@ class OptimusTabBar extends StatelessWidget {
         insets: const EdgeInsets.only(bottom: -1),
       );
 
+  TabAlignment? get _tabAlignment => isScrollable ? null : TabAlignment.fill;
+
+  EdgeInsets _getLabelPadding(OptimusTokens tokens) =>
+      tabPadding ?? EdgeInsets.symmetric(horizontal: tokens.spacing150);
+
   @override
   Widget build(BuildContext context) {
     final tokens = context.tokens;
@@ -94,7 +111,7 @@ class OptimusTabBar extends StatelessWidget {
     return DefaultTabController(
       length: tabs.length,
       child: Column(
-        children: <Widget>[
+        children: [
           DecoratedBox(
             decoration: BoxDecoration(
               border: Border(
@@ -115,8 +132,10 @@ class OptimusTabBar extends StatelessWidget {
                 unselectedLabelStyle: textStyle,
                 labelStyle: textStyle,
                 splashBorderRadius: null,
+                isScrollable: isScrollable,
                 splashFactory: NoSplash.splashFactory,
-                labelPadding: EdgeInsets.zero,
+                labelPadding: _getLabelPadding(tokens),
+                tabAlignment: _tabAlignment,
               ),
             ),
           ),

--- a/optimus/lib/src/tabs.dart
+++ b/optimus/lib/src/tabs.dart
@@ -87,7 +87,7 @@ class OptimusTabBar extends StatelessWidget {
   /// Defines if the [OptimusTabBar] is scrollable. The scroll is enabled in the horizontal axis only.
   final bool isScrollable;
 
-  /// A padding between tabs. Defaults to the horizontal padding with [tokens.spacing150].
+  /// A padding between tabs. If not provided, the default padding will be used.
   final EdgeInsets? tabPadding;
 
   Decoration _buildIndicator(OptimusTokens tokens) => UnderlineTabIndicator(

--- a/optimus_widgetbook/lib/components/tab/tabs.dart
+++ b/optimus_widgetbook/lib/components/tab/tabs.dart
@@ -13,11 +13,13 @@ Widget createDefaultStyle(BuildContext context) {
   final knobs = context.knobs;
   final icon = knobs.optimusIconOrNullKnob(label: 'Icon');
   final badge = knobs.string(label: 'Badge');
+  final isScrollable = knobs.boolean(label: 'Scrollable', initialValue: false);
 
   return Container(
     color: OptimusTheme.of(context).colors.success500t16,
     constraints: const BoxConstraints(maxWidth: _tabBarWidth, maxHeight: 200),
     child: OptimusTabBar(
+      isScrollable: isScrollable,
       tabs: _items
           .map(
             (i) => OptimusTab(


### PR DESCRIPTION
#### Summary

- padding is now set up in the `TabBar` instead for each `OptimusTab`
- the padding could be overridden
- added a possibility to enable scrolling the `OptimusTabBar`
- `OptimusTabBar` will try to fill the screen if `isScrollable` is `false`.
- updated story

#### Testing steps

1. Open `OptimusTab` story
2. Test the component using exposed knobs
3. Look for obvious visual/behavior bugs

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
