### PR TITLE
ci: Update DCM check action

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Dart Code Metrics
-        run: melos exec -c 1 --ignore="*example*" -- dcm analyze --fatal-style --fatal-performance --fatal-warnings --ci-key=${{ secrets.DCM_CI_KEY }} --email=${{ vars.DCM_CI_EMAIL }} .
+        run: melos exec -c 1 --ignore="*example*" -- dcm analyze --fatal-style --fatal-warnings --ci-key=${{ secrets.DCM_CI_KEY }} --email=${{ vars.DCM_CI_EMAIL }} .


### PR DESCRIPTION
#### Summary

- Removed `--fatal-performance` argument, it was removed and is now turned on by default.

#### Testing steps

None

#### Follow-up issues

Will unblock #800 

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
