### PR TITLE
ci: [DX-3968] Update Azure deployment workflow

### DIFF
--- a/.github/workflows/deploy-widgetbook-azure.yml
+++ b/.github/workflows/deploy-widgetbook-azure.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Remove uploaded files before the batch upload
         run: |
-          rm optimus_widgetbook/build/web/index.html
+          rm optimus_widgetbook/build/web/manifest.json
 
       - name: Upload assets to the app folder
         uses: azure/CLI@v2

--- a/.github/workflows/deploy-widgetbook-azure.yml
+++ b/.github/workflows/deploy-widgetbook-azure.yml
@@ -28,12 +28,18 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Clean Widgetbook blob folder
+        uses: azure/CLI@v2
+        with:
+          inlineScript: |
+            az storage blob delete-batch --source mews-ui-widgetbook --account-name ${{ secrets.AZURE_ACCOUNT_NAME }} --auth-mode login --pattern "*"
+
       - name: Setup Flutter environment
         uses: ./.github/actions/setup
 
       - name: Build Web
         run: |
-          melos exec --scope="optimus_widgetbook" -- "flutter build web --base-href '/app/'"
+          melos exec --scope="optimus_widgetbook" -- "flutter build web"
 
       - name: Modify manifest.json
         run: |
@@ -45,19 +51,12 @@ jobs:
           inlineScript: |
             az storage blob upload --overwrite true --container-name mews-ui-widgetbook --file optimus_widgetbook/build/web/manifest.json --account-name ${{ secrets.AZURE_ACCOUNT_NAME }} --auth-mode login
 
-      - name: Upload index.html to the release folder
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az storage blob upload --overwrite true --container-name mews-ui-widgetbook --file optimus_widgetbook/build/web/index.html --name release/index.html --account-name ${{ secrets.AZURE_ACCOUNT_NAME }} --auth-mode login
-
       - name: Remove uploaded files before the batch upload
         run: |
-          rm optimus_widgetbook/build/web/manifest.json
           rm optimus_widgetbook/build/web/index.html
 
       - name: Upload assets to the app folder
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            az storage blob upload-batch --overwrite true --destination mews-ui-widgetbook/release/app --source optimus_widgetbook/build/web --account-name ${{ secrets.AZURE_ACCOUNT_NAME }} --auth-mode login
+            az storage blob upload-batch --overwrite true --destination mews-ui-widgetbook/release --source optimus_widgetbook/build/web --account-name ${{ secrets.AZURE_ACCOUNT_NAME }} --auth-mode login


### PR DESCRIPTION
#### Summary

- The widgetbook instance has a slight launch delay, which may be caused by how we had to upload and store files on Azure Blob. Now the resolver is fixed and there is no need to split files into different folders. If this change won't fix the delay, we'll have to look for an alternative solution (maybe glance at the Cloudflare config)
- added a step to clean the blob before the upload

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
