### PR TITLE
feat!: Upgrade to DCM 1.30.1

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.29.1"
+          version: "1.30.1"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -257,11 +257,13 @@ dart_code_metrics:
     - avoid-assignments-as-conditions
     # - avoid-async-call-in-sync-function
     # - avoid-banned-annotations
+    # - avoid-banned-exports
     # - avoid-banned-file-names
     # - avoid-banned-imports
     # - avoid-banned-names
     # - avoid-banned-types
     - avoid-barrel-files
+    - avoid-bitwise-operators-with-booleans
     - avoid-bottom-type-in-patterns
     - avoid-bottom-type-in-records
     - avoid-cascade-after-if-null
@@ -278,6 +280,8 @@ dart_code_metrics:
     # - avoid-continue
     - avoid-contradictory-expressions
     # - avoid-declaring-call-method
+    # - avoid-default-tostring
+    # - avoid-deprecated-usage
     - avoid-double-slash-imports
     - avoid-duplicate-cascades
     - avoid-duplicate-collection-elements
@@ -320,8 +324,8 @@ dart_code_metrics:
     - avoid-late-final-reassignment
     # - avoid-late-keyword
     # - avoid-local-functions
-    # - avoid-long-functions
     # - avoid-long-files
+    # - avoid-long-functions
     # - avoid-long-parameter-list
     # - avoid-long-records
     - avoid-map-keys-contains
@@ -330,8 +334,8 @@ dart_code_metrics:
     # - avoid-missing-enum-constant-in-map
     - avoid-missing-interpolation
     # - avoid-missing-test-files
-    - avoid-misused-test-matchers
     - avoid-misused-set-literals
+    - avoid-misused-test-matchers
     - avoid-misused-wildcard-pattern
     - avoid-mixing-named-and-positional-fields
     - avoid-multi-assignment
@@ -379,7 +383,9 @@ dart_code_metrics:
     # - avoid-similar-names
     # - avoid-single-field-destructuring
     # - avoid-slow-collection-methods
+    - avoid-stream-tostring
     # - avoid-substring
+    - avoid-suspicious-global-reference
     - avoid-suspicious-super-overrides
     # - avoid-throw-in-catch-block
     # - avoid-throw-objects-without-tostring
@@ -404,16 +410,21 @@ dart_code_metrics:
     - avoid-unnecessary-futures
     - avoid-unnecessary-getter
     - avoid-unnecessary-if
+    - avoid-unnecessary-length-check
     - avoid-unnecessary-local-late
     - avoid-unnecessary-negations
+    # - avoid-unnecessary-null-aware-elements
+    - avoid-unnecessary-nullable-fields
     - avoid-unnecessary-nullable-return-type
     - avoid-unnecessary-overrides
     - avoid-unnecessary-patterns
     - avoid-unnecessary-reassignment
     - avoid-unnecessary-return
+    - avoid-unnecessary-statements
     - avoid-unnecessary-super
     - avoid-unnecessary-type-assertions
     - avoid-unnecessary-type-casts
+    - avoid-unreachable-for-loop
     - avoid-unrelated-type-assertions
     - avoid-unrelated-type-casts
     # - avoid-unsafe-collection-methods
@@ -441,6 +452,7 @@ dart_code_metrics:
     - match-getter-setter-field-names
     - match-lib-folder-structure
     # - match-positional-field-names-on-assignment
+    # - max-imports
     # - member-ordering
     # - missing-test-assertion
     - missing-use-result-annotation:
@@ -464,6 +476,7 @@ dart_code_metrics:
     # - no-magic-string
     - no-object-declaration
     # - parameters-ordering
+    - pass-correct-accepted-type
     # - pattern-fields-ordering
     - prefer-abstract-final-static-class
     - prefer-add-all
@@ -478,6 +491,7 @@ dart_code_metrics:
     # - prefer-class-destructuring
     - prefer-commenting-analyzer-ignores
     # - prefer-commenting-future-delayed
+    - prefer-compound-assignment-operators
     # - prefer-conditional-expressions
     - prefer-contains
     # - prefer-correct-callback-field-name
@@ -518,12 +532,14 @@ dart_code_metrics:
     # - prefer-named-imports
     - prefer-named-parameters:
         max-number: 2
+    # - prefer-null-aware-elements
     - prefer-null-aware-spread
     - prefer-overriding-parent-equality
     - prefer-parentheses-with-if-null
     # - prefer-prefixed-global-constants
     # - prefer-private-extension-type-field
     - prefer-public-exception-classes
