### PR TITLE
feat: [DX-6570] Update feedback widgets semantics

### DIFF
--- a/optimus/lib/src/feedback/alert.dart
+++ b/optimus/lib/src/feedback/alert.dart
@@ -158,6 +158,38 @@ class _AlertContent extends StatelessWidget {
     final linkText = this.linkText;
     final onLinkPressed = this.onLinkPressed;
 
+    final content = Row(
+      children: [
+        SizedBox(width: leadingSectionWidth).excludeSemantics(),
+        Expanded(
+          child: Container(
+            padding: _getContentPadding(tokens),
+            decoration: BoxDecoration(
+              color: tokens.backgroundStaticFlat,
+              borderRadius: BorderRadius.horizontal(
+                right: tokens.borderRadius100,
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              spacing: tokens.spacing50,
+              children: [
+                if (title case final title?) FeedbackTitle(title: title),
+                if (description case final description?)
+                  FeedbackDescription(description: description),
+                if (linkText != null && onLinkPressed != null)
+                  FeedbackLink(
+                    text: linkText,
+                    semanticLinkUri: semanticLinkUri,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+
     return DecoratedBox(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.all(tokens.borderRadius100),
@@ -187,41 +219,10 @@ class _AlertContent extends StatelessWidget {
               child: FeedbackIcon(icon: icon, variant: variant),
             ),
           ),
-          GestureDetector(
-            onTap: onLinkPressed,
-            child: Row(
-              children: [
-                SizedBox(width: leadingSectionWidth).excludeSemantics(),
-                Expanded(
-                  child: Container(
-                    padding: _getContentPadding(tokens),
-                    decoration: BoxDecoration(
-                      color: tokens.backgroundStaticFlat,
-                      borderRadius: BorderRadius.horizontal(
-                        right: tokens.borderRadius100,
-                      ),
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      spacing: tokens.spacing50,
-                      children: [
-                        if (title case final title?)
-                          FeedbackTitle(title: title),
-                        if (description case final description?)
-                          FeedbackDescription(description: description),
-                        if (linkText != null && onLinkPressed != null)
-                          FeedbackLink(
-                            text: linkText,
-                            semanticLinkUri: semanticLinkUri,
-                          ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
+          if (onLinkPressed != null)
+            GestureDetector(onTap: onLinkPressed, child: content)
+          else
+            content,
         ],
       ),
     );

--- a/optimus/lib/src/feedback/alert.dart
+++ b/optimus/lib/src/feedback/alert.dart
@@ -72,7 +72,6 @@ class OptimusAlert extends StatelessWidget {
     );
 
     return Semantics(
-      role: SemanticsRole.alert,
       liveRegion: true,
       child: Padding(
         padding: EdgeInsets.symmetric(

--- a/optimus/lib/src/feedback/alert.dart
+++ b/optimus/lib/src/feedback/alert.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/semantics.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/common/semantics.dart';
@@ -187,37 +187,40 @@ class _AlertContent extends StatelessWidget {
               child: FeedbackIcon(icon: icon, variant: variant),
             ),
           ),
-          Row(
-            children: [
-              SizedBox(width: leadingSectionWidth).excludeSemantics(),
-              Expanded(
-                child: Container(
-                  padding: _getContentPadding(tokens),
-                  decoration: BoxDecoration(
-                    color: tokens.backgroundStaticFlat,
-                    borderRadius: BorderRadius.horizontal(
-                      right: tokens.borderRadius100,
+          GestureDetector(
+            onTap: onLinkPressed,
+            child: Row(
+              children: [
+                SizedBox(width: leadingSectionWidth).excludeSemantics(),
+                Expanded(
+                  child: Container(
+                    padding: _getContentPadding(tokens),
+                    decoration: BoxDecoration(
+                      color: tokens.backgroundStaticFlat,
+                      borderRadius: BorderRadius.horizontal(
+                        right: tokens.borderRadius100,
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      spacing: tokens.spacing50,
+                      children: [
+                        if (title case final title?)
+                          FeedbackTitle(title: title),
+                        if (description case final description?)
+                          FeedbackDescription(description: description),
+                        if (linkText != null && onLinkPressed != null)
+                          FeedbackLink(
+                            text: linkText,
+                            semanticLinkUri: semanticLinkUri,
+                          ),
+                      ],
                     ),
                   ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    spacing: tokens.spacing50,
-                    children: [
-                      if (title case final title?) FeedbackTitle(title: title),
-                      if (description case final description?)
-                        FeedbackDescription(description: description),
-                      if (linkText != null && onLinkPressed != null)
-                        FeedbackLink(
-                          text: linkText,
-                          onPressed: onLinkPressed,
-                          semanticLinkUri: semanticLinkUri,
-                        ),
-                    ],
-                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ],
       ),

--- a/optimus/lib/src/feedback/banner.dart
+++ b/optimus/lib/src/feedback/banner.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:optimus/src/feedback/common.dart';
 import 'package:optimus/src/feedback/feedback_variant.dart';
 import 'package:optimus/src/theme/theme.dart';

--- a/optimus/lib/src/feedback/banner.dart
+++ b/optimus/lib/src/feedback/banner.dart
@@ -65,7 +65,6 @@ class OptimusBanner extends StatelessWidget {
     final tokens = context.tokens;
 
     return Semantics(
-      role: SemanticsRole.alert,
       liveRegion: true,
       child: GestureDetector(
         onTap: onPressed,

--- a/optimus/lib/src/feedback/common.dart
+++ b/optimus/lib/src/feedback/common.dart
@@ -78,15 +78,9 @@ class FeedbackDescription extends StatelessWidget {
 }
 
 class FeedbackLink extends StatelessWidget {
-  const FeedbackLink({
-    super.key,
-    required this.text,
-    required this.onPressed,
-    this.semanticLinkUri,
-  });
+  const FeedbackLink({super.key, required this.text, this.semanticLinkUri});
 
   final Widget text;
-  final VoidCallback onPressed;
   final Uri? semanticLinkUri;
 
   @override
@@ -96,16 +90,13 @@ class FeedbackLink extends StatelessWidget {
     return Semantics(
       link: true,
       linkUrl: semanticLinkUri,
-      child: GestureDetector(
-        onTap: onPressed,
-        child: DefaultTextStyle.merge(
-          child: text,
-          maxLines: _maxLinesLink,
-          overflow: overflowStyle,
-          style: tokens.bodyMediumStrong.copyWith(
-            color: tokens.textStaticSecondary,
-            decoration: TextDecoration.underline,
-          ),
+      child: DefaultTextStyle.merge(
+        child: text,
+        maxLines: _maxLinesLink,
+        overflow: overflowStyle,
+        style: tokens.bodyMediumStrong.copyWith(
+          color: tokens.textStaticSecondary,
+          decoration: TextDecoration.underline,
         ),
       ),
     );

--- a/optimus/lib/src/feedback/system_wide_banner.dart
+++ b/optimus/lib/src/feedback/system_wide_banner.dart
@@ -52,6 +52,27 @@ class OptimusSystemWideBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = context.tokens;
 
+    final linkOnPressed = link?.onPressed;
+    final content = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        FeedbackTitle(title: title),
+        if (description case final description?)
+          Padding(
+            padding: EdgeInsets.only(top: tokens.spacing50),
+            child: FeedbackDescription(description: description),
+          ),
+        if (link case final link?)
+          Padding(
+            padding: EdgeInsets.only(top: tokens.spacing50),
+            child: FeedbackLink(
+              text: link.text,
+              semanticLinkUri: link.semanticUri,
+            ),
+          ),
+      ],
+    );
+
     return GestureDetector(
       onTap: onPressed,
       child: DecoratedBox(
@@ -71,30 +92,13 @@ class OptimusSystemWideBanner extends StatelessWidget {
               Expanded(
                 child: Padding(
                   padding: EdgeInsets.only(left: tokens.spacing150),
-                  child: GestureDetector(
-                    onTap: link?.onPressed,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        FeedbackTitle(title: title),
-                        if (description case final description?)
-                          Padding(
-                            padding: EdgeInsets.only(top: tokens.spacing50),
-                            child: FeedbackDescription(
-                              description: description,
-                            ),
-                          ),
-                        if (link case final link?)
-                          Padding(
-                            padding: EdgeInsets.only(top: tokens.spacing50),
-                            child: FeedbackLink(
-                              text: link.text,
-                              semanticLinkUri: link.semanticUri,
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
+                  child:
+                      linkOnPressed != null
+                          ? GestureDetector(
+                            onTap: linkOnPressed,
+                            child: content,
+                          )
+                          : content,
                 ),
               ),
             ],

--- a/optimus/lib/src/feedback/system_wide_banner.dart
+++ b/optimus/lib/src/feedback/system_wide_banner.dart
@@ -71,25 +71,29 @@ class OptimusSystemWideBanner extends StatelessWidget {
               Expanded(
                 child: Padding(
                   padding: EdgeInsets.only(left: tokens.spacing150),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      FeedbackTitle(title: title),
-                      if (description case final description?)
-                        Padding(
-                          padding: EdgeInsets.only(top: tokens.spacing50),
-                          child: FeedbackDescription(description: description),
-                        ),
-                      if (link case final link?)
-                        Padding(
-                          padding: EdgeInsets.only(top: tokens.spacing50),
-                          child: FeedbackLink(
-                            text: link.text,
-                            onPressed: link.onPressed,
-                            semanticLinkUri: link.semanticUri,
+                  child: GestureDetector(
+                    onTap: link?.onPressed,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        FeedbackTitle(title: title),
+                        if (description case final description?)
+                          Padding(
+                            padding: EdgeInsets.only(top: tokens.spacing50),
+                            child: FeedbackDescription(
+                              description: description,
+                            ),
                           ),
-                        ),
-                    ],
+                        if (link case final link?)
+                          Padding(
+                            padding: EdgeInsets.only(top: tokens.spacing50),
+                            child: FeedbackLink(
+                              text: link.text,
+                              semanticLinkUri: link.semanticUri,
+                            ),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
#### Summary

- removed contradicting semantics
- The tap zone on text wasn't accessible. Made the tap zone bigger: if link/action is present, tapping on the whole alert will trigger it, not just text, like before. 

#### Testing steps

1. Open Alert/System Wide Banner/ Banner use case
2. Test if components work as intended using exposed knobs.
3. 
#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
