### PR TITLE
ci: [DX-8132] Add scope to rebuild theme action

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -9,8 +9,8 @@ scripts:
     run: melos exec --scope="optimus_icons" -- "dart utils/gen_icons.dart $MELOS_ROOT_PATH/optimus_icons/lib/fonts/config/ lib/src && dart format lib/src/icons_list.dart"
     description: Generate the list of all icons
   gen_theme:
-    run: melos exec --depends-on=build_runner -- "dart run build_runner build -d"
-    description: Build all generated files
+    run: melos exec --scope="optimus" --depends-on=build_runner -- "dart run build_runner build -d"
+    description: Rebuild theme generated files
 
 packages:
   - "**"


### PR DESCRIPTION
#### Summary

GH action was [failing](https://github.com/MewsSystems/mews-flutter/actions/runs/17672703622/job/50373363126) because `melos` would run `build_runner` on packages simultaneously. That would lead to fails because build would remove files before the rebuild and other active builds would fail because of the missing files 🤦  I could limit the number or parallel runs or enable build order by dependency graph, but since this action is triggered by change in `optimus` only, there is no need to rebuild other files.  

- added an `optimus` scope for `gen_theme` action

#### Testing steps

None. We'll see if next tokens sync will be successful.

#### Follow-up issues

None

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
