### PR TITLE
feat: [DX-7500] Update input focus border

### DIFF
--- a/optimus/lib/src/common/field_wrapper.dart
+++ b/optimus/lib/src/common/field_wrapper.dart
@@ -115,8 +115,8 @@ class _FieldWrapper extends State<FieldWrapper> with ThemeGetter {
 
   Color get _borderColor {
     if (!widget.isEnabled) return tokens.borderDisabled;
-    if (widget.hasError) return tokens.borderAlertDanger;
     if (_isFocused) return tokens.borderInteractiveFocus;
+    if (widget.hasError) return tokens.borderAlertDanger;
     if (_isHovered) return tokens.borderInteractiveSecondaryHover;
 
     return tokens.borderInteractiveSecondaryDefault;

--- a/optimus/lib/src/form/number_input/number_input.dart
+++ b/optimus/lib/src/form/number_input/number_input.dart
@@ -109,11 +109,11 @@ class OptimusNumberInput extends StatefulWidget {
   final ValueChanged<String>? onSubmitted;
 
   /// Semantic label for marking the button as a decrease function button.
-  /// This will have enrish component for the screen reader.
+  /// This will enrich component for the screen reader.
   final String? decreaseSemanticLabel;
 
   /// Semantic label for marking the button as an increase function button.
-  /// This will have enrish component for the screen reader.
+  /// This will enrich component for the screen reader.
   final String? increaseSemanticLabel;
 
   @override


### PR DESCRIPTION
#### Summary

- Due to accessibility guidelines, the focused input state should have priority above other states (except disabled). I changed the way we retrieve the border color to follow the requirement.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
