### PR TITLE
feat: Upgrade to DCM 1.29.1

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.28.1"
+          version: "1.29.1"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -524,7 +524,7 @@ dart_code_metrics:
     # - prefer-prefixed-global-constants
     # - prefer-private-extension-type-field
     - prefer-public-exception-classes
-    # - prefer-redirecting-superclass-constructor
+    - prefer-redirecting-superclass-constructor
     - prefer-return-await
     - prefer-returning-conditional-expressions
     - prefer-simpler-boolean-expressions


### PR DESCRIPTION
#### Summary

- bumped `dcm` to `1.29.1`. There are no new rules, just fixes and other feature updates
- enabled `prefer-redirecting-superclass-constructor`, which was updated in `1.28.0`, and false positives were fixed

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
