### PR TITLE
feat: [DX-6855] Add Semantic roles

### DIFF
--- a/optimus/lib/src/button/base_dropdown_button.dart
+++ b/optimus/lib/src/button/base_dropdown_button.dart
@@ -1,5 +1,6 @@
 import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/button/base_button_variant.dart';
 import 'package:optimus/src/button/common.dart';
@@ -136,6 +137,8 @@ class _BaseDropDownButtonState<T> extends State<BaseDropDownButton<T>>
         ignoring: !_isEnabled,
         child: Semantics(
           label: widget.semanticLabel,
+          role: SemanticsRole.menu,
+          button: true,
           child: GestureWrapper(
             onHoverChanged: _handleHoverChanged,
             onPressedChanged: _handlePressedChanged,

--- a/optimus/lib/src/button/icon.dart
+++ b/optimus/lib/src/button/icon.dart
@@ -67,6 +67,7 @@ class _OptimusIconButtonState extends State<OptimusIconButton>
       ignoring: !isEnabled,
       child: Semantics(
         label: widget.semanticLabel,
+        button: true,
         enabled: _isEnabled,
         child: GestureWrapper(
           onHoverChanged: _handleHoverChanged,

--- a/optimus/lib/src/dialogs/dialog.dart
+++ b/optimus/lib/src/dialogs/dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/dialogs/dialog_content.dart';
 
@@ -186,7 +187,8 @@ class OptimusDialog extends StatelessWidget {
     final size = _autoSize(context);
     final tokens = context.tokens;
 
-    return SafeArea(
+    return Semantics(
+      role: SemanticsRole.dialog,
       child: Align(
         alignment: _alignment(context),
         child: DialogContent(

--- a/optimus/lib/src/dropdown/base_dropdown_tile.dart
+++ b/optimus/lib/src/dropdown/base_dropdown_tile.dart
@@ -1,6 +1,7 @@
 import 'package:dfunc/dfunc.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/checkbox/checkbox_tick.dart';
@@ -43,35 +44,40 @@ class BaseDropdownTile extends StatelessWidget {
       ],
     );
 
-    return Container(
-      padding: EdgeInsets.symmetric(
-        horizontal: tokens.spacing200,
-        vertical: size.getVerticalPadding(tokens),
-      ),
-      decoration: BoxDecoration(
-        color: isSelected ? tokens.backgroundInteractiveSecondaryDefault : null,
-        borderRadius: BorderRadius.all(tokens.borderRadius100),
-      ),
-      child:
-          hasCheckbox
-              ? Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IgnorePointer(
-                    child: Padding(
-                      padding: EdgeInsets.only(right: tokens.spacing200),
-                      child: CheckboxTick(
-                        isEnabled: true,
-                        onChanged: ignore,
-                        onTap: ignore,
-                        isChecked: isSelected,
+    return Semantics(
+      role:
+          hasCheckbox ? SemanticsRole.menuItemCheckbox : SemanticsRole.menuItem,
+      child: Container(
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing200,
+          vertical: size.getVerticalPadding(tokens),
+        ),
+        decoration: BoxDecoration(
+          color:
+              isSelected ? tokens.backgroundInteractiveSecondaryDefault : null,
+          borderRadius: BorderRadius.all(tokens.borderRadius100),
+        ),
+        child:
+            hasCheckbox
+                ? Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IgnorePointer(
+                      child: Padding(
+                        padding: EdgeInsets.only(right: tokens.spacing200),
+                        child: CheckboxTick(
+                          isEnabled: true,
+                          onChanged: ignore,
+                          onTap: ignore,
+                          isChecked: isSelected,
+                        ),
                       ),
                     ),
-                  ),
-                  Flexible(fit: FlexFit.loose, child: tile),
-                ],
-              )
-              : tile,
+                    Flexible(fit: FlexFit.loose, child: tile),
+                  ],
+                )
+                : tile,
+      ),
     );
   }
 }

--- a/optimus/lib/src/dropdown/dropdown_select.dart
+++ b/optimus/lib/src/dropdown/dropdown_select.dart
@@ -346,53 +346,56 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>>
             )
             : null;
 
-    return PopScope(
-      canPop: _canPop,
-      onPopInvokedWithResult: _handleOnBackPressed,
-      child:
-          widget.allowMultipleSelection && _hasValues
-              ? MultiSelectInputField(
-                values: _values ?? [],
-                leading: leading,
-                prefix: widget.prefix,
-                isRequired: widget.isRequired,
-                label: widget.label,
-                focusNode: _effectiveFocusNode,
-                isFocused: _isFocused,
-                fieldBoxKey: _fieldBoxKey,
-                suffix: widget.suffix,
-                trailing: trailing,
-                isEnabled: widget.isEnabled,
-                caption: widget.caption,
-                helperMessage: widget.helperMessage,
-                error: widget.error,
-                size: widget.size,
-                showLoader: widget.showLoader,
-              )
-              : OptimusInputField(
-                leading: leading,
-                prefix: widget.prefix,
-                controller: _effectiveController,
-                onChanged: widget.onTextChanged,
-                isRequired: widget.isRequired,
-                label: widget.label,
-                placeholder: widget.placeholder,
-                placeholderStyle: widget.placeholderStyle,
-                focusNode: _effectiveFocusNode,
-                isFocused: _isFocused,
-                onTap: _onTap,
-                fieldBoxKey: _fieldBoxKey,
-                suffix: widget.suffix,
-                trailing: trailing,
-                isEnabled: widget.isEnabled,
-                caption: widget.caption,
-                helperMessage: widget.helperMessage,
-                error: widget.error,
-                size: widget.size,
-                isReadOnly: widget.isReadOnly,
-                showCursor: widget.showCursor,
-                showLoader: widget.showLoader,
-              ),
+    return Semantics(
+      role: widget.isReadOnly ? SemanticsRole.menu : SemanticsRole.comboBox,
+      child: PopScope(
+        canPop: _canPop,
+        onPopInvokedWithResult: _handleOnBackPressed,
+        child:
+            widget.allowMultipleSelection && _hasValues
+                ? MultiSelectInputField(
+                  values: _values ?? [],
+                  leading: leading,
+                  prefix: widget.prefix,
+                  isRequired: widget.isRequired,
+                  label: widget.label,
+                  focusNode: _effectiveFocusNode,
+                  isFocused: _isFocused,
+                  fieldBoxKey: _fieldBoxKey,
+                  suffix: widget.suffix,
+                  trailing: trailing,
+                  isEnabled: widget.isEnabled,
+                  caption: widget.caption,
+                  helperMessage: widget.helperMessage,
+                  error: widget.error,
+                  size: widget.size,
+                  showLoader: widget.showLoader,
+                )
+                : OptimusInputField(
+                  leading: leading,
+                  prefix: widget.prefix,
+                  controller: _effectiveController,
+                  onChanged: widget.onTextChanged,
+                  isRequired: widget.isRequired,
+                  label: widget.label,
+                  placeholder: widget.placeholder,
+                  placeholderStyle: widget.placeholderStyle,
+                  focusNode: _effectiveFocusNode,
+                  isFocused: _isFocused,
+                  onTap: _onTap,
+                  fieldBoxKey: _fieldBoxKey,
+                  suffix: widget.suffix,
+                  trailing: trailing,
+                  isEnabled: widget.isEnabled,
+                  caption: widget.caption,
+                  helperMessage: widget.helperMessage,
+                  error: widget.error,
+                  size: widget.size,
+                  isReadOnly: widget.isReadOnly,
+                  showCursor: widget.showCursor,
+                  showLoader: widget.showLoader,
+                ),
+      ),
     );
   }
 }

--- a/optimus/lib/src/dropdown/embedded_search.dart
+++ b/optimus/lib/src/dropdown/embedded_search.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:optimus/optimus.dart';
 
 /// An embedded search that is designed to be used inside the dropdown menu.
@@ -52,13 +53,16 @@ class _OptimusDropdownEmbeddedSearchState
   }
 
   @override
-  Widget build(BuildContext context) => OptimusInputField(
-    controller: _controller,
-    onChanged: widget.onTextChanged,
-    focusNode: _focusNode,
-    placeholder: widget.placeholder,
-    leading: const Icon(OptimusIcons.search),
-    isClearEnabled: widget.isClearEnabled,
-    hasBorders: false,
+  Widget build(BuildContext context) => Semantics(
+    role: SemanticsRole.searchBox,
+    child: OptimusInputField(
+      controller: _controller,
+      onChanged: widget.onTextChanged,
+      focusNode: _focusNode,
+      placeholder: widget.placeholder,
+      leading: const Icon(OptimusIcons.search),
+      isClearEnabled: widget.isClearEnabled,
+      hasBorders: false,
+    ),
   );
 }

--- a/optimus/lib/src/feedback/alert.dart
+++ b/optimus/lib/src/feedback/alert.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/feedback/common.dart';
@@ -69,42 +70,45 @@ class OptimusAlert extends StatelessWidget {
       _maxWidth,
     );
 
-    return Padding(
-      padding: EdgeInsets.symmetric(
-        horizontal: horizontalPadding,
-        vertical: tokens.spacing50,
-      ),
-      child: GestureDetector(
-        onTap: onPressed,
-        child: ConstrainedBox(
-          constraints: BoxConstraints(maxWidth: alertWidth),
-          child: Stack(
-            children: [
-              _AlertContent(
-                icon: icon,
-                variant: variant,
-                title: title,
-                description: description,
-                linkText: action?.text,
-                onLinkPressed: () {
-                  action?.onPressed();
-                  OptimusAlertOverlay.of(context)?.remove(this);
-                },
-                isDismissible: isDismissible,
-              ),
-              if (isDismissible)
-                Positioned(
-                  top: _isExpanded ? tokens.spacing200 : tokens.spacing0,
-                  right: tokens.spacing200,
-                  bottom: _isExpanded ? null : tokens.spacing0,
-                  child: FeedbackDismissButton(
-                    onDismiss: () {
-                      onDismiss?.call();
-                      OptimusAlertOverlay.of(context)?.remove(this);
-                    },
-                  ),
+    return Semantics(
+      role: SemanticsRole.alert,
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: horizontalPadding,
+          vertical: tokens.spacing50,
+        ),
+        child: GestureDetector(
+          onTap: onPressed,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: alertWidth),
+            child: Stack(
+              children: [
+                _AlertContent(
+                  icon: icon,
+                  variant: variant,
+                  title: title,
+                  description: description,
+                  linkText: action?.text,
+                  onLinkPressed: () {
+                    action?.onPressed();
+                    OptimusAlertOverlay.of(context)?.remove(this);
+                  },
+                  isDismissible: isDismissible,
                 ),
-            ],
+                if (isDismissible)
+                  Positioned(
+                    top: _isExpanded ? tokens.spacing200 : tokens.spacing0,
+                    right: tokens.spacing200,
+                    bottom: _isExpanded ? null : tokens.spacing0,
+                    child: FeedbackDismissButton(
+                      onDismiss: () {
+                        onDismiss?.call();
+                        OptimusAlertOverlay.of(context)?.remove(this);
+                      },
+                    ),
+                  ),
+              ],
+            ),
           ),
         ),
       ),

--- a/optimus/lib/src/feedback/banner.dart
+++ b/optimus/lib/src/feedback/banner.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:optimus/src/feedback/common.dart';
 import 'package:optimus/src/feedback/feedback_variant.dart';
 import 'package:optimus/src/theme/theme.dart';
@@ -63,59 +64,62 @@ class OptimusBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.tokens;
 
-    return GestureDetector(
-      onTap: onPressed,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: variant.backgroundColor(tokens),
-          borderRadius: BorderRadius.all(tokens.borderRadius100),
-        ),
-        child: Stack(
-          children: [
-            Padding(
-              padding: EdgeInsets.all(tokens.spacing200),
-              child: Row(
-                crossAxisAlignment:
-                    _isExpanded
-                        ? CrossAxisAlignment.start
-                        : CrossAxisAlignment.center,
-                children: [
-                  if (hasIcon)
-                    Padding(
-                      padding: EdgeInsets.only(right: tokens.spacing200),
-                      child: FeedbackIcon(variant: variant),
-                    ),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding:
-                              isDismissible
-                                  ? EdgeInsets.only(right: tokens.spacing200)
-                                  : EdgeInsets.zero,
-                          child: FeedbackTitle(title: title),
-                        ),
-                        if (description case final description?)
+    return Semantics(
+      role: SemanticsRole.alert,
+      child: GestureDetector(
+        onTap: onPressed,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: variant.backgroundColor(tokens),
+            borderRadius: BorderRadius.all(tokens.borderRadius100),
+          ),
+          child: Stack(
+            children: [
+              Padding(
+                padding: EdgeInsets.all(tokens.spacing200),
+                child: Row(
+                  crossAxisAlignment:
+                      _isExpanded
+                          ? CrossAxisAlignment.start
+                          : CrossAxisAlignment.center,
+                  children: [
+                    if (hasIcon)
+                      Padding(
+                        padding: EdgeInsets.only(right: tokens.spacing200),
+                        child: FeedbackIcon(variant: variant),
+                      ),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
                           Padding(
-                            padding: EdgeInsets.only(top: tokens.spacing50),
-                            child: FeedbackDescription(
-                              description: description,
-                            ),
+                            padding:
+                                isDismissible
+                                    ? EdgeInsets.only(right: tokens.spacing200)
+                                    : EdgeInsets.zero,
+                            child: FeedbackTitle(title: title),
                           ),
-                      ],
+                          if (description case final description?)
+                            Padding(
+                              padding: EdgeInsets.only(top: tokens.spacing50),
+                              child: FeedbackDescription(
+                                description: description,
+                              ),
+                            ),
+                        ],
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            if (isDismissible)
-              Positioned(
-                top: tokens.spacing200,
-                right: tokens.spacing200,
-                child: FeedbackDismissButton(onDismiss: onDismiss),
-              ),
-          ],
+              if (isDismissible)
+                Positioned(
+                  top: tokens.spacing200,
+                  right: tokens.spacing200,
+                  child: FeedbackDismissButton(onDismiss: onDismiss),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/optimus/lib/src/lists/list_tile.dart
+++ b/optimus/lib/src/lists/list_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/lists/base_list_tile.dart';
 import 'package:optimus/src/typography/typography.dart';
@@ -92,65 +93,68 @@ class OptimusListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.tokens;
 
-    return BaseListTile(
-      onTap: onTap,
-      content: Padding(
-        padding: _getContentPadding(tokens),
-        child: Stack(
-          children: [
-            if (prefix case final prefix?)
-              Positioned(
-                top: tokens.spacing0,
-                bottom: _prefixVerticalAlignment.getBottom(tokens),
-                child: _Prefix(prefix: prefix, size: prefixSize),
-              ),
-            Row(
-              children: [
-                if (prefix != null)
-                  SizedBox(width: prefixSize.getWidth(tokens)),
-                Expanded(
-                  child: Padding(
-                    padding: EdgeInsets.only(right: tokens.spacing100),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Flexible(
-                              child: _Title(
-                                title: title,
-                                fontVariant: fontVariant,
-                              ),
-                            ),
-                            if (info case final info?)
-                              Flexible(child: _Info(info: info)),
-                          ],
-                        ),
-                        Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            if (subtitle case final subtitle?)
-                              Expanded(
-                                child: _Subtitle(
-                                  subtitle: subtitle,
+    return Semantics(
+      role: SemanticsRole.listItem,
+      child: BaseListTile(
+        onTap: onTap,
+        content: Padding(
+          padding: _getContentPadding(tokens),
+          child: Stack(
+            children: [
+              if (prefix case final prefix?)
+                Positioned(
+                  top: tokens.spacing0,
+                  bottom: _prefixVerticalAlignment.getBottom(tokens),
+                  child: _Prefix(prefix: prefix, size: prefixSize),
+                ),
+              Row(
+                children: [
+                  if (prefix != null)
+                    SizedBox(width: prefixSize.getWidth(tokens)),
+                  Expanded(
+                    child: Padding(
+                      padding: EdgeInsets.only(right: tokens.spacing100),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Flexible(
+                                child: _Title(
+                                  title: title,
                                   fontVariant: fontVariant,
                                 ),
-                              )
-                            else
-                              const Spacer(),
-                            if (infoWidget case final infoWidget?) infoWidget,
-                          ],
-                        ),
-                      ],
+                              ),
+                              if (info case final info?)
+                                Flexible(child: _Info(info: info)),
+                            ],
+                          ),
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              if (subtitle case final subtitle?)
+                                Expanded(
+                                  child: _Subtitle(
+                                    subtitle: subtitle,
+                                    fontVariant: fontVariant,
+                                  ),
+                                )
+                              else
+                                const Spacer(),
+                              if (infoWidget case final infoWidget?) infoWidget,
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-                ),
-                if (suffix case final suffix?) _Suffix(suffix: suffix),
-              ],
-            ),
-          ],
+                  if (suffix case final suffix?) _Suffix(suffix: suffix),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/optimus/lib/src/lists/nav_list_tile.dart
+++ b/optimus/lib/src/lists/nav_list_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/common/gesture_wrapper.dart';
 import 'package:optimus/src/lists/base_list_tile.dart';
@@ -112,6 +113,7 @@ class _OptimusNavListTileState extends State<OptimusNavListTile>
       ignoring: !widget.isEnabled,
       child: Semantics(
         label: widget.semanticLabel,
+        role: SemanticsRole.listItem,
         child: GestureWrapper(
           onHoverChanged: _handleHoverChanged,
           onPressedChanged: _handlePressedChanged,

--- a/optimus/lib/src/loader/spinner.dart
+++ b/optimus/lib/src/loader/spinner.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/loader/painter.dart';
@@ -90,44 +91,47 @@ class _OptimusSpinnerState extends State<OptimusSpinner>
   }
 
   @override
-  Widget build(BuildContext context) => SizedBox.square(
-    dimension: widget.size.getSize(tokens),
-    child: AnimatedBuilder(
-      animation: _controller,
-      builder:
-          (context, child) => Stack(
-            alignment: Alignment.center,
-            children: [
-              CustomPaint(
-                size: Size.square(widget.size.getSize(tokens)),
-                painter: CirclePainter(
-                  indicatorColor:
-                      tokens.backgroundInteractiveNeutralBoldDefault,
-                  strokeWidth: widget.size.strokeWidth,
-                  progress: _thirdProgressAnimation.value,
-                  baseAngle: _thirdBaseAnimation.value,
-                  strokeCap: StrokeCap.round,
+  Widget build(BuildContext context) => Semantics(
+    role: SemanticsRole.loadingSpinner,
+    child: SizedBox.square(
+      dimension: widget.size.getSize(tokens),
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder:
+            (context, child) => Stack(
+              alignment: Alignment.center,
+              children: [
+                CustomPaint(
+                  size: Size.square(widget.size.getSize(tokens)),
+                  painter: CirclePainter(
+                    indicatorColor:
+                        tokens.backgroundInteractiveNeutralBoldDefault,
+                    strokeWidth: widget.size.strokeWidth,
+                    progress: _thirdProgressAnimation.value,
+                    baseAngle: _thirdBaseAnimation.value,
+                    strokeCap: StrokeCap.round,
+                  ),
+                  foregroundPainter: CirclePainter(
+                    indicatorColor: tokens.backgroundAccentSecondary,
+                    strokeWidth: widget.size.strokeWidth,
+                    progress: _secondProgressAnimation.value,
+                    baseAngle: _secondBaseAnimation.value,
+                    strokeCap: StrokeCap.round,
+                  ),
                 ),
-                foregroundPainter: CirclePainter(
-                  indicatorColor: tokens.backgroundAccentSecondary,
-                  strokeWidth: widget.size.strokeWidth,
-                  progress: _secondProgressAnimation.value,
-                  baseAngle: _secondBaseAnimation.value,
-                  strokeCap: StrokeCap.round,
+                CustomPaint(
+                  size: Size.square(widget.size.getSize(tokens)),
+                  painter: CirclePainter(
+                    indicatorColor: tokens.backgroundAccentPrimary,
+                    strokeWidth: widget.size.strokeWidth,
+                    progress: _firstProgressAnimation.value,
+                    baseAngle: _firstBaseAnimation.value,
+                    strokeCap: StrokeCap.round,
+                  ),
                 ),
-              ),
-              CustomPaint(
-                size: Size.square(widget.size.getSize(tokens)),
-                painter: CirclePainter(
-                  indicatorColor: tokens.backgroundAccentPrimary,
-                  strokeWidth: widget.size.strokeWidth,
-                  progress: _firstProgressAnimation.value,
-                  baseAngle: _firstBaseAnimation.value,
-                  strokeCap: StrokeCap.round,
-                ),
-              ),
-            ],
-          ),
+              ],
+            ),
+      ),
     ),
   );
 }

--- a/optimus/lib/src/pictogram/pictogram.dart
+++ b/optimus/lib/src/pictogram/pictogram.dart
@@ -28,6 +28,7 @@ class OptimusPictogram extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Semantics(
     label: semanticsLabel ?? variant.name.replaceAll('_', ' '),
+    image: true,
     child: SizedBox.square(
       dimension: size.getSize(context.tokens),
       child: SvgPicture.asset(

--- a/optimus/lib/src/progress_indicator/progress_indicator.dart
+++ b/optimus/lib/src/progress_indicator/progress_indicator.dart
@@ -1,5 +1,6 @@
 import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart' hide ProgressIndicator;
+import 'package:flutter/semantics.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/common/gesture_detector.dart';
 import 'package:optimus/src/progress_indicator/common.dart';
@@ -86,55 +87,58 @@ class _HorizontalProgressIndicator extends StatelessWidget {
       final indicatorRowHorizontalPadding = itemWidth / 2 - indicatorWidth / 2;
       final height = indicatorHeight + textRowHeight;
 
-      return SizedBox(
-        width: effectiveWidth,
-        height: height,
-        child: Stack(
-          children: [
-            if (items.length > 1)
-              _SpacerLayer(
-                horizontalPadding: indicatorRowHorizontalPadding,
-                itemHeight: indicatorHeight,
-                children:
-                    items
-                        .intersperseWith(
-                          itemBuilder: (_) => SizedBox(width: indicatorWidth),
-                          separatorBuilder:
-                              (_, nextItem) => Expanded(
-                                child: ProgressIndicatorSpacer(
-                                  layout: Axis.horizontal,
-                                  nextItemState: items.getIndicatorState(
-                                    item: nextItem,
-                                    currentItem: currentItem,
-                                    maxItem: maxItem,
+      return Semantics(
+        role: SemanticsRole.progressBar,
+        child: SizedBox(
+          width: effectiveWidth,
+          height: height,
+          child: Stack(
+            children: [
+              if (items.length > 1)
+                _SpacerLayer(
+                  horizontalPadding: indicatorRowHorizontalPadding,
+                  itemHeight: indicatorHeight,
+                  children:
+                      items
+                          .intersperseWith(
+                            itemBuilder: (_) => SizedBox(width: indicatorWidth),
+                            separatorBuilder:
+                                (_, nextItem) => Expanded(
+                                  child: ProgressIndicatorSpacer(
+                                    layout: Axis.horizontal,
+                                    nextItemState: items.getIndicatorState(
+                                      item: nextItem,
+                                      currentItem: currentItem,
+                                      maxItem: maxItem,
+                                    ),
                                   ),
                                 ),
+                          )
+                          .toList(),
+                ),
+              Row(
+                children:
+                    items
+                        .map(
+                          (item) => SizedBox(
+                            width: itemWidth,
+                            height: constraints.maxHeight,
+                            child: ProgressIndicatorItem(
+                              index: items.getIndex(item),
+                              text: item.text,
+                              description: item.description,
+                              state: items.getIndicatorState(
+                                item: item,
+                                currentItem: currentItem,
+                                maxItem: maxItem,
                               ),
+                            ),
+                          ),
                         )
                         .toList(),
               ),
-            Row(
-              children:
-                  items
-                      .map(
-                        (item) => SizedBox(
-                          width: itemWidth,
-                          height: constraints.maxHeight,
-                          child: ProgressIndicatorItem(
-                            index: items.getIndex(item),
-                            text: item.text,
-                            description: item.description,
-                            state: items.getIndicatorState(
-                              item: item,
-                              currentItem: currentItem,
-                              maxItem: maxItem,
-                            ),
-                          ),
-                        ),
-                      )
-                      .toList(),
-            ),
-          ],
+            ],
+          ),
         ),
       );
     },
@@ -275,30 +279,33 @@ class _VerticalProgressIndicatorState extends State<_VerticalProgressIndicator>
     return AnimatedBuilder(
       animation: _animationController.view,
       builder:
-          (_, child) => Container(
-            clipBehavior: Clip.none,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                AllowMultipleRawGestureDetector(
-                  onTap: _handleTap,
-                  child: ProgressIndicatorItem(
-                    state: _getIndicatorState(headerItem),
-                    index: items.getIndex(headerItem),
-                    text: headerItem.text,
-                    description: headerItem.description,
-                    itemsCount: _itemsCount,
-                    axis: Axis.vertical,
+          (_, child) => Semantics(
+            role: SemanticsRole.progressBar,
+            child: Container(
+              clipBehavior: Clip.none,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  AllowMultipleRawGestureDetector(
+                    onTap: _handleTap,
+                    child: ProgressIndicatorItem(
+                      state: _getIndicatorState(headerItem),
+                      index: items.getIndex(headerItem),
+                      text: headerItem.text,
+                      description: headerItem.description,
+                      itemsCount: _itemsCount,
+                      axis: Axis.vertical,
+                    ),
                   ),
-                ),
-                ClipRect(
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    heightFactor: _heightFactor.value,
-                    child: child,
+                  ClipRect(
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      heightFactor: _heightFactor.value,
+                      child: child,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
       child: result,

--- a/optimus/lib/src/radio/radio.dart
+++ b/optimus/lib/src/radio/radio.dart
@@ -128,62 +128,69 @@ class _OptimusRadioState<T> extends State<OptimusRadio<T>> with ThemeGetter {
     return ListenableBuilder(
       listenable: _stateController,
       builder:
-          (context, _) => GroupWrapper(
-            error: widget.error,
-            isEnabled: widget.isEnabled,
-            child: IgnorePointer(
-              ignoring: !widget.isEnabled,
-              child: GestureWrapper(
-                onHoverChanged:
-                    (isHovered) =>
-                        _stateController.update(WidgetState.hovered, isHovered),
-                onPressedChanged:
-                    (isPressed) =>
-                        _stateController.update(WidgetState.pressed, isPressed),
-                onTap: _handleChanged,
-                child: Stack(
-                  children: [
-                    Positioned(
-                      left: 0,
-                      top: 0,
-                      bottom: 0,
-                      width: leadingSize,
-                      child: Align(
-                        alignment: Alignment.topLeft,
-                        child: Padding(
-                          padding: EdgeInsets.only(
-                            top: tokens.spacing100,
-                            bottom: tokens.spacing100,
-                            right: tokens.spacing200,
-                          ),
-                          child: RadioCircle(
-                            isSelected: _isSelected,
-                            controller: _stateController,
+          (context, _) => Semantics(
+            inMutuallyExclusiveGroup: true,
+            child: GroupWrapper(
+              error: widget.error,
+              isEnabled: widget.isEnabled,
+              child: IgnorePointer(
+                ignoring: !widget.isEnabled,
+                child: GestureWrapper(
+                  onHoverChanged:
+                      (isHovered) => _stateController.update(
+                        WidgetState.hovered,
+                        isHovered,
+                      ),
+                  onPressedChanged:
+                      (isPressed) => _stateController.update(
+                        WidgetState.pressed,
+                        isPressed,
+                      ),
+                  onTap: _handleChanged,
+                  child: Stack(
+                    children: [
+                      Positioned(
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: leadingSize,
+                        child: Align(
+                          alignment: Alignment.topLeft,
+                          child: Padding(
+                            padding: EdgeInsets.only(
+                              top: tokens.spacing100,
+                              bottom: tokens.spacing100,
+                              right: tokens.spacing200,
+                            ),
+                            child: RadioCircle(
+                              isSelected: _isSelected,
+                              controller: _stateController,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                    ConstrainedBox(
-                      constraints: BoxConstraints(minHeight: leadingSize),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          SizedBox(width: leadingSize),
-                          Expanded(
-                            child: Padding(
-                              padding: EdgeInsets.symmetric(
-                                vertical: tokens.spacing25,
-                              ),
-                              child: DefaultTextStyle.merge(
-                                style: _labelStyle,
-                                child: widget.label,
+                      ConstrainedBox(
+                        constraints: BoxConstraints(minHeight: leadingSize),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            SizedBox(width: leadingSize),
+                            Expanded(
+                              child: Padding(
+                                padding: EdgeInsets.symmetric(
+                                  vertical: tokens.spacing25,
+                                ),
+                                child: DefaultTextStyle.merge(
+                                  style: _labelStyle,
+                                  child: widget.label,
+                                ),
                               ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/optimus/lib/src/radio/radio_group.dart
+++ b/optimus/lib/src/radio/radio_group.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/src/common/group_item.dart';
 import 'package:optimus/src/common/group_wrapper.dart';
@@ -59,25 +60,28 @@ class OptimusRadioGroup<T> extends StatelessWidget {
   final bool isEnabled;
 
   @override
-  Widget build(BuildContext context) => GroupWrapper(
-    label: label,
-    error: error,
-    isEnabled: isEnabled,
-    child: OptimusEnabled(
+  Widget build(BuildContext context) => Semantics(
+    role: SemanticsRole.radioGroup,
+    child: GroupWrapper(
+      label: label,
+      error: error,
       isEnabled: isEnabled,
-      child: Column(
-        children:
-            items
-                .map(
-                  (i) => OptimusRadio<T>(
-                    label: i.label,
-                    value: i.value,
-                    groupValue: value,
-                    onChanged: onChanged,
-                    size: size,
-                  ),
-                )
-                .toList(),
+      child: OptimusEnabled(
+        isEnabled: isEnabled,
+        child: Column(
+          children:
+              items
+                  .map(
+                    (i) => OptimusRadio<T>(
+                      label: i.label,
+                      value: i.value,
+                      groupValue: value,
+                      onChanged: onChanged,
+                      size: size,
+                    ),
+                  )
+                  .toList(),
+        ),
       ),
     ),
   );

--- a/optimus/lib/src/search/search_field.dart
+++ b/optimus/lib/src/search/search_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/dropdown/dropdown_select.dart';
@@ -119,32 +120,38 @@ class OptimusSearch<T> extends StatelessWidget {
   final GroupBuilder? groupBuilder;
 
   @override
-  Widget build(BuildContext context) => DropdownSelect<T>(
-    label: label,
-    placeholder: placeholder,
-    placeholderStyle: placeholderStyle,
-    controller: controller,
-    onTextChanged: onTextChanged,
-    items: items,
-    isUpdating: isUpdating,
-    isEnabled: isEnabled,
-    isRequired: isRequired,
-    onChanged: onChanged,
-    leading: leading,
-    leadingImplicit: Icon(OptimusIcons.search, size: context.tokens.sizing200),
-    trailing: trailing,
-    caption: caption,
-    helperMessage: helperMessage,
-    error: error,
-    size: size,
-    isReadOnly: isReadOnly,
-    showCursor: showCursor,
-    prefix: prefix,
-    suffix: suffix,
-    focusNode: focusNode,
-    shouldCloseOnInputTap: shouldCloseOnInputTap,
-    isClearEnabled: isClearEnabled,
-    groupBy: groupBy,
-    groupBuilder: groupBuilder,
+  Widget build(BuildContext context) => Semantics(
+    role: SemanticsRole.searchBox,
+    child: DropdownSelect<T>(
+      label: label,
+      placeholder: placeholder,
+      placeholderStyle: placeholderStyle,
+      controller: controller,
+      onTextChanged: onTextChanged,
+      items: items,
+      isUpdating: isUpdating,
+      isEnabled: isEnabled,
+      isRequired: isRequired,
+      onChanged: onChanged,
+      leading: leading,
+      leadingImplicit: Icon(
+        OptimusIcons.search,
+        size: context.tokens.sizing200,
+      ),
+      trailing: trailing,
+      caption: caption,
+      helperMessage: helperMessage,
+      error: error,
+      size: size,
+      isReadOnly: isReadOnly,
+      showCursor: showCursor,
+      prefix: prefix,
+      suffix: suffix,
+      focusNode: focusNode,
+      shouldCloseOnInputTap: shouldCloseOnInputTap,
+      isClearEnabled: isClearEnabled,
+      groupBy: groupBy,
+      groupBuilder: groupBuilder,
+    ),
   );
 }

--- a/optimus/lib/src/segmented_control/segmented_control.dart
+++ b/optimus/lib/src/segmented_control/segmented_control.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/common/gesture_wrapper.dart';
 import 'package:optimus/src/common/group_wrapper.dart';
@@ -71,39 +72,42 @@ class OptimusSegmentedControl<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.tokens;
 
-    return GroupWrapper(
-      label: label,
-      error: error,
-      isRequired: isRequired,
-      isEnabled: isEnabled,
-      child: OptimusEnabled(
+    return Semantics(
+      role: SemanticsRole.radioGroup,
+      child: GroupWrapper(
+        label: label,
+        error: error,
+        isRequired: isRequired,
         isEnabled: isEnabled,
-        child: DecoratedBox(
-          decoration:
-              direction == Axis.horizontal
-                  ? BoxDecoration(
-                    color: tokens.backgroundInteractiveNeutralDefault,
-                    borderRadius: BorderRadius.all(tokens.borderRadius100),
-                  )
-                  : const BoxDecoration(),
-          child: OptimusStack(
-            direction: direction,
-            distribution: _distribution,
-            spacing: _spacing,
-            children:
-                items
-                    .map(
-                      (item) => _OptimusSegmentedControlItem<T>(
-                        value: item.value,
-                        size: size,
-                        groupValue: value,
-                        onItemSelected: onItemSelected,
-                        isEnabled: isEnabled,
-                        maxLines: _maxLines,
-                        child: item.label,
-                      ),
+        child: OptimusEnabled(
+          isEnabled: isEnabled,
+          child: DecoratedBox(
+            decoration:
+                direction == Axis.horizontal
+                    ? BoxDecoration(
+                      color: tokens.backgroundInteractiveNeutralDefault,
+                      borderRadius: BorderRadius.all(tokens.borderRadius100),
                     )
-                    .toList(),
+                    : const BoxDecoration(),
+            child: OptimusStack(
+              direction: direction,
+              distribution: _distribution,
+              spacing: _spacing,
+              children:
+                  items
+                      .map(
+                        (item) => _OptimusSegmentedControlItem<T>(
+                          value: item.value,
+                          size: size,
+                          groupValue: value,
+                          onItemSelected: onItemSelected,
+                          isEnabled: isEnabled,
+                          maxLines: _maxLines,
+                          child: item.label,
+                        ),
+                      )
+                      .toList(),
+            ),
           ),
         ),
       ),
@@ -180,36 +184,39 @@ class _OptimusSegmentedControlItemState<T>
 
     return LayoutBuilder(
       builder:
-          (context, constrains) => GestureWrapper(
-            onTap: _handleChanged,
-            onHoverChanged: _handleHoverChanged,
-            onPressedChanged: _handlePressedChanged,
-            child: Padding(
-              padding: EdgeInsets.all(tokens.spacing25),
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 100),
-                curve: Curves.easeOut,
-                constraints: BoxConstraints(
-                  minHeight: widget.size.getValue(tokens),
-                ),
-                padding: EdgeInsets.symmetric(vertical: tokens.spacing50),
-                decoration: BoxDecoration(
-                  color: _color(tokens),
-                  borderRadius: BorderRadius.all(tokens.borderRadius100),
-                ),
-                alignment: Alignment.center,
-                child: DefaultTextStyle.merge(
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                  maxLines: widget.maxLines,
-                  style: tokens.bodyMediumStrong.copyWith(
-                    color: _foregroundColor(tokens),
+          (context, constrains) => Semantics(
+            inMutuallyExclusiveGroup: true,
+            child: GestureWrapper(
+              onTap: _handleChanged,
+              onHoverChanged: _handleHoverChanged,
+              onPressedChanged: _handlePressedChanged,
+              child: Padding(
+                padding: EdgeInsets.all(tokens.spacing25),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 100),
+                  curve: Curves.easeOut,
+                  constraints: BoxConstraints(
+                    minHeight: widget.size.getValue(tokens),
                   ),
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(
-                      horizontal: constrains.getAdaptivePadding(tokens),
+                  padding: EdgeInsets.symmetric(vertical: tokens.spacing50),
+                  decoration: BoxDecoration(
+                    color: _color(tokens),
+                    borderRadius: BorderRadius.all(tokens.borderRadius100),
+                  ),
+                  alignment: Alignment.center,
+                  child: DefaultTextStyle.merge(
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    maxLines: widget.maxLines,
+                    style: tokens.bodyMediumStrong.copyWith(
+                      color: _foregroundColor(tokens),
                     ),
-                    child: widget.child,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: constrains.getAdaptivePadding(tokens),
+                      ),
+                      child: widget.child,
+                    ),
                   ),
                 ),
               ),

--- a/optimus/lib/src/select.dart
+++ b/optimus/lib/src/select.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/overlay_controller.dart';
@@ -100,28 +101,31 @@ class _OptimusSelectState<T> extends State<OptimusSelect<T>> with ThemeGetter {
     size: widget.size,
     onShown: () => _handleOpenedChanged(true),
     onHidden: () => _handleOpenedChanged(false),
-    child: GestureDetector(
-      onTap: () => widget.isEnabled ? _node.requestFocus() : null,
-      child: Focus(
-        focusNode: _node,
-        child: FieldWrapper(
-          fieldBoxKey: _selectFieldKey,
+    child: Semantics(
+      role: SemanticsRole.comboBox,
+      child: GestureDetector(
+        onTap: () => widget.isEnabled ? _node.requestFocus() : null,
+        child: Focus(
           focusNode: _node,
-          label: widget.label,
-          error: widget.error,
-          isEnabled: widget.isEnabled,
-          isRequired: widget.isRequired,
-          prefix: widget.prefix,
-          suffix: _icon,
-          caption: widget.caption,
-          helperMessage: widget.secondaryCaption,
-          children: [
-            _SelectedValue(
-              size: widget.size,
-              textStyle: _textStyle,
-              child: _fieldContent,
-            ),
-          ],
+          child: FieldWrapper(
+            fieldBoxKey: _selectFieldKey,
+            focusNode: _node,
+            label: widget.label,
+            error: widget.error,
+            isEnabled: widget.isEnabled,
+            isRequired: widget.isRequired,
+            prefix: widget.prefix,
+            suffix: _icon,
+            caption: widget.caption,
+            helperMessage: widget.secondaryCaption,
+            children: [
+              _SelectedValue(
+                size: widget.size,
+                textStyle: _textStyle,
+                child: _fieldContent,
+              ),
+            ],
+          ),
         ),
       ),
     ),

--- a/optimus/lib/src/selection_card.dart
+++ b/optimus/lib/src/selection_card.dart
@@ -1,4 +1,5 @@
 import 'package:dfunc/dfunc.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/checkbox/checkbox_tick.dart';
@@ -125,87 +126,93 @@ class _OptimusSelectionCardState extends State<OptimusSelectionCard>
   }
 
   @override
-  Widget build(BuildContext context) => IgnorePointer(
-    ignoring: !widget.isEnabled,
-    child: ListenableBuilder(
-      listenable: _controller,
-      builder: (context, _) {
-        final backgroundColor = _backgroundColor.resolve(_controller.value);
-        final borderColor = _borderColor.resolve(_controller.value);
-        final titleColor = _titleColor.resolve(_controller.value);
-        final descriptionColor = _descriptionColor.resolve(_controller.value);
+  Widget build(BuildContext context) => Semantics(
+    role: SemanticsRole.radioGroup,
+    child: IgnorePointer(
+      ignoring: !widget.isEnabled,
+      child: ListenableBuilder(
+        listenable: _controller,
+        builder: (context, _) {
+          final backgroundColor = _backgroundColor.resolve(_controller.value);
+          final borderColor = _borderColor.resolve(_controller.value);
+          final titleColor = _titleColor.resolve(_controller.value);
+          final descriptionColor = _descriptionColor.resolve(_controller.value);
 
-        final selector =
-            widget.isSelectorVisible
-                ? switch (widget.selectionVariant) {
-                  OptimusSelectionCardSelectionVariant.radio => RadioCircle(
-                    controller: _controller,
-                    isSelected: widget.isSelected,
-                  ),
-                  OptimusSelectionCardSelectionVariant.checkbox => CheckboxTick(
-                    isEnabled: widget.isEnabled,
-                    isChecked: widget.isSelected,
-                    onChanged: (_) {},
-                    onTap: () {},
-                  ),
-                }
-                : null;
+          final selector =
+              widget.isSelectorVisible
+                  ? switch (widget.selectionVariant) {
+                    OptimusSelectionCardSelectionVariant.radio => RadioCircle(
+                      controller: _controller,
+                      isSelected: widget.isSelected,
+                    ),
+                    OptimusSelectionCardSelectionVariant.checkbox =>
+                      CheckboxTick(
+                        isEnabled: widget.isEnabled,
+                        isChecked: widget.isSelected,
+                        onChanged: (_) {},
+                        onTap: () {},
+                      ),
+                  }
+                  : null;
 
-        final title = DefaultTextStyle.merge(
-          child: widget.title,
-          style: tokens.bodyLargeStrong.copyWith(color: titleColor),
-        );
+          final title = DefaultTextStyle.merge(
+            child: widget.title,
+            style: tokens.bodyLargeStrong.copyWith(color: titleColor),
+          );
 
-        final Widget? description = widget.description?.let(
-          (it) => DefaultTextStyle.merge(
-            child: it,
-            style: tokens.bodyMedium.copyWith(color: descriptionColor),
-          ),
-        );
-
-        final Widget? trailing = widget.trailing?.let(
-          (it) => IconTheme.merge(
-            child: it,
-            data: IconThemeData(color: titleColor),
-          ),
-        );
-
-        return GestureWrapper(
-          onHoverChanged:
-              (isHovered) => _controller.update(WidgetState.hovered, isHovered),
-          onPressedChanged:
-              (isPressed) => _controller.update(WidgetState.pressed, isPressed),
-          onTap: widget.onPressed,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: backgroundColor,
-              borderRadius: BorderRadius.all(
-                widget.borderRadius.getBorderRadius(tokens),
-              ),
-              border: Border.all(
-                color: borderColor,
-                width: tokens.borderWidth150,
-              ),
+          final Widget? description = widget.description?.let(
+            (it) => DefaultTextStyle.merge(
+              child: it,
+              style: tokens.bodyMedium.copyWith(color: descriptionColor),
             ),
-            child: switch (widget.variant) {
-              OptimusSelectionCardVariant.horizontal => _HorizontalCard(
-                title: title,
-                description: description,
-                trailing: trailing,
-                isSelected: widget.isSelected,
-                selector: selector,
+          );
+
+          final Widget? trailing = widget.trailing?.let(
+            (it) => IconTheme.merge(
+              child: it,
+              data: IconThemeData(color: titleColor),
+            ),
+          );
+
+          return GestureWrapper(
+            onHoverChanged:
+                (isHovered) =>
+                    _controller.update(WidgetState.hovered, isHovered),
+            onPressedChanged:
+                (isPressed) =>
+                    _controller.update(WidgetState.pressed, isPressed),
+            onTap: widget.onPressed,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: backgroundColor,
+                borderRadius: BorderRadius.all(
+                  widget.borderRadius.getBorderRadius(tokens),
+                ),
+                border: Border.all(
+                  color: borderColor,
+                  width: tokens.borderWidth150,
+                ),
               ),
-              OptimusSelectionCardVariant.vertical => _VerticalCard(
-                title: title,
-                description: description,
-                trailing: trailing,
-                isSelected: widget.isSelected,
-                selector: selector,
-              ),
-            },
-          ),
-        );
-      },
+              child: switch (widget.variant) {
+                OptimusSelectionCardVariant.horizontal => _HorizontalCard(
+                  title: title,
+                  description: description,
+                  trailing: trailing,
+                  isSelected: widget.isSelected,
+                  selector: selector,
+                ),
+                OptimusSelectionCardVariant.vertical => _VerticalCard(
+                  title: title,
+                  description: description,
+                  trailing: trailing,
+                  isSelected: widget.isSelected,
+                  selector: selector,
+                ),
+              },
+            ),
+          );
+        },
+      ),
     ),
   );
 }
@@ -229,30 +236,33 @@ class _HorizontalCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.tokens;
 
-    return Padding(
-      padding: EdgeInsets.all(tokens.spacing200),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (selector case final selector?) selector,
-          Expanded(
-            child: Padding(
-              padding: EdgeInsets.symmetric(horizontal: tokens.spacing200),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Flexible(child: title),
-                  SizedBox(height: tokens.spacing25),
-                  if (description case final description?)
-                    Flexible(child: description),
-                ],
+    return Semantics(
+      inMutuallyExclusiveGroup: true,
+      child: Padding(
+        padding: EdgeInsets.all(tokens.spacing200),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (selector case final selector?) selector,
+            Expanded(
+              child: Padding(
+                padding: EdgeInsets.symmetric(horizontal: tokens.spacing200),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Flexible(child: title),
+                    SizedBox(height: tokens.spacing25),
+                    if (description case final description?)
+                      Flexible(child: description),
+                  ],
+                ),
               ),
             ),
-          ),
-          if (trailing case final trailing?) trailing,
-        ],
+            if (trailing case final trailing?) trailing,
+          ],
+        ),
       ),
     );
   }
@@ -274,36 +284,39 @@ class _VerticalCard extends StatelessWidget {
   final Widget? selector;
 
   @override
-  Widget build(BuildContext context) => Stack(
-    alignment: Alignment.center,
-    children: [
-      if (selector case final selector?)
-        Positioned(
-          right: context.tokens.spacing100,
-          top: context.tokens.spacing100,
-          child: selector,
+  Widget build(BuildContext context) => Semantics(
+    inMutuallyExclusiveGroup: true,
+    child: Stack(
+      alignment: Alignment.center,
+      children: [
+        if (selector case final selector?)
+          Positioned(
+            right: context.tokens.spacing100,
+            top: context.tokens.spacing100,
+            child: selector,
+          ),
+        Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: context.tokens.spacing200,
+            vertical: context.tokens.spacing400,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (trailing case final trailing?) trailing,
+              SizedBox(
+                height: context.tokens.spacing200,
+                width: context.tokens.sizing1300,
+              ),
+              Flexible(child: title),
+              SizedBox(height: context.tokens.spacing50),
+              if (description case final description?)
+                Flexible(child: description),
+            ],
+          ),
         ),
-      Padding(
-        padding: EdgeInsets.symmetric(
-          horizontal: context.tokens.spacing200,
-          vertical: context.tokens.spacing400,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (trailing case final trailing?) trailing,
-            SizedBox(
-              height: context.tokens.spacing200,
-              width: context.tokens.sizing1300,
-            ),
-            Flexible(child: title),
-            SizedBox(height: context.tokens.spacing50),
-            if (description case final description?)
-              Flexible(child: description),
-          ],
-        ),
-      ),
-    ],
+      ],
+    ),
   );
 }
 

--- a/optimus/lib/src/tooltip/tooltip.dart
+++ b/optimus/lib/src/tooltip/tooltip.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/tooltip/tooltip_alignment.dart';
 import 'package:optimus/src/tooltip/tooltip_overlay.dart';
@@ -40,26 +41,29 @@ class OptimusTooltip extends StatelessWidget {
     final foregroundColor = tokens.textStaticInverse;
     final backgroundColor = tokens.backgroundStaticInverse;
 
-    return Padding(
-      padding: const EdgeInsets.all(_arrowHeight),
-      child: CustomPaint(
-        painter: _TooltipPainter(
-          color: backgroundColor,
-          alignment: alignment,
-          borderRadius: tokens.borderRadius50,
-        ),
-        child: Container(
-          width: size.maxWidth,
-          padding: EdgeInsets.symmetric(
-            vertical: tokens.spacing50,
-            horizontal: tokens.spacing150,
-          ),
-          child: Material(
+    return Semantics(
+      role: SemanticsRole.tooltip,
+      child: Padding(
+        padding: const EdgeInsets.all(_arrowHeight),
+        child: CustomPaint(
+          painter: _TooltipPainter(
             color: backgroundColor,
-            child: DefaultTextStyle.merge(
-              style: tokens.bodySmallStrong.copyWith(color: foregroundColor),
-              textAlign: TextAlign.center,
-              child: content,
+            alignment: alignment,
+            borderRadius: tokens.borderRadius50,
+          ),
+          child: Container(
+            width: size.maxWidth,
+            padding: EdgeInsets.symmetric(
+              vertical: tokens.spacing50,
+              horizontal: tokens.spacing150,
+            ),
+            child: Material(
+              color: backgroundColor,
+              child: DefaultTextStyle.merge(
+                style: tokens.bodySmallStrong.copyWith(color: foregroundColor),
+                textAlign: TextAlign.center,
+                child: content,
+              ),
             ),
           ),
         ),

--- a/optimus/lib/src/tooltip/tooltip_overlay.dart
+++ b/optimus/lib/src/tooltip/tooltip_overlay.dart
@@ -290,7 +290,7 @@ class TooltipOverlayState extends State<TooltipOverlay>
     controller: this,
     child: Builder(
       builder:
-          (context) => Positioned(
+          (_) => Positioned(
             left: _leftOffset,
             top: _topOffset,
             bottom: _bottomOffset,
@@ -305,5 +305,5 @@ class TooltipOverlayState extends State<TooltipOverlay>
   );
 }
 
-const double _tooltipAlignOffset = 20.0;
+const double _tooltipAlignOffset = 20.0; // TODO(witwash): check with design
 const Duration _animationDuration = Duration(milliseconds: 100);


### PR DESCRIPTION
#### Summary

- added `SemanticRole` to suitable components. Most of them are using `material` of `cupertino` underneath, so they are covered there. Custom-built components that fit the role were marked with one.
- implicitly bump to Flutter 3.32, since `SemanticRole` was added there.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
