### PR TITLE
chore: Bump slidable to 4.0.0 and up

### DIFF
--- a/optimus/pubspec.yaml
+++ b/optimus/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   dfunc: ^0.10.0
   flutter:
     sdk: flutter
-  flutter_slidable: ">=1.2.0 <5.0.0"
+  flutter_slidable: ^4.0.0
   flutter_svg: ^2.0.7
   freezed_annotation: ">=1.0.0 <3.0.0"
   intl: ">=0.17.0 <0.21.0"


### PR DESCRIPTION
#### Summary

- bumped `flutter_slidable` to fix build fails

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
