### PR TITLE
fix: [DX-7510] Fix missing assets on the home page

### DIFF
--- a/optimus_widgetbook/lib/branding/home_page.dart
+++ b/optimus_widgetbook/lib/branding/home_page.dart
@@ -143,7 +143,7 @@ enum _CardImageVariant {
 }
 
 extension on _CardImageVariant {
-  String get path => 'svg/$fileName.svg';
+  String get path => 'assets/svg/$fileName.svg';
 }
 
 class _CardImage extends StatelessWidget {


### PR DESCRIPTION
#### Summary

Due to the [bug](https://github.com/flutter/flutter/issues/67655) the path to assets is not set correctly and deployed Widgetbook version is missing some svgs on the home page. This PR fixes the path.

#### Testing steps

None

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
