### PR TITLE
chore: Bump widgetbook to 3.14.3

### DIFF
--- a/optimus_widgetbook/pubspec.yaml
+++ b/optimus_widgetbook/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   optimus:
     path: ../optimus
   url_launcher: ^6.3.1
-  widgetbook: ^3.14.2
-  widgetbook_annotation: ^3.4.0
+  widgetbook: ^3.14.3
+  widgetbook_annotation: ^3.5.0
 
 dev_dependencies:
   build_runner: ^2.4.12


### PR DESCRIPTION
#### Summary

- bumped `widgetbook`. It's now more accessible, and accessibility testing gives fewer false positives.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