+    - prefer-pushing-conditional-expressions
     - prefer-redirecting-superclass-constructor
     - prefer-return-await
     - prefer-returning-conditional-expressions
@@ -531,6 +547,7 @@ dart_code_metrics:
     - prefer-simpler-patterns-null-check
     # - prefer-single-declaration-per-file
     - prefer-specific-cases-first
+    - prefer-specifying-future-value-type
     # - prefer-static-class
     - prefer-static-method:
         ignore-private: true
@@ -565,7 +582,8 @@ dart_code_metrics:
     # - avoid-inherited-widget-in-initstate
     - avoid-late-context
     - avoid-missing-controller
-    # - avoid-missing-image-alt
+    - avoid-missing-image-alt
+    - avoid-mounted-in-setstate
     - avoid-recursive-widget-calls
     # - avoid-returning-widgets
     - avoid-shrink-wrap-in-lists
@@ -595,6 +613,7 @@ dart_code_metrics:
     # - prefer-extracting-callbacks
     # - prefer-for-loop-in-children
     - prefer-padding-over-container
+    - prefer-single-setstate
     # - prefer-single-widget-per-file
     - prefer-sized-box-square
     - prefer-sliver-prefix
@@ -614,7 +633,9 @@ dart_code_metrics:
     - avoid-read-inside-build
     # - avoid-watch-outside-build
     - dispose-providers
+    - prefer-immutable-selector-value
     - prefer-multi-provider
+    # - prefer-nullable-provider-types
     - prefer-provider-extensions
 
     # Bloc
@@ -649,6 +670,7 @@ dart_code_metrics:
         banned:
           - get
   #    - prefer-caret-version-syntax
+    - prefer-commenting-pubspec-ignores
   #    - prefer-correct-package-name
   #    - prefer-correct-screenshots
   #    - prefer-pinned-version-syntax

