### PR TITLE
fix: [DX-7835] Fix DropdownListTile overflow

### DIFF
--- a/optimus/lib/src/dropdown/base_dropdown_tile.dart
+++ b/optimus/lib/src/dropdown/base_dropdown_tile.dart
@@ -29,7 +29,7 @@ class BaseDropdownTile extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
+      children: [
         OptimusTypography(
           resolveStyle: (_) => tokens.bodyMediumStrong,
           child: title,

--- a/optimus/lib/src/dropdown/dropdown.dart
+++ b/optimus/lib/src/dropdown/dropdown.dart
@@ -314,10 +314,7 @@ class _GroupedDropdownListViewState<T>
         reverse: widget.isReversed,
         padding: EdgeInsets.symmetric(vertical: tokens.spacing100),
         itemCount: widget.items.length,
-        prototypeItem: widget.items.isNotEmpty
-            ? _buildPrototypeItem(widget.items.first)
-            : null,
-        itemBuilder: (context, index) {
+        itemBuilder: (_, index) {
           final current = _sortedItems[index];
           final child = _DropdownItem(
             onChanged: widget.onChanged,
@@ -379,16 +376,6 @@ class _GroupedDropdownListViewState<T>
     }
 
     return totalHeight.clamp(0.0, widget.maxHeight);
-  }
-
-  Widget _buildPrototypeItem(OptimusDropdownTile<T> item) {
-    final child = _DropdownItem(onChanged: widget.onChanged, child: item);
-
-    return _GroupWrapper(
-      useBorder: false,
-      group: _effectiveGroupBuilder(widget.groupBy(item.value)),
-      child: child,
-    );
   }
 }
 


### PR DESCRIPTION
#### Summary

- removed list item prototype because it is making everything the same height and it is not always the case (for example grouping or items without subtitle, long title, etc.)

#### Testing steps

1. Open OptimusSelectInput
2. Enable being grouped
3. Test if the component is not overflowing and is behaving like expected

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
