### PR TITLE
chore: Deprecate OptimusColors

### DIFF
--- a/optimus/lib/src/colors/colors.dart
+++ b/optimus/lib/src/colors/colors.dart
@@ -457,6 +457,7 @@ abstract final class OptimusDarkColors {
 }
 
 class OptimusColors {
+  @Deprecated('Use OptimusTokens instead. This will be removed on 01.07.2025')
   const OptimusColors(this.brightness);
 
   final Brightness brightness;

--- a/optimus_widgetbook/lib/main.dart
+++ b/optimus_widgetbook/lib/main.dart
@@ -29,6 +29,7 @@ class WidgetbookApp extends StatelessWidget {
             name: 'Light',
             data: OptimusThemeData(
               brightness: Brightness.light,
+              // ignore: deprecated_member_use, to be removed alongside with the OptimusColors
               colors: OptimusColors(Brightness.light),
               tokens: OptimusTokens.light,
             ),
@@ -37,6 +38,7 @@ class WidgetbookApp extends StatelessWidget {
             name: 'Dark',
             data: OptimusThemeData(
               brightness: Brightness.dark,
+              // ignore: deprecated_member_use, to be removed alongside with the OptimusColors
               colors: OptimusColors(Brightness.dark),
               tokens: OptimusTokens.dark,
             ),


### PR DESCRIPTION
#### Summary

`OptimusColors` are about to be removed and replaced with tokens. It's been a while since we've introduced tokens and `OptimusColors` shouldn't be used anywhere any more. 

#### Testing steps

None

#### Follow-up issues

@chaeMil, I'll help you with the migration.

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
