### PR TITLE
feat: [DX-6152] Updated OptimusSplitButton design

### DIFF
--- a/optimus/lib/src/button/base_button.dart
+++ b/optimus/lib/src/button/base_button.dart
@@ -1,7 +1,11 @@
+import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/button/base_button_variant.dart';
 import 'package:optimus/src/button/common.dart';
+
+typedef ShapeBuilder =
+    OutlinedBorder Function(BorderRadius borderRadius, BorderSide borderSide);
 
 class BaseButton extends StatefulWidget {
   const BaseButton({
@@ -17,6 +21,7 @@ class BaseButton extends StatefulWidget {
     this.variant = BaseButtonVariant.primary,
     this.borderRadius,
     this.padding,
+    this.shapeBuilder,
   });
 
   final VoidCallback? onPressed;
@@ -30,6 +35,7 @@ class BaseButton extends StatefulWidget {
   final BaseButtonVariant variant;
   final BorderRadius? borderRadius;
   final EdgeInsets? padding;
+  final ShapeBuilder? shapeBuilder;
 
   @override
   State<BaseButton> createState() => _BaseButtonState();
@@ -75,14 +81,15 @@ class _BaseButtonState extends State<BaseButton> with ThemeGetter {
               isPressed: _statesController.value.isPressed,
               isHovered: _statesController.value.isHovered,
             );
+            final side =
+                color != null
+                    ? BorderSide(color: color, width: tokens.borderWidth150)
+                    : BorderSide.none;
 
-            return RoundedRectangleBorder(
-              borderRadius: borderRadius,
-              side:
-                  color != null
-                      ? BorderSide(color: color, width: tokens.borderWidth150)
-                      : BorderSide.none,
-            );
+            return widget.shapeBuilder?.let(
+                  (builder) => builder(borderRadius, side),
+                ) ??
+                RoundedRectangleBorder(borderRadius: borderRadius, side: side);
           }),
           animationDuration: buttonAnimationDuration,
           elevation: WidgetStateProperty.all<double>(0),

--- a/optimus/lib/src/button/base_dropdown_button.dart
+++ b/optimus/lib/src/button/base_dropdown_button.dart
@@ -1,9 +1,12 @@
+import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/button/base_button_variant.dart';
 import 'package:optimus/src/button/common.dart';
 import 'package:optimus/src/common/gesture_wrapper.dart';
 import 'package:optimus/src/overlay_controller.dart';
+
+typedef BorderBuilder = Border Function(Color color);
 
 class BaseDropDownButton<T> extends StatefulWidget {
   const BaseDropDownButton({
@@ -14,6 +17,7 @@ class BaseDropDownButton<T> extends StatefulWidget {
     this.size = OptimusWidgetSize.large,
     this.variant = OptimusDropdownButtonVariant.tertiary,
     this.borderRadius,
+    this.borderBuilder,
   });
 
   /// Typically the button's label.
@@ -24,6 +28,7 @@ class BaseDropDownButton<T> extends StatefulWidget {
   final OptimusWidgetSize size;
   final OptimusDropdownButtonVariant variant;
   final BorderRadius? borderRadius;
+  final BorderBuilder? borderBuilder;
 
   @override
   State<BaseDropDownButton<T>> createState() => _BaseDropDownButtonState<T>();
@@ -110,6 +115,12 @@ class _BaseDropDownButtonState<T> extends State<BaseDropDownButton<T>>
     final borderRadius =
         widget.borderRadius ?? BorderRadius.all(tokens.borderRadius100);
 
+    final border =
+        borderColor != null
+            ? (widget.borderBuilder?.let((it) => it(borderColor)) ??
+                Border.all(color: borderColor, width: tokens.borderWidth150))
+            : null;
+
     return OverlayController(
       items: widget.items,
       size: widget.size,
@@ -135,13 +146,7 @@ class _BaseDropDownButtonState<T> extends State<BaseDropDownButton<T>>
                 decoration: BoxDecoration(
                   color: _color,
                   borderRadius: borderRadius,
-                  border:
-                      borderColor != null
-                          ? Border.all(
-                            color: borderColor,
-                            width: tokens.borderWidth150,
-                          )
-                          : null,
+                  border: border,
                 ),
                 duration: buttonAnimationDuration,
                 curve: buttonAnimationCurve,

--- a/optimus/lib/src/button/outlined_border.dart
+++ b/optimus/lib/src/button/outlined_border.dart
@@ -53,12 +53,12 @@ class CustomOutlinedBorder extends OutlinedBorder {
         .toRRect(rect)
         .deflate(borderSide.width / 2);
 
+    // have to add an offset because of the deflation if the connecting side is not present, otherwise there will be a gap
+    final double pixelOffset = borderSide.width / 2;
+
     if (hasTop) {
-      final double leftOffset =
-          hasLeft
-              ? 0
-              : _pixelOffset; // have to add an offset because of the deflation if the connecting side is not present
-      final double rightOffset = hasRight ? 0 : _pixelOffset;
+      final double leftOffset = hasLeft ? 0 : pixelOffset;
+      final double rightOffset = hasRight ? 0 : pixelOffset;
       canvas.drawLine(
         Offset(
           borderRect.left + borderRect.tlRadiusX - leftOffset,
@@ -72,8 +72,8 @@ class CustomOutlinedBorder extends OutlinedBorder {
       );
     }
     if (hasRight) {
-      final double topOffset = hasTop ? 0 : _pixelOffset;
-      final double bottomOffset = hasBottom ? 0 : _pixelOffset;
+      final double topOffset = hasTop ? 0 : pixelOffset;
+      final double bottomOffset = hasBottom ? 0 : pixelOffset;
       canvas.drawLine(
         Offset(
           borderRect.right,
@@ -87,8 +87,8 @@ class CustomOutlinedBorder extends OutlinedBorder {
       );
     }
     if (hasBottom) {
-      final double leftOffset = hasLeft ? 0 : _pixelOffset;
-      final double rightOffset = hasRight ? 0 : _pixelOffset;
+      final double leftOffset = hasLeft ? 0 : pixelOffset;
+      final double rightOffset = hasRight ? 0 : pixelOffset;
       canvas.drawLine(
         Offset(
           borderRect.right - borderRect.brRadiusX + rightOffset,
@@ -102,8 +102,8 @@ class CustomOutlinedBorder extends OutlinedBorder {
       );
     }
     if (hasLeft) {
-      final double topOffset = hasTop ? 0 : _pixelOffset;
-      final double bottomOffset = hasBottom ? 0 : _pixelOffset;
+      final double topOffset = hasTop ? 0 : pixelOffset;
+      final double bottomOffset = hasBottom ? 0 : pixelOffset;
       canvas.drawLine(
         Offset(
           borderRect.left,
@@ -222,5 +222,3 @@ class CustomOutlinedBorder extends OutlinedBorder {
   String toString() =>
       'CustomOutlinedBorder($borderRadius, $borderSide, top: $hasTop, right: $hasRight, bottom: $hasBottom, left: $hasLeft)';
 }
-
-const _pixelOffset = 0.5;

--- a/optimus/lib/src/button/outlined_border.dart
+++ b/optimus/lib/src/button/outlined_border.dart
@@ -1,0 +1,226 @@
+import 'dart:math' as math;
+import 'package:flutter/widgets.dart';
+
+class CustomOutlinedBorder extends OutlinedBorder {
+  const CustomOutlinedBorder({
+    this.borderRadius = BorderRadius.zero,
+    this.borderSide = BorderSide.none,
+    this.hasTop = true,
+    this.hasRight = true,
+    this.hasBottom = true,
+    this.hasLeft = true,
+  });
+
+  final BorderRadiusGeometry borderRadius;
+  final BorderSide borderSide;
+  final bool hasTop;
+  final bool hasRight;
+  final bool hasBottom;
+  final bool hasLeft;
+
+  @override
+  OutlinedBorder copyWith({
+    BorderSide? side,
+    BorderRadiusGeometry? borderRadius,
+  }) => CustomOutlinedBorder(
+    borderRadius: borderRadius ?? this.borderRadius,
+    borderSide: side ?? borderSide,
+    hasTop: hasTop,
+    hasRight: hasRight,
+    hasBottom: hasBottom,
+    hasLeft: hasLeft,
+  );
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) {
+    final RRect borderRect = borderRadius.resolve(textDirection).toRRect(rect);
+    final RRect adjustedRect = borderRect.deflate(borderSide.width / 2);
+
+    // ignore: avoid-returning-cascades, no other way to do it (would trigger other lints)
+    return Path()..addRRect(adjustedRect);
+  }
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) =>
+      // ignore: avoid-returning-cascades, no other way to do it (would trigger other lints)
+      Path()..addRRect(borderRadius.resolve(textDirection).toRRect(rect));
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
+    final Paint paint = borderSide.toPaint();
+    final RRect borderRect = borderRadius
+        .resolve(textDirection)
+        .toRRect(rect)
+        .deflate(borderSide.width / 2);
+
+    if (hasTop) {
+      final double leftOffset =
+          hasLeft
+              ? 0
+              : _pixelOffset; // have to add an offset because of the deflation if the connecting side is not present
+      final double rightOffset = hasRight ? 0 : _pixelOffset;
+      canvas.drawLine(
+        Offset(
+          borderRect.left + borderRect.tlRadiusX - leftOffset,
+          borderRect.top,
+        ),
+        Offset(
+          borderRect.right - borderRect.trRadiusX + rightOffset,
+          borderRect.top,
+        ),
+        paint,
+      );
+    }
+    if (hasRight) {
+      final double topOffset = hasTop ? 0 : _pixelOffset;
+      final double bottomOffset = hasBottom ? 0 : _pixelOffset;
+      canvas.drawLine(
+        Offset(
+          borderRect.right,
+          borderRect.top + borderRect.trRadiusY - topOffset,
+        ),
+        Offset(
+          borderRect.right,
+          borderRect.bottom - borderRect.brRadiusY + bottomOffset,
+        ),
+        paint,
+      );
+    }
+    if (hasBottom) {
+      final double leftOffset = hasLeft ? 0 : _pixelOffset;
+      final double rightOffset = hasRight ? 0 : _pixelOffset;
+      canvas.drawLine(
+        Offset(
+          borderRect.right - borderRect.brRadiusX + rightOffset,
+          borderRect.bottom,
+        ),
+        Offset(
+          borderRect.left + borderRect.blRadiusX - leftOffset,
+          borderRect.bottom,
+        ),
+        paint,
+      );
+    }
+    if (hasLeft) {
+      final double topOffset = hasTop ? 0 : _pixelOffset;
+      final double bottomOffset = hasBottom ? 0 : _pixelOffset;
+      canvas.drawLine(
+        Offset(
+          borderRect.left,
+          borderRect.bottom - borderRect.blRadiusY + bottomOffset,
+        ),
+        Offset(
+          borderRect.left,
+          borderRect.top + borderRect.tlRadiusY + topOffset,
+        ),
+        paint,
+      );
+    }
+
+    // Draw the rounded corners
+    if (hasTop && hasLeft) {
+      canvas.drawArc(
+        Rect.fromCircle(
+          center: Offset(
+            borderRect.left + borderRect.tlRadiusX,
+            borderRect.top + borderRect.tlRadiusY,
+          ),
+          radius: borderRect.tlRadiusX,
+        ),
+        -math.pi,
+        math.pi / 2,
+        false,
+        paint,
+      );
+    }
+    if (hasTop && hasRight) {
+      canvas.drawArc(
+        Rect.fromCircle(
+          center: Offset(
+            borderRect.right - borderRect.trRadiusX,
+            borderRect.top + borderRect.trRadiusY,
+          ),
+          radius: borderRect.trRadiusX,
+        ),
+        -math.pi / 2,
+        math.pi / 2,
+        false,
+        paint,
+      );
+    }
+    if (hasBottom && hasRight) {
+      canvas.drawArc(
+        Rect.fromCircle(
+          center: Offset(
+            borderRect.right - borderRect.brRadiusX,
+            borderRect.bottom - borderRect.brRadiusY,
+          ),
+          radius: borderRect.brRadiusX,
+        ),
+        0,
+        math.pi / 2,
+        false,
+        paint,
+      );
+    }
+    if (hasBottom && hasLeft) {
+      canvas.drawArc(
+        Rect.fromCircle(
+          center: Offset(
+            borderRect.left + borderRect.blRadiusX,
+            borderRect.bottom - borderRect.blRadiusY,
+          ),
+          radius: borderRect.blRadiusX,
+        ),
+        math.pi / 2,
+        math.pi / 2,
+        false,
+        paint,
+      );
+    }
+  }
+
+  @override
+  ShapeBorder scale(double t) => CustomOutlinedBorder(
+    borderRadius: borderRadius * t,
+    borderSide: borderSide.scale(t),
+    hasTop: hasTop,
+    hasRight: hasRight,
+    hasBottom: hasBottom,
+    hasLeft: hasLeft,
+  );
+
+  @override
+  EdgeInsetsGeometry get dimensions =>
+      EdgeInsets.all(math.max(borderSide.width, 0));
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (runtimeType != other.runtimeType) return false;
+
+    return other is CustomOutlinedBorder &&
+        other.borderRadius == borderRadius &&
+        other.borderSide == borderSide &&
+        other.hasTop == hasTop &&
+        other.hasRight == hasRight &&
+        other.hasBottom == hasBottom &&
+        other.hasLeft == hasLeft;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    borderRadius,
+    borderSide,
+    hasTop,
+    hasRight,
+    hasBottom,
+    hasLeft,
+  );
+
+  @override
+  String toString() =>
+      'CustomOutlinedBorder($borderRadius, $borderSide, top: $hasTop, right: $hasRight, bottom: $hasBottom, left: $hasLeft)';
+}
+
+const _pixelOffset = 0.5;

--- a/optimus/lib/src/button/split.dart
+++ b/optimus/lib/src/button/split.dart
@@ -1,15 +1,17 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/button/base_button.dart';
 import 'package:optimus/src/button/base_button_variant.dart';
 import 'package:optimus/src/button/base_dropdown_button.dart';
+import 'package:optimus/src/button/outlined_border.dart';
+import 'package:optimus/src/common/gesture_wrapper.dart';
 
 enum OptimusSplitButtonVariant { primary, secondary, tertiary }
 
 /// Split buttons have a main action and a dropdown action. The main action is
 /// on the left. An arrow on the right opens a dropdown menu with more actions
 /// related to the main action.
-class OptimusSplitButton<T> extends StatelessWidget {
+class OptimusSplitButton<T> extends StatefulWidget {
   const OptimusSplitButton({
     super.key,
     required this.child,
@@ -42,36 +44,72 @@ class OptimusSplitButton<T> extends StatelessWidget {
   final OptimusSplitButtonVariant variant;
 
   @override
+  State<OptimusSplitButton<T>> createState() => _OptimusSplitButtonState<T>();
+}
+
+class _OptimusSplitButtonState<T> extends State<OptimusSplitButton<T>> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+
+  @override
   Widget build(BuildContext context) {
     final tokens = context.tokens;
     final borderRadius = tokens.borderRadius100;
+    final dividerColor = widget.variant.toButtonVariant().getBorderColor(
+      tokens,
+      isEnabled: widget.onPressed != null,
+      isPressed: _isPressed,
+      isHovered: _isHovered,
+    );
 
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        BaseButton(
-          onPressed: onPressed,
-          variant: variant.toButtonVariant(),
-          borderRadius: BorderRadius.only(
-            topLeft: borderRadius,
-            bottomLeft: borderRadius,
+    return GestureWrapper(
+      onHoverChanged: (isHovered) => setState(() => _isHovered = isHovered),
+      onPressedChanged: (isPressed) => setState(() => _isPressed = isPressed),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          BaseButton(
+            onPressed: widget.onPressed,
+            variant: widget.variant.toButtonVariant(),
+            borderRadius: BorderRadius.only(
+              topLeft: borderRadius,
+              bottomLeft: borderRadius,
+            ),
+            size: widget.size,
+            shapeBuilder:
+                (borderRadius, borderSide) => CustomOutlinedBorder(
+                  borderRadius: borderRadius,
+                  borderSide: borderSide,
+                  hasRight: false,
+                ),
+            child: widget.child,
           ),
-          size: size,
-          child: child,
-        ),
-        if (variant == OptimusSplitButtonVariant.primary)
-          const SizedBox(width: 1),
-        BaseDropDownButton(
-          items: items,
-          onItemSelected: onItemSelected,
-          variant: variant.toDropdownButtonVariant(),
-          borderRadius: BorderRadius.only(
-            topRight: borderRadius,
-            bottomRight: borderRadius,
+          SizedBox(
+            width: tokens.borderWidth150,
+            height: widget.size.getValue(tokens),
+            child: ColoredBox(color: dividerColor ?? Colors.transparent),
           ),
-          size: size,
-        ),
-      ],
+          BaseDropDownButton(
+            items: widget.items,
+            onItemSelected: widget.onItemSelected,
+            variant: widget.variant.toDropdownButtonVariant(),
+            borderRadius: BorderRadius.only(
+              topRight: borderRadius,
+              bottomRight: borderRadius,
+            ),
+            borderBuilder:
+                (color) => Border(
+                  top: BorderSide(color: color, width: tokens.borderWidth150),
+                  right: BorderSide(color: color, width: tokens.borderWidth150),
+                  bottom: BorderSide(
+                    color: color,
+                    width: tokens.borderWidth150,
+                  ),
+                ),
+            size: widget.size,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/optimus_widgetbook/lib/utils.dart
+++ b/optimus_widgetbook/lib/utils.dart
@@ -27,6 +27,7 @@ extension KnobsBuilderExt on KnobsBuilder {
   OptimusWidgetSize get widgetSizeKnob => list(
     label: 'Size',
     options: OptimusWidgetSize.values,
+    initialOption: OptimusWidgetSize.large,
     labelBuilder: enumLabelBuilder,
   );
 


### PR DESCRIPTION
#### Summary

- added a possibility to define a border and shape for the `DropdownButton` and `BaseButton`
- added a custom `OutlinedBorder` that would enable us to skip 0-4 borders, as it is not possible to do with the available borders https://github.com/flutter/flutter/issues/68368
- this was made so we could disable borders and make the split button look like one button with two sections instead of two buttons close to each other.

<details><summary>Preview</summary>
Before:

https://github.com/user-attachments/assets/eefb9402-e6b8-4a73-9931-8f873d6fb4df



After:

https://github.com/user-attachments/assets/1bfd89d5-d391-4cff-b27f-82d760a7597d


</details>


#### Testing steps
1. Open OptimusSplitButton use case
2. Test the component using exposed knobs
#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
