### PR TITLE
feat!: Upgrade to DCM 1.38

### DIFF
--- a/.github/workflows/dcm.yml
+++ b/.github/workflows/dcm.yml
@@ -16,7 +16,7 @@ jobs:
         uses: CQLabs/setup-dcm@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: "1.37.0"
+          version: "1.38.1"
 
       - uses: ./.github/actions/setup
 

--- a/mews_pedantic/lib/analysis_options.yaml
+++ b/mews_pedantic/lib/analysis_options.yaml
@@ -292,6 +292,7 @@ dart_code_metrics:
     - avoid-duplicate-collection-elements
     - avoid-duplicate-constant-values
     - avoid-duplicate-exports
+    - avoid-duplicate-factories
     - avoid-duplicate-initializers
     - avoid-duplicate-map-keys
     - avoid-duplicate-mixins
@@ -388,6 +389,7 @@ dart_code_metrics:
     - avoid-returning-void
     - avoid-self-assignment
     - avoid-self-compare
+    - avoid-sensitive-query-params
     - avoid-shadowed-extension-methods
     # - avoid-shadowing
     # - avoid-similar-names
@@ -409,6 +411,7 @@ dart_code_metrics:
     - avoid-uncaught-future-errors
     - avoid-unconditional-break
     # - avoid-unknown-pragma
+    - avoid-unmodified-loop-condition
     - avoid-unnecessary-block
     - avoid-unnecessary-call
     - avoid-unnecessary-collections
@@ -420,6 +423,7 @@ dart_code_metrics:
     - avoid-unnecessary-enum-arguments
     - avoid-unnecessary-enum-prefix
     - avoid-unnecessary-extends
+    - avoid-unnecessary-factory
     - avoid-unnecessary-futures
     - avoid-unnecessary-getter
     - avoid-unnecessary-if
@@ -607,6 +611,7 @@ dart_code_metrics:
     - prefer-for-in
     # - prefer-getter-over-method
     - prefer-immediate-return
+    - prefer-initializing-formals
     - prefer-iterable-of
     - prefer-last
     # - prefer-match-file-name
@@ -624,8 +629,10 @@ dart_code_metrics:
     - prefer-parentheses-with-if-null
     # - prefer-prefixed-global-constants
     # - prefer-private-extension-type-field
+    # - prefer-private-named-parameters
     - prefer-public-exception-classes
     - prefer-pushing-conditional-expressions
+    - prefer-random-secure
     - prefer-redirecting-superclass-constructor
     - prefer-return-await
     - prefer-returning-conditional-expressions
@@ -689,6 +696,8 @@ dart_code_metrics:
     - avoid-unnecessary-overrides-in-state
     - avoid-unnecessary-setstate
     - avoid-unnecessary-stateful-widgets
+    - avoid-unrestricted-javascript
+    - avoid-unrestricted-navigation
     # - avoid-wrapping-in-padding
     - check-for-equals-in-render-object-setters
     - consistent-update-render-object

--- a/optimus/lib/src/badge/base_badge.dart
+++ b/optimus/lib/src/badge/base_badge.dart
@@ -39,9 +39,7 @@ class BaseBadge extends StatelessWidget {
     final decoration = BoxDecoration(
       borderRadius: const .all(.circular(50)),
       color: backgroundColor,
-      border: isOutlined
-          ? Border.all(width: outlineSize, color: outlineColor)
-          : null,
+      border: isOutlined ? .all(width: outlineSize, color: outlineColor) : null,
     );
 
     final child = hasText

--- a/optimus/lib/src/button/base_button.dart
+++ b/optimus/lib/src/button/base_button.dart
@@ -216,7 +216,7 @@ class _ButtonContentState extends State<_ButtonContent> with ThemeGetter {
             if (widget.leadingIcon case final leadingIcon?)
               Padding(
                 padding: widget.child != null
-                    ? EdgeInsets.only(right: insideHorizontalPadding)
+                    ? .only(right: insideHorizontalPadding)
                     : EdgeInsets.zero,
                 child: Icon(
                   leadingIcon,

--- a/optimus/lib/src/button/icon.dart
+++ b/optimus/lib/src/button/icon.dart
@@ -1,3 +1,4 @@
+import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart';
 import 'package:optimus/optimus.dart';
 import 'package:optimus/src/button/base_button_variant.dart';
@@ -93,12 +94,9 @@ class _OptimusIconButtonState extends State<OptimusIconButton>
                   isPressed: _isPressed,
                   isHovered: _isHovered,
                 ),
-                border: borderColor != null
-                    ? Border.all(
-                        color: borderColor,
-                        width: tokens.borderWidth100,
-                      )
-                    : null,
+                border: borderColor?.let(
+                  (it) => Border.all(color: it, width: tokens.borderWidth100),
+                ),
                 borderRadius: .all(tokens.borderRadius100),
               ),
               duration: buttonAnimationDuration,

--- a/optimus/lib/src/checkbox/checkbox_tick.dart
+++ b/optimus/lib/src/checkbox/checkbox_tick.dart
@@ -102,7 +102,7 @@ class _CheckboxTickState extends State<CheckboxTick> with ThemeGetter {
           decoration: BoxDecoration(
             color: _fillColor.resolve(_controller.value),
             border: _state.isUnchecked
-                ? Border.all(
+                ? .all(
                     color: _borderColor.resolve(_controller.value),
                     width: tokens.borderWidth100,
                   )

--- a/optimus/lib/src/feedback/banner.dart
+++ b/optimus/lib/src/feedback/banner.dart
@@ -102,7 +102,7 @@ class OptimusBanner extends StatelessWidget {
                         children: [
                           Padding(
                             padding: isDismissible
-                                ? EdgeInsets.only(right: tokens.spacing200)
+                                ? .only(right: tokens.spacing200)
                                 : EdgeInsets.zero,
                             child: FeedbackTitle(
                               title: title,

--- a/optimus/lib/src/tag.dart
+++ b/optimus/lib/src/tag.dart
@@ -164,7 +164,7 @@ class _Tag extends StatelessWidget {
       decoration: BoxDecoration(
         color: isOutlined ? tokens.backgroundStaticFlat : backgroundColor,
         border: isOutlined
-            ? Border.all(
+            ? .all(
                 color: borderColor,
                 width: tokens.borderWidth100,
                 style: .solid,


### PR DESCRIPTION
#### Summary

- bumped [DCM](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/) to `1.38`
- new rule for privates in constructors requires a migration to Flutter 3.44 first. Disabled for now.

##### Enabled rules
[avoid-duplicate-factories](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/#avoid-duplicate-factories)
[avoid-unnecessary-factory](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/#avoid-unnecessary-factory)
[avoid-unmodified-loop-condition](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/#avoid-unmodified-loop-condition)
[prefer-initializing-formals](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/#prefer-initializing-formals)
[prefer-random-secure](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/#prefer-random-secure)
[avoid-sensitive-query-params](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/#avoid-sensitive-query-params)
[avoid-unrestricted-navigation](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/#avoid-unrestricted-navigation)
[avoid-unrestricted-javascript](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/#avoid-unrestricted-javascript)

##### Rules left disabled

[prefer-private-named-parameters](https://dcm.dev/blog/2026/06/22/whats-new-in-dcm-1-38-0/#prefer-private-named-parameters)

#### Testing steps

None

#### Follow-up issues

Release

#### Check during review

- Verify against Jira issue.
- Is the PR over 300 additions? Consider rejecting it with advice to split it. Is it over 500 additions? It should definitely be rejected.
- Unused code removed.
- Build passing.
- Is it a bug fix? Check that it is covered by a proper test (unit or integration).
