### PR TITLE
fix: [DX-7983] Fix overlays not following theme change

### DIFF
--- a/optimus/lib/src/dropdown/dropdown_select.dart
+++ b/optimus/lib/src/dropdown/dropdown_select.dart
@@ -301,23 +301,28 @@ class _DropdownSelectState<T> extends State<DropdownSelect<T>>
         }
       }
 
-      return MediaQuery(
-        data: MediaQuery.of(context),
-        child: AllowMultipleRawGestureDetector(
-          key: const Key('OptimusDropdownOverlay'),
-          behavior: HitTestBehavior.translucent,
-          onTapDown: handleTapDown,
-          child: DropdownTapInterceptor(
-            onTap: widget.allowMultipleSelection ? () {} : _handleClose,
-            child: OptimusDropdown(
-              items: widget.items,
-              size: widget.size,
-              anchorKey: _fieldBoxKey,
-              onChanged: widget.onChanged,
-              embeddedSearch: widget.embeddedSearch,
-              emptyResultPlaceholder: widget.emptyResultPlaceholder,
-              groupBy: widget.groupBy,
-              groupBuilder: widget.groupBuilder,
+      return OptimusTheme(
+        themeMode: context.theme.brightness == Brightness.dark
+            ? ThemeMode.dark
+            : ThemeMode.light,
+        child: MediaQuery(
+          data: MediaQuery.of(context),
+          child: AllowMultipleRawGestureDetector(
+            key: const Key('OptimusDropdownOverlay'),
+            behavior: HitTestBehavior.translucent,
+            onTapDown: handleTapDown,
+            child: DropdownTapInterceptor(
+              onTap: widget.allowMultipleSelection ? () {} : _handleClose,
+              child: OptimusDropdown(
+                items: widget.items,
+                size: widget.size,
+                anchorKey: _fieldBoxKey,
+                onChanged: widget.onChanged,
+                embeddedSearch: widget.embeddedSearch,
+                emptyResultPlaceholder: widget.emptyResultPlaceholder,
+                groupBy: widget.groupBy,
+                groupBuilder: widget.groupBuilder,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
#### Summary

- fixed OverlayEntries losing actual brightness variant

#### Testing steps

1. Open component that uses overlays (Dialog, Dropdown)
2. Switch to the dark theme in the Widgetbook (right panel, in addons)
3. Dropdown should follow the brightness change

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
