### PR TITLE
ci: Bump CI Flutter to 3.32

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: 3.29.0
+        flutter-version: 3.32.0
 
     - name: Get ID Token
       uses: actions/github-script@v6

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Set up Flutter
       uses: subosito/flutter-action@ea686d7c56499339ad176e9f19c516ff6cf05a31
       with:
-        flutter-version: 3.29.0
+        flutter-version: 3.32.0
         cache: true
 
     - name: Set up environment paths


### PR DESCRIPTION
#### Summary

-  bumped CI Flutter to 3.32

#### Testing steps

None

#### Follow-up issues

#795 

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