--- a/optimus/lib/src/avatar/avatar.dart
+++ b/optimus/lib/src/avatar/avatar.dart
@@ -74,6 +74,7 @@ class OptimusAvatar extends StatelessWidget {
           children: <Widget>[
             _CircleImage(
               imageUrl: imageUrl,
+              semanticLabel: semanticLabel,
               decoration: decoration,
               diameter: size.getSize(tokens),
               fallbackWidget: _FallbackText(title: title, size: size),
@@ -103,12 +104,14 @@ class _CircleImage extends StatelessWidget {
     required this.imageUrl,
     required this.fallbackWidget,
     this.decoration,
+    this.semanticLabel,
   });
 
   final double diameter;
   final String? imageUrl;
   final BoxDecoration? decoration;
   final Widget fallbackWidget;
+  final String? semanticLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -135,6 +138,7 @@ class _CircleImage extends StatelessWidget {
                       height: diameter,
                       placeholder: _transparentImage,
                       image: imageUrl,
+                      imageSemanticLabel: semanticLabel,
                       fit: BoxFit.cover,
                       imageErrorBuilder:
                           (_, _, _) => Container(

--- a/optimus/lib/src/checkbox/checkbox.dart
+++ b/optimus/lib/src/checkbox/checkbox.dart
@@ -45,6 +45,7 @@ class OptimusCheckbox extends StatelessWidget {
   /// {@template optimus.checkbox.isChecked}
   /// Whether this checkbox is checked.
   /// {@endtemplate}
+  // ignore: avoid-unnecessary-nullable-fields, required for the tristate
   final bool? isChecked;
 
   /// {@template optimus.checkbox.tristate}

--- a/optimus/lib/src/expansion/expansion_tile.dart
+++ b/optimus/lib/src/expansion/expansion_tile.dart
@@ -123,16 +123,18 @@ class _OptimusExpansionTileState extends State<OptimusExpansionTile>
       if (_isExpanded) {
         _controller.forward();
       } else {
-        _controller.reverse().then<void>((void value) {
-          if (!mounted) return;
-          setState(() {
-            // Rebuild without widget.children.
-          });
-        });
+        _controller.reverse().then<void>((_) => _handleReverse());
       }
       PageStorage.of(context).writeState(context, _isExpanded);
     });
     widget.onExpansionChanged?.call(_isExpanded);
+  }
+
+  void _handleReverse() {
+    if (!mounted) return;
+    setState(() {
+      // Rebuild without widget.children.
+    });
   }
 
   @override

--- a/optimus/lib/src/form/input_field.dart
+++ b/optimus/lib/src/form/input_field.dart
@@ -19,7 +19,7 @@ class OptimusInputField extends StatefulWidget {
     this.focusNode,
     this.label,
     this.caption,
-    this.captionIcon = OptimusIcons.info,
+    this.captionIcon,
     this.helperMessage,
     this.maxLines = 1,
     this.minLines,

--- a/optimus/lib/src/form/multiselect/multiselect_field.dart
+++ b/optimus/lib/src/form/multiselect/multiselect_field.dart
@@ -11,7 +11,7 @@ class MultiSelectInputField extends StatefulWidget {
     this.focusNode,
     this.label,
     this.caption,
-    this.captionIcon = OptimusIcons.info,
+    this.captionIcon,
     this.helperMessage,
     this.error,
     this.errorVariant = OptimusInputErrorVariant.bottomHint,

--- a/optimus/lib/src/form/text_area.dart
+++ b/optimus/lib/src/form/text_area.dart
@@ -55,7 +55,7 @@ class OptimusTextArea extends StatelessWidget {
 
   /// {@macro flutter.widgets.editableText.keyboardType}
   /// Defaults to [TextInputType.multiline].
-  final TextInputType? keyboardType;
+  final TextInputType keyboardType;
 
   /// Controls whether the field is enabled.
   final bool isEnabled;

--- a/optimus/lib/src/progress_indicator/progress_indicator.dart
+++ b/optimus/lib/src/progress_indicator/progress_indicator.dart
@@ -216,15 +216,15 @@ class _VerticalProgressIndicatorState extends State<_VerticalProgressIndicator>
       if (_isExpanded) {
         _animationController.forward();
       } else {
-        _animationController.reverse().then<void>((_) {
-          if (!mounted) {
-            return;
-          }
-          setState(() {
-            // Rebuild without children.
-          });
-        });
+        _animationController.reverse().then<void>((_) => _handleReverse());
       }
+    });
+  }
+
+  void _handleReverse() {
+    if (!mounted) return;
+    setState(() {
+      // Rebuild without children.
     });
   }
 

--- a/optimus/lib/src/skeleton/bone.dart
+++ b/optimus/lib/src/skeleton/bone.dart
@@ -57,13 +57,13 @@ class OptimusBone extends StatelessWidget {
   final OptimusBoneRadiusVariant? radiusVariant;
   final BoxShape boxShape;
   final Widget? child;
-  final bool? isLoading;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) => Semantics(
     liveRegion: true,
     child: _Bone(
-      isLoading: isLoading ?? true,
+      isLoading: isLoading,
       child:
           child ??
           SizedBox(

--- a/optimus/lib/src/slidable/slidable.dart
+++ b/optimus/lib/src/slidable/slidable.dart
@@ -6,7 +6,7 @@ class OptimusSlidable extends StatefulWidget {
   const OptimusSlidable({
     super.key,
     required this.child,
-    this.actions = const <Widget>[],
+    this.actions,
     this.isEnabled = true,
     this.hasBorders = true,
     this.actionsWidth = 0,

--- a/optimus/lib/src/tooltip/tooltip_wrapper.dart
+++ b/optimus/lib/src/tooltip/tooltip_wrapper.dart
@@ -29,7 +29,7 @@ class OptimusTooltipWrapper extends StatefulWidget {
   /// the tooltip will be positioned automatically. Defaults to
   /// [OptimusTooltipPosition.top] or [OptimusTooltipPosition.bottom], whichever
   /// has more space available.
-  final OptimusTooltipPosition? tooltipPosition;
+  final OptimusTooltipPosition tooltipPosition;
 
   /// Duration for which the tooltip will be shown.
   final Duration autoHideDuration;

--- a/optimus_widgetbook/lib/main.dart
+++ b/optimus_widgetbook/lib/main.dart
@@ -15,15 +15,13 @@ class WidgetbookApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Widgetbook.material(
     addons: <WidgetbookAddon>[
-      DeviceFrameAddon(
-        devices: [
-          Devices.ios.iPhone13Mini,
-          Devices.ios.iPhone13,
-          Devices.ios.iPhone13ProMax,
-          Devices.ios.iPadAir4,
-          Devices.ios.iPad12InchesGen4,
-        ],
-      ),
+      ViewportAddon([
+        IosViewports.iPhone13Mini,
+        IosViewports.iPhone13,
+        IosViewports.iPhone13ProMax,
+        IosViewports.iPadAir4,
+        IosViewports.iPad12InchesGen4,
+      ]),
       InspectorAddon(),
       ThemeAddon<OptimusThemeData>(
         themes: [

--- a/optimus_widgetbook/pubspec.yaml
+++ b/optimus_widgetbook/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   optimus:
     path: ../optimus
   url_launcher: ^6.3.1
-  widgetbook: ^3.14.3
+  widgetbook: ^3.15.0
   widgetbook_annotation: ^3.5.0
 
 dev_dependencies:

--- a/remote_logger/lib/src/remote_logger.dart
+++ b/remote_logger/lib/src/remote_logger.dart
@@ -62,7 +62,6 @@ class RemoteLogger {
   final GetHeaders _getHeaders;
   Duration _currentTimeout = _initialTimeout;
 
-  // ignore: dispose-class-fields, we don't want to dispose a user-provided client.
   final Client? _client;
   Client? _internalClient;
 


### PR DESCRIPTION
#### Summary

New rules:
Common:
[prefer-pushing-conditional-expressions](https://dcm.dev/docs/rules/common/prefer-pushing-conditional-expressions/)
[avoid-suspicious-global-reference](https://dcm.dev/docs/rules/common/avoid-suspicious-global-reference/)
[pass-correct-accepted-type](https://dcm.dev/docs/rules/common/pass-correct-accepted-type/) - actually, I'm not sure we even use `dart_code_metrics_annotations`. Might disable it as well.
[avoid-unreachable-for-loop](https://dcm.dev/docs/rules/common/avoid-unreachable-for-loop/)
[avoid-unnecessary-length-check](https://dcm.dev/docs/rules/common/avoid-unnecessary-length-check/)
[prefer-specifying-future-value-type](https://dcm.dev/docs/rules/common/prefer-specifying-future-value-type/)
[avoid-stream-tostring](https://dcm.dev/docs/rules/common/avoid-stream-tostring/)
[prefer-null-aware-elements](https://dcm.dev/docs/rules/common/prefer-null-aware-elements/)
[avoid-unnecessary-null-aware-elements](https://dcm.dev/docs/rules/common/avoid-unnecessary-null-aware-elements/) 
[avoid-unnecessary-statements](https://dcm.dev/docs/rules/common/avoid-unnecessary-statements/)
[avoid-unnecessary-nullable-fields](https://dcm.dev/docs/rules/common/avoid-unnecessary-nullable-fields/)
[avoid-bitwise-operators-with-booleans](https://dcm.dev/docs/rules/common/avoid-bitwise-operators-with-booleans/) 
[prefer-compound-assignment-operators](https://dcm.dev/docs/rules/common/prefer-compound-assignment-operators/) 
[avoid-missing-image-alt](https://dcm.dev/docs/rules/common/avoid-default-tostring/)

Flutter:
[prefer-single-setstate](https://dcm.dev/docs/rules/flutter/prefer-single-setstate/)
[avoid-mounted-in-setstate](https://dcm.dev/docs/rules/flutter/avoid-mounted-in-setstate/)
Provider:
[prefer-immutable-selector-value](https://dcm.dev/docs/rules/provider/prefer-immutable-selector-value/)
Pub:
[prefer-commenting-pubspec-ignores](https://dcm.dev/docs/rules/pub/prefer-commenting-pubspec-ignores/)

Rules left disabled:
- [prefer-nullable-provider-types](https://dcm.dev/docs/rules/provider/prefer-nullable-provider-types/) - need your opinion before I add it. Might cause a lot of refactoring.
- [avoid-deprecated-usage](https://dcm.dev/docs/rules/common/avoid-deprecated-usage/) - used the rule from the `dart` linter
- [max-imports](https://dcm.dev/docs/rules/common/max-imports/) - not sure we want it
- [avoid-default-tostring](https://dcm.dev/docs/rules/common/avoid-default-tostring/) - right now it flags `enum` as well. Will wait for the next version. The DCM author confirmed that `enum`s will be fixed in the next version.
- [avoid-banned-exports](https://dcm.dev/docs/rules/common/avoid-banned-exports/)


#### Testing steps

*Info about test cases. If you think the issue is not testable, describe why.*

#### Follow-up issues

*Is there some action/cleanup needed after this PR is merged or deployed (e.g. consolidate some part outside the scope of this PR, etc)? Create issues for it with deadline and note them here and in the PR comments.*

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
